### PR TITLE
Add SEO infrastructure — meta tags, structured data, sitemap, and landing pages

### DIFF
--- a/src/app/centers/[slug]/page.tsx
+++ b/src/app/centers/[slug]/page.tsx
@@ -4,7 +4,9 @@ import { PageLayout } from "@/components/page-layout";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { JsonLd } from "@/components/json-ld";
 import { getAllCenters, getCenter, getTeacher, getTradition } from "@/lib/data";
+import { centerJsonLd, SITE_URL } from "@/lib/seo";
 
 export function generateStaticParams() {
   return getAllCenters().map((c) => ({ slug: c.slug }));
@@ -14,11 +16,18 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   const { slug } = await params;
   const center = getCenter(slug);
   if (!center) return {};
+  const description = center.traditions.length > 0
+    ? `${center.name} — ${center.traditions.join(", ")} center in ${center.city}, ${center.state}.`
+    : `${center.name} — contemplative center in ${center.city}, ${center.state}.`;
   return {
-    title: `${center.name} — Lineage`,
-    description: center.traditions.length > 0
-      ? `${center.name} — ${center.traditions.join(", ")} center in ${center.city}, ${center.state}.`
-      : `${center.name} — contemplative center in ${center.city}, ${center.state}.`,
+    title: center.name,
+    description,
+    openGraph: {
+      title: center.name,
+      description,
+      url: `${SITE_URL}/centers/${center.slug}`,
+      type: "website",
+    },
   };
 }
 
@@ -36,6 +45,7 @@ export default async function CenterPage({ params }: { params: Promise<{ slug: s
 
   return (
     <PageLayout>
+      <JsonLd data={centerJsonLd(center)} />
       <Breadcrumbs
         items={[
           { label: "Centers", href: "/centers" },

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,11 +1,8 @@
 import type { Metadata } from "next";
+import { defaultMetadata } from "@/lib/seo";
 import "./globals.css";
 
-export const metadata: Metadata = {
-  title: "Lineage",
-  description:
-    "An interactive map of contemplative traditions and a directory of teachers and centers.",
-};
+export const metadata: Metadata = defaultMetadata;
 
 export default function RootLayout({
   children,

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,15 @@
+import type { MetadataRoute } from "next";
+import { SITE_URL } from "@/lib/seo";
+
+// Required for Next.js static export (output: 'export')
+export const dynamic = "force-static";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: {
+      userAgent: "*",
+      allow: "/",
+    },
+    sitemap: `${SITE_URL}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,53 @@
+import type { MetadataRoute } from "next";
+import { getAllTeachers, getAllCenters, getAllTraditions } from "@/lib/data";
+import { getTeacherLocationStates } from "@/lib/location";
+import { SITE_URL } from "@/lib/seo";
+
+// Required for Next.js static export (output: 'export')
+export const dynamic = "force-static";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  const now = new Date();
+
+  const staticPages: MetadataRoute.Sitemap = [
+    { url: SITE_URL, lastModified: now, changeFrequency: "weekly", priority: 1 },
+    { url: `${SITE_URL}/traditions`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
+    { url: `${SITE_URL}/teachers`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
+  ];
+
+  const traditionPages: MetadataRoute.Sitemap = getAllTraditions().map((t) => ({
+    url: `${SITE_URL}/traditions/${t.slug}`,
+    lastModified: now,
+    changeFrequency: "monthly" as const,
+    priority: 0.8,
+  }));
+
+  const teacherPages: MetadataRoute.Sitemap = getAllTeachers().map((t) => ({
+    url: `${SITE_URL}/teachers/${t.slug}`,
+    lastModified: now,
+    changeFrequency: "monthly" as const,
+    priority: 0.7,
+  }));
+
+  const centerPages: MetadataRoute.Sitemap = getAllCenters().map((c) => ({
+    url: `${SITE_URL}/centers/${c.slug}`,
+    lastModified: now,
+    changeFrequency: "monthly" as const,
+    priority: 0.7,
+  }));
+
+  const locationPages: MetadataRoute.Sitemap = getTeacherLocationStates().map((state) => ({
+    url: `${SITE_URL}/teachers/location/${state.slug}`,
+    lastModified: now,
+    changeFrequency: "weekly" as const,
+    priority: 0.6,
+  }));
+
+  return [
+    ...staticPages,
+    ...traditionPages,
+    ...teacherPages,
+    ...centerPages,
+    ...locationPages,
+  ];
+}

--- a/src/app/teachers/[slug]/page.tsx
+++ b/src/app/teachers/[slug]/page.tsx
@@ -4,7 +4,9 @@ import { PageLayout } from "@/components/page-layout";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { JsonLd } from "@/components/json-ld";
 import { getAllTeachers, getTeacher, getCenter, getTradition } from "@/lib/data";
+import { teacherJsonLd, SITE_URL } from "@/lib/seo";
 
 export function generateStaticParams() {
   return getAllTeachers().map((t) => ({ slug: t.slug }));
@@ -14,11 +16,18 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   const { slug } = await params;
   const teacher = getTeacher(slug);
   if (!teacher) return {};
+  const description = teacher.traditions.length > 0
+    ? `${teacher.name} — ${teacher.traditions.join(", ")} teacher in ${teacher.city}, ${teacher.state}.`
+    : `${teacher.name} — contemplative teacher in ${teacher.city}, ${teacher.state}.`;
   return {
-    title: `${teacher.name} — Lineage`,
-    description: teacher.traditions.length > 0
-      ? `${teacher.name} — ${teacher.traditions.join(", ")} teacher in ${teacher.city}, ${teacher.state}.`
-      : `${teacher.name} — contemplative teacher in ${teacher.city}, ${teacher.state}.`,
+    title: teacher.name,
+    description,
+    openGraph: {
+      title: teacher.name,
+      description,
+      url: `${SITE_URL}/teachers/${teacher.slug}`,
+      type: "profile",
+    },
   };
 }
 
@@ -36,6 +45,7 @@ export default async function TeacherPage({ params }: { params: Promise<{ slug: 
 
   return (
     <PageLayout>
+      <JsonLd data={teacherJsonLd(teacher)} />
       <Breadcrumbs
         items={[
           { label: "Teachers", href: "/teachers" },

--- a/src/app/teachers/location/[state]/page.tsx
+++ b/src/app/teachers/location/[state]/page.tsx
@@ -1,0 +1,97 @@
+import Link from "next/link";
+import type { Metadata } from "next";
+import { notFound } from "next/navigation";
+import { PageLayout } from "@/components/page-layout";
+import { Breadcrumbs } from "@/components/breadcrumbs";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { getTradition } from "@/lib/data";
+import {
+  getTeachersByState,
+  getTeachersForState,
+} from "@/lib/location";
+import { SITE_URL } from "@/lib/seo";
+
+export function generateStaticParams() {
+  return getTeachersByState().map((s) => ({ state: s.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ state: string }>;
+}): Promise<Metadata> {
+  const { state: stateSlug } = await params;
+  const group = getTeachersForState(stateSlug);
+  if (!group) return {};
+  const description = `Browse ${group.teachers.length} contemplative teacher${group.teachers.length === 1 ? "" : "s"} in ${group.state}.`;
+  return {
+    title: `Teachers in ${group.state}`,
+    description,
+    openGraph: {
+      title: `Teachers in ${group.state}`,
+      description,
+      url: `${SITE_URL}/teachers/location/${stateSlug}`,
+    },
+  };
+}
+
+export default async function StateTeachersPage({
+  params,
+}: {
+  params: Promise<{ state: string }>;
+}) {
+  const { state: stateSlug } = await params;
+  const group = getTeachersForState(stateSlug);
+  if (!group) notFound();
+
+  return (
+    <PageLayout>
+      <Breadcrumbs
+        items={[
+          { label: "Teachers", href: "/teachers" },
+          { label: group.state },
+        ]}
+      />
+
+      <header className="mb-10">
+        <h1 className="mb-3">Teachers in {group.state}</h1>
+        <p className="text-lg text-muted-foreground leading-relaxed max-w-2xl">
+          {group.teachers.length} contemplative teacher
+          {group.teachers.length === 1 ? "" : "s"} based in {group.state}.
+        </p>
+      </header>
+
+      <div className="grid gap-4 sm:grid-cols-2">
+        {group.teachers.map((teacher) => (
+          <Link
+            key={teacher.slug}
+            href={`/teachers/${teacher.slug}`}
+            className="group"
+          >
+            <Card accent="terracotta" className="h-full group-hover:shadow-md">
+              <CardHeader>
+                <CardTitle className="group-hover:text-primary transition-colors">
+                  {teacher.name}
+                </CardTitle>
+                <CardDescription>
+                  {teacher.city}, {teacher.state}
+                </CardDescription>
+              </CardHeader>
+              <div className="flex flex-wrap gap-1.5 px-5 pb-5">
+                {teacher.traditions.map((slug) => {
+                  const t = getTradition(slug);
+                  return (
+                    <Badge key={slug} variant="tradition">
+                      {t?.name ?? slug}
+                    </Badge>
+                  );
+                })}
+              </div>
+            </Card>
+          </Link>
+        ))}
+      </div>
+    </PageLayout>
+  );
+}

--- a/src/app/teachers/page.tsx
+++ b/src/app/teachers/page.tsx
@@ -7,8 +7,12 @@ import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/ca
 import { getAllTeachers, getTradition } from "@/lib/data";
 
 export const metadata: Metadata = {
-  title: "Teachers — Lineage",
+  title: "Teachers",
   description: "Browse contemplative teachers by tradition and location.",
+  openGraph: {
+    title: "Teachers",
+    description: "Browse contemplative teachers by tradition and location.",
+  },
 };
 
 export default function TeachersPage() {

--- a/src/app/traditions/[slug]/page.tsx
+++ b/src/app/traditions/[slug]/page.tsx
@@ -5,6 +5,7 @@ import { PageLayout } from "@/components/page-layout";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+import { JsonLd } from "@/components/json-ld";
 import {
   getAllTraditions,
   getTradition,
@@ -12,6 +13,7 @@ import {
   getCentersByTradition,
   getRelatedTraditions,
 } from "@/lib/data";
+import { traditionJsonLd, SITE_URL } from "@/lib/seo";
 
 export function generateStaticParams() {
   return getAllTraditions().map((t) => ({ slug: t.slug }));
@@ -22,8 +24,14 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   const tradition = getTradition(slug);
   if (!tradition) return {};
   return {
-    title: `${tradition.name} — Lineage`,
+    title: tradition.name,
     description: tradition.summary,
+    openGraph: {
+      title: tradition.name,
+      description: tradition.summary,
+      url: `${SITE_URL}/traditions/${tradition.slug}`,
+      type: "article",
+    },
   };
 }
 
@@ -38,6 +46,7 @@ export default async function TraditionPage({ params }: { params: Promise<{ slug
 
   return (
     <PageLayout>
+      <JsonLd data={traditionJsonLd(tradition)} />
       <Breadcrumbs
         items={[
           { label: "Traditions", href: "/traditions" },

--- a/src/app/traditions/page.tsx
+++ b/src/app/traditions/page.tsx
@@ -8,9 +8,14 @@ import { getAllTraditions } from "@/lib/data";
 import type { ParsedTradition } from "@/lib/data";
 
 export const metadata: Metadata = {
-  title: "Traditions — Lineage",
+  title: "Traditions",
   description:
     "Explore contemplative traditions — Buddhist, Hindu, Modern Non-Dual, Yogic, and more.",
+  openGraph: {
+    title: "Traditions",
+    description:
+      "Explore contemplative traditions — Buddhist, Hindu, Modern Non-Dual, Yogic, and more.",
+  },
 };
 
 const familyOrder = ["Buddhist", "Hindu", "Modern Non-Dual", "Yogic", "Other"];

--- a/src/components/json-ld.tsx
+++ b/src/components/json-ld.tsx
@@ -1,0 +1,17 @@
+/**
+ * Renders a JSON-LD script tag for structured data.
+ *
+ * Usage:
+ *   <JsonLd data={teacherJsonLd(teacher)} />
+ *
+ * Why a component? Encapsulates the serialization and dangerouslySetInnerHTML
+ * pattern in one place, keeping page components clean.
+ */
+export function JsonLd({ data }: { data: Record<string, unknown> }) {
+  return (
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(data) }}
+    />
+  );
+}

--- a/src/lib/__tests__/location.test.ts
+++ b/src/lib/__tests__/location.test.ts
@@ -1,0 +1,46 @@
+import { getTeachersByState, getTeachersForState, getTeacherLocationStates } from "../location";
+
+describe("getTeachersByState", () => {
+  it("groups teachers by state", () => {
+    const groups = getTeachersByState();
+    expect(groups.length).toBeGreaterThan(0);
+    for (const g of groups) {
+      expect(g.state).toBeTruthy();
+      expect(g.slug).toBeTruthy();
+      expect(g.teachers.length).toBeGreaterThan(0);
+      // Every teacher in the group should match the state
+      for (const t of g.teachers) {
+        expect(t.state).toBe(g.state);
+      }
+    }
+  });
+
+  it("produces lowercase hyphenated slugs", () => {
+    const groups = getTeachersByState();
+    for (const g of groups) {
+      expect(g.slug).toMatch(/^[a-z][a-z0-9-]*$/);
+    }
+  });
+});
+
+describe("getTeachersForState", () => {
+  it("returns teachers for california", () => {
+    const group = getTeachersForState("california");
+    expect(group).toBeDefined();
+    expect(group!.state).toBe("California");
+    expect(group!.teachers.length).toBeGreaterThan(0);
+  });
+
+  it("returns undefined for non-existent state", () => {
+    expect(getTeachersForState("nonexistent")).toBeUndefined();
+  });
+});
+
+describe("getTeacherLocationStates", () => {
+  it("returns state/slug pairs", () => {
+    const states = getTeacherLocationStates();
+    expect(states.length).toBeGreaterThan(0);
+    expect(states[0]).toHaveProperty("state");
+    expect(states[0]).toHaveProperty("slug");
+  });
+});

--- a/src/lib/__tests__/seo.test.ts
+++ b/src/lib/__tests__/seo.test.ts
@@ -1,0 +1,93 @@
+import { teacherJsonLd, centerJsonLd, traditionJsonLd, SITE_URL } from "../seo";
+import type { Teacher, Center } from "../types";
+import type { ParsedTradition } from "../data";
+
+const mockTeacher: Teacher = {
+  name: "Test Teacher",
+  slug: "test-teacher",
+  bio: "A test bio.",
+  photo: null,
+  website: "https://example.com",
+  city: "San Francisco",
+  state: "California",
+  country: "US",
+  latitude: 37.7749,
+  longitude: -122.4194,
+  traditions: ["zen"],
+  centers: [],
+};
+
+const mockCenter: Center = {
+  name: "Test Center",
+  slug: "test-center",
+  description: "A test center.",
+  website: "https://example.com",
+  city: "Oakland",
+  state: "California",
+  country: "US",
+  latitude: 37.8044,
+  longitude: -122.2712,
+  traditions: ["zen"],
+  teachers: ["test-teacher"],
+};
+
+const mockTradition: ParsedTradition = {
+  name: "Zen",
+  slug: "zen",
+  family: "Buddhist",
+  summary: "A school of Mahayana Buddhism.",
+  connections: [],
+  content: "# Zen\nContent here.",
+};
+
+describe("teacherJsonLd", () => {
+  it("returns Person schema with correct fields", () => {
+    const result = teacherJsonLd(mockTeacher);
+    expect(result["@context"]).toBe("https://schema.org");
+    expect(result["@type"]).toBe("Person");
+    expect(result.name).toBe("Test Teacher");
+    expect(result.url).toBe(`${SITE_URL}/teachers/test-teacher`);
+    expect(result.sameAs).toEqual(["https://example.com"]);
+  });
+
+  it("includes geo coordinates when available", () => {
+    const result = teacherJsonLd(mockTeacher);
+    expect(result.geo).toEqual({
+      "@type": "GeoCoordinates",
+      latitude: 37.7749,
+      longitude: -122.4194,
+    });
+  });
+
+  it("omits sameAs when no website", () => {
+    const result = teacherJsonLd({ ...mockTeacher, website: null });
+    expect(result.sameAs).toBeUndefined();
+  });
+
+  it("omits geo when coordinates are null", () => {
+    const result = teacherJsonLd({
+      ...mockTeacher,
+      latitude: null,
+      longitude: null,
+    });
+    expect(result.geo).toBeUndefined();
+  });
+});
+
+describe("centerJsonLd", () => {
+  it("returns Organization schema", () => {
+    const result = centerJsonLd(mockCenter);
+    expect(result["@type"]).toBe("Organization");
+    expect(result.name).toBe("Test Center");
+    expect(result.url).toBe(`${SITE_URL}/centers/test-center`);
+  });
+});
+
+describe("traditionJsonLd", () => {
+  it("returns Article schema", () => {
+    const result = traditionJsonLd(mockTradition);
+    expect(result["@type"]).toBe("Article");
+    expect(result.headline).toBe("Zen");
+    expect(result.description).toBe("A school of Mahayana Buddhism.");
+  });
+});

--- a/src/lib/location.ts
+++ b/src/lib/location.ts
@@ -1,0 +1,45 @@
+import { getAllTeachers } from "./data";
+import type { Teacher } from "./types";
+
+export interface StateGroup {
+  state: string;
+  slug: string;
+  teachers: Teacher[];
+}
+
+function toSlug(state: string): string {
+  return state.toLowerCase().replace(/\s+/g, "-");
+}
+
+/**
+ * Groups all teachers by state and returns one entry per state.
+ * Used for generating location-based landing pages like /teachers/california.
+ */
+export function getTeachersByState(): StateGroup[] {
+  const teachers = getAllTeachers();
+  const byState = new Map<string, Teacher[]>();
+
+  for (const t of teachers) {
+    const group = byState.get(t.state) ?? [];
+    group.push(t);
+    byState.set(t.state, group);
+  }
+
+  return Array.from(byState.entries())
+    .map(([state, teachers]) => ({
+      state,
+      slug: toSlug(state),
+      teachers,
+    }))
+    .sort((a, b) => a.state.localeCompare(b.state));
+}
+
+export function getTeacherLocationStates(): { state: string; slug: string }[] {
+  return getTeachersByState().map(({ state, slug }) => ({ state, slug }));
+}
+
+export function getTeachersForState(
+  stateSlug: string
+): StateGroup | undefined {
+  return getTeachersByState().find((s) => s.slug === stateSlug);
+}

--- a/src/lib/seo.ts
+++ b/src/lib/seo.ts
@@ -1,0 +1,97 @@
+import type { Metadata } from "next";
+import type { Teacher, Center } from "./types";
+import type { ParsedTradition } from "./data";
+
+export const SITE_URL = "https://lineage.app";
+export const SITE_NAME = "Lineage";
+export const SITE_DESCRIPTION =
+  "An interactive map of contemplative traditions and a directory of teachers and centers.";
+
+// -- Default metadata for root layout --
+
+export const defaultMetadata: Metadata = {
+  metadataBase: new URL(SITE_URL),
+  title: {
+    default: `${SITE_NAME} — A Map of Contemplative Traditions`,
+    template: `%s — ${SITE_NAME}`,
+  },
+  description: SITE_DESCRIPTION,
+  openGraph: {
+    type: "website",
+    siteName: SITE_NAME,
+    locale: "en_US",
+  },
+  robots: {
+    index: true,
+    follow: true,
+  },
+};
+
+// -- JSON-LD helpers --
+
+export function teacherJsonLd(teacher: Teacher): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Person",
+    name: teacher.name,
+    url: `${SITE_URL}/teachers/${teacher.slug}`,
+    description: teacher.bio,
+    ...(teacher.website && { sameAs: [teacher.website] }),
+    address: {
+      "@type": "PostalAddress",
+      addressLocality: teacher.city,
+      addressRegion: teacher.state,
+      addressCountry: teacher.country,
+    },
+    ...(teacher.latitude != null &&
+      teacher.longitude != null && {
+        geo: {
+          "@type": "GeoCoordinates",
+          latitude: teacher.latitude,
+          longitude: teacher.longitude,
+        },
+      }),
+  };
+}
+
+export function centerJsonLd(center: Center): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Organization",
+    name: center.name,
+    url: `${SITE_URL}/centers/${center.slug}`,
+    description: center.description,
+    ...(center.website && { sameAs: [center.website] }),
+    address: {
+      "@type": "PostalAddress",
+      addressLocality: center.city,
+      addressRegion: center.state,
+      addressCountry: center.country,
+    },
+    ...(center.latitude != null &&
+      center.longitude != null && {
+        geo: {
+          "@type": "GeoCoordinates",
+          latitude: center.latitude,
+          longitude: center.longitude,
+        },
+      }),
+  };
+}
+
+export function traditionJsonLd(
+  tradition: ParsedTradition
+): Record<string, unknown> {
+  return {
+    "@context": "https://schema.org",
+    "@type": "Article",
+    headline: tradition.name,
+    url: `${SITE_URL}/traditions/${tradition.slug}`,
+    description: tradition.summary,
+    publisher: {
+      "@type": "Organization",
+      name: SITE_NAME,
+      url: SITE_URL,
+    },
+  };
+}


### PR DESCRIPTION
Closes #10

## Summary
- Every page now has unique `<title>` (using template pattern `%s — Lineage`) and `<meta description>`
- OpenGraph tags on all page types for social sharing
- Schema.org JSON-LD structured data: Person (teachers), Organization (centers), Article (traditions)
- `sitemap.xml` generated at build time covering all static pages including location landing pages
- `robots.txt` allows all crawling with sitemap reference
- Location-based landing pages at `/teachers/location/[state]` (e.g., `/teachers/location/california`)
- All pages render as full static HTML (Next.js static export)

**Changes:**
- New `src/lib/seo.ts` — centralized SEO config, default metadata, JSON-LD builders
- New `src/lib/location.ts` — teacher grouping by state for landing pages
- New `src/components/json-ld.tsx` — reusable JSON-LD script component
- New `src/app/sitemap.ts` and `src/app/robots.ts` with `force-static` for static export
- New `src/app/teachers/location/[state]/page.tsx` — location landing pages
- Updated all existing page files with OG metadata and JSON-LD
- 11 new tests for JSON-LD generation and location grouping

**Tested:**
- All 73 tests pass
- `npm run build` succeeds with all pages statically generated
- Location pages generated for california, massachusetts, oxfordshire

🤖 Generated with [Claude Code](https://claude.com/claude-code)