### PR TITLE
Expand data model for tradition map rebuild

### DIFF
--- a/data/traditions/advaita-vedanta.mdx
+++ b/data/traditions/advaita-vedanta.mdx
@@ -2,13 +2,16 @@
 name: Advaita Vedanta
 slug: advaita-vedanta
 family: Hindu
+origin_century: 8
 summary: The "non-dual" school of Hindu philosophy teaching that the individual self (Atman) and ultimate reality (Brahman) are one and the same.
 connections:
   - tradition_slug: kashmir-shaivism
     connection_type: related_to
+    strength: 3
     description: Both are non-dual traditions within Hinduism, though Kashmir Shaivism sees the world as a real expression of consciousness rather than illusion (maya).
   - tradition_slug: dzogchen
     connection_type: related_to
+    strength: 1
     description: Dzogchen shares Advaita's emphasis on recognizing one's true nature directly, though within a Buddhist framework and with different metaphysical commitments.
 ---
 

--- a/data/traditions/dzogchen.mdx
+++ b/data/traditions/dzogchen.mdx
@@ -2,13 +2,16 @@
 name: Dzogchen
 slug: dzogchen
 family: Buddhist
+origin_century: 8
 summary: The "Great Perfection" — the highest teaching in the Nyingma school of Tibetan Buddhism, pointing directly to the nature of mind as already pure and awake.
 connections:
   - tradition_slug: zen
     connection_type: related_to
+    strength: 2
     description: Both point to the nature of mind as already awake, though Zen emphasizes seated meditation while Dzogchen works more with awareness in all activities.
   - tradition_slug: advaita-vedanta
     connection_type: related_to
+    strength: 1
     description: Both emphasize recognizing one's true nature directly, though Dzogchen operates within a Buddhist framework and Advaita within Hinduism.
 ---
 

--- a/data/traditions/kashmir-shaivism.mdx
+++ b/data/traditions/kashmir-shaivism.mdx
@@ -2,11 +2,13 @@
 name: Kashmir Shaivism
 slug: kashmir-shaivism
 family: Hindu
+origin_century: 9
 summary: A non-dual tantric tradition from medieval Kashmir teaching that all of reality is the creative expression of a single divine consciousness (Shiva).
 connections:
   - tradition_slug: advaita-vedanta
-    connection_type: related_to
-    description: Both are non-dual Hindu traditions, but Kashmir Shaivism sees the world as a real expression of consciousness rather than illusion, offering a more world-affirming view.
+    connection_type: diverged_from
+    strength: 3
+    description: Both are non-dual Hindu traditions, but Kashmir Shaivism diverged from Advaita by seeing the world as a real expression of consciousness rather than illusion, offering a more world-affirming view.
 ---
 
 # Kashmir Shaivism

--- a/data/traditions/theravada.mdx
+++ b/data/traditions/theravada.mdx
@@ -2,10 +2,12 @@
 name: Theravada
 slug: theravada
 family: Buddhist
+origin_century: -3
 summary: The "Way of the Elders" — the oldest surviving Buddhist school, preserving the original Pali canon teachings and emphasizing mindfulness and insight meditation.
 connections:
   - tradition_slug: zen
     connection_type: related_to
+    strength: 2
     description: Both emphasize meditation practice as central, though Theravada preserves the earlier Pali canon teachings while Zen developed within the later Mahayana tradition.
 ---
 

--- a/data/traditions/zen.mdx
+++ b/data/traditions/zen.mdx
@@ -2,13 +2,16 @@
 name: Zen
 slug: zen
 family: Buddhist
+origin_century: 6
 summary: A school of Mahayana Buddhism emphasizing meditation (zazen) and direct insight into one's true nature, transmitted from teacher to student.
 connections:
   - tradition_slug: theravada
-    connection_type: related_to
-    description: Both emphasize meditation practice as central, though Zen developed within the Mahayana tradition while Theravada preserves the earlier Pali canon teachings.
+    connection_type: influenced_by
+    strength: 2
+    description: Zen inherits core Buddhist teachings from the earlier Theravada canon, though it developed within the Mahayana tradition with a distinct emphasis on direct transmission.
   - tradition_slug: dzogchen
     connection_type: related_to
+    strength: 1
     description: Both point to the nature of mind as already awake, though Zen emphasizes seated meditation (zazen) while Dzogchen works more with awareness in all activities.
 ---
 

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -7,7 +7,7 @@ import { TraditionMap } from "@/components/tradition-map";
 export const metadata: Metadata = {
   title: "Map of Contemplative Traditions — Lineage",
   description:
-    "An interactive visual map of contemplative traditions and how they connect — Buddhist, Hindu, Modern Non-Dual, Yogic, and more.",
+    "An interactive visual map of contemplative traditions and how they connect — Buddhist, Hindu, Taoist, Christian, Islamic, and more.",
 };
 
 export default function MapPage() {

--- a/src/app/traditions/page.tsx
+++ b/src/app/traditions/page.tsx
@@ -10,15 +10,15 @@ import type { ParsedTradition } from "@/lib/data";
 export const metadata: Metadata = {
   title: "Traditions",
   description:
-    "Explore contemplative traditions — Buddhist, Hindu, Modern Non-Dual, Yogic, and more.",
+    "Explore contemplative traditions — Buddhist, Hindu, Taoist, Christian, Islamic, and more.",
   openGraph: {
     title: "Traditions",
     description:
-      "Explore contemplative traditions — Buddhist, Hindu, Modern Non-Dual, Yogic, and more.",
+      "Explore contemplative traditions — Buddhist, Hindu, Taoist, Christian, Islamic, and more.",
   },
 };
 
-const familyOrder = ["Buddhist", "Hindu", "Modern Non-Dual", "Yogic", "Other"];
+const familyOrder = ["Buddhist", "Hindu", "Taoist", "Christian Contemplative", "Islamic Contemplative", "Modern Secular", "Other"];
 
 function groupByFamily(traditions: ParsedTradition[]) {
   const grouped = new Map<string, ParsedTradition[]>();

--- a/src/lib/__tests__/seed-data.test.ts
+++ b/src/lib/__tests__/seed-data.test.ts
@@ -8,14 +8,17 @@ const DATA_DIR = join(process.cwd(), "data");
 const VALID_FAMILIES: TraditionFamily[] = [
   "Buddhist",
   "Hindu",
-  "Modern Non-Dual",
-  "Yogic",
+  "Taoist",
+  "Christian Contemplative",
+  "Islamic Contemplative",
+  "Modern Secular",
   "Other",
 ];
 const VALID_CONNECTION_TYPES: ConnectionType[] = [
   "influenced_by",
   "branch_of",
   "related_to",
+  "diverged_from",
 ];
 
 function readJsonFiles<T>(subdir: string): { name: string; data: T }[] {
@@ -140,6 +143,7 @@ describe("Tradition seed data", () => {
       expect(typeof data.slug).toBe("string");
       expect(VALID_FAMILIES).toContain(data.family);
       expect(typeof data.summary).toBe("string");
+      expect(typeof data.origin_century).toBe("number");
       expect(Array.isArray(data.connections)).toBe(true);
       for (const conn of data.connections) {
         expect(typeof conn.tradition_slug).toBe("string");

--- a/src/lib/__tests__/tradition-graph.test.ts
+++ b/src/lib/__tests__/tradition-graph.test.ts
@@ -149,7 +149,7 @@ describe("filterByFamilies", () => {
 
   it("returns empty graph for no matching families", () => {
     const graph = buildTraditionGraph(sampleTraditions);
-    const filtered = filterByFamilies(graph, new Set(["Yogic"]));
+    const filtered = filterByFamilies(graph, new Set(["Taoist"]));
     expect(filtered.nodes).toHaveLength(0);
     expect(filtered.edges).toHaveLength(0);
   });

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -120,6 +120,7 @@ export interface ParsedTradition {
   slug: string;
   family: string;
   summary: string;
+  origin_century: number;
   connections: TraditionConnection[];
   content: string;
 }
@@ -132,6 +133,7 @@ function isValidTraditionFrontmatter(
     typeof data.slug === "string" &&
     typeof data.family === "string" &&
     typeof data.summary === "string" &&
+    typeof data.origin_century === "number" &&
     Array.isArray(data.connections)
   );
 }
@@ -149,6 +151,7 @@ function parseTraditionFile(filePath: string): ParsedTradition | undefined {
       slug: data.slug,
       family: data.family,
       summary: data.summary,
+      origin_century: data.origin_century,
       connections: (data.connections ?? []) as TraditionConnection[],
       content,
     };

--- a/src/lib/tradition-graph.ts
+++ b/src/lib/tradition-graph.ts
@@ -10,6 +10,7 @@ export interface GraphNode {
   name: string;
   family: TraditionFamily;
   summary: string;
+  originCentury: number;
 }
 
 export interface GraphEdge {
@@ -17,6 +18,7 @@ export interface GraphEdge {
   target: string;
   connectionType: ConnectionType;
   description: string;
+  strength: number;
 }
 
 export interface TraditionGraph {
@@ -41,17 +43,29 @@ export const FAMILY_COLORS: Record<TraditionFamily, { fill: string; stroke: stri
     text: "#5a2a20",
     bg: "#f3e8e5",
   },
-  "Modern Non-Dual": {
-    fill: "#6b8f71",     // sage green
-    stroke: "#4d7053",
-    text: "#2d4a33",
-    bg: "#e5ede7",
+  Taoist: {
+    fill: "#4a7c7e",     // teal
+    stroke: "#3a6264",
+    text: "#2a4a4c",
+    bg: "#e5eeef",
   },
-  Yogic: {
-    fill: "#8b7ec8",     // muted purple
-    stroke: "#6b5ea8",
-    text: "#3d3570",
-    bg: "#eae7f3",
+  "Christian Contemplative": {
+    fill: "#4a5a8a",     // deep blue
+    stroke: "#3a4a7a",
+    text: "#2a3560",
+    bg: "#e7e9f0",
+  },
+  "Islamic Contemplative": {
+    fill: "#3a7a5a",     // forest green
+    stroke: "#2a6a4a",
+    text: "#1a4a3a",
+    bg: "#e5ede8",
+  },
+  "Modern Secular": {
+    fill: "#6a7a8a",     // slate
+    stroke: "#5a6a7a",
+    text: "#3a4a5a",
+    bg: "#eaedf0",
   },
   Other: {
     fill: "#8a8279",     // warm gray
@@ -66,10 +80,12 @@ export interface TraditionInput {
   slug: string;
   family: string;
   summary: string;
+  origin_century?: number;
   connections: {
     tradition_slug: string;
     connection_type: string;
     description: string;
+    strength?: number;
   }[];
 }
 
@@ -85,6 +101,7 @@ export function buildTraditionGraph(traditions: TraditionInput[]): TraditionGrap
     name: t.name,
     family: t.family as TraditionFamily,
     summary: t.summary,
+    originCentury: t.origin_century ?? 0,
   }));
 
   // Deduplicate edges: use sorted slug pair as key
@@ -99,6 +116,7 @@ export function buildTraditionGraph(traditions: TraditionInput[]): TraditionGrap
           target: conn.tradition_slug,
           connectionType: conn.connection_type as ConnectionType,
           description: conn.description,
+          strength: conn.strength ?? 1,
         });
       }
     }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,16 +1,19 @@
 export type TraditionFamily =
   | "Buddhist"
   | "Hindu"
-  | "Modern Non-Dual"
-  | "Yogic"
+  | "Taoist"
+  | "Christian Contemplative"
+  | "Islamic Contemplative"
+  | "Modern Secular"
   | "Other";
 
-export type ConnectionType = "influenced_by" | "branch_of" | "related_to";
+export type ConnectionType = "influenced_by" | "branch_of" | "related_to" | "diverged_from";
 
 export interface TraditionConnection {
   tradition_slug: string;
   connection_type: ConnectionType;
   description: string;
+  strength?: 1 | 2 | 3;
 }
 
 export interface Tradition {


### PR DESCRIPTION
## Summary
- Expands `TraditionFamily` to 7 families (drops Yogic/Modern Non-Dual, adds Taoist, Christian Contemplative, Islamic Contemplative, Modern Secular)
- Adds `diverged_from` connection type and optional `strength` (1-3) to connections
- Adds `origin_century` field to tradition schema, `GraphNode`, `GraphEdge`, and all 5 MDX files
- Adds `FAMILY_COLORS` entries for all 7 families
- Updates page metadata and tests to reflect new type system

Closes #22

## Test plan
- [x] All 101 existing tests pass (updated for new types)
- [x] `npm run build` succeeds with static export
- [x] All 5 MDX files have valid `origin_century` values
- [x] No remaining references to dropped families (Yogic, Modern Non-Dual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)