### PR TITLE
Add 17 new tradition MDX files with connections

### DIFF
--- a/data/traditions/advaita-vedanta.mdx
+++ b/data/traditions/advaita-vedanta.mdx
@@ -13,6 +13,18 @@ connections:
     connection_type: related_to
     strength: 1
     description: Dzogchen shares Advaita's emphasis on recognizing one's true nature directly, though within a Buddhist framework and with different metaphysical commitments.
+  - tradition_slug: modern-non-dual
+    connection_type: influenced_by
+    strength: 3
+    description: Modern Non-Dual teachings draw most directly from Advaita Vedanta, particularly through the lineage of Ramana Maharshi and Nisargadatta Maharaj.
+  - tradition_slug: bhakti
+    connection_type: related_to
+    strength: 2
+    description: Advaita and Bhakti represent complementary approaches within Hinduism — philosophical inquiry and devotional love — and many teachers have integrated both.
+  - tradition_slug: classical-yoga
+    connection_type: related_to
+    strength: 2
+    description: Both are classical Indian darshanas sharing contemplative goals, though Yoga is dualistic while Advaita is non-dual.
 ---
 
 # Advaita Vedanta

--- a/data/traditions/bhakti.mdx
+++ b/data/traditions/bhakti.mdx
@@ -1,0 +1,32 @@
+---
+name: Bhakti
+slug: bhakti
+family: Hindu
+origin_century: 6
+summary: The devotional path of Hinduism emphasizing love, surrender, and personal relationship with the divine as the primary means of spiritual realization.
+connections:
+  - tradition_slug: advaita-vedanta
+    connection_type: related_to
+    strength: 2
+    description: Bhakti and Advaita represent complementary approaches within Hinduism — devotional love and philosophical inquiry — and many teachers have integrated both.
+  - tradition_slug: sufism
+    connection_type: related_to
+    strength: 1
+    description: Bhakti and Sufism share a striking emphasis on ecstatic devotional love as a path to the divine, with evidence of mutual influence in medieval India.
+---
+
+# Bhakti
+
+Bhakti is the path of devotion — the yoga of love. It teaches that the most direct route to spiritual liberation is not philosophical analysis or ascetic discipline but wholehearted, passionate love for the divine.
+
+## Origins and History
+
+While devotional elements appear in the earliest Hindu scriptures, the Bhakti movement as a distinct force emerged in South India around the 6th–7th centuries CE with the Tamil poet-saints: the Alvars (Vishnu devotees) and the Nayanars (Shiva devotees). These wandering mystics composed ecstatic hymns in the vernacular rather than Sanskrit, making the contemplative path accessible regardless of caste, gender, or education.
+
+The movement swept northward, producing extraordinary poet-saints: Ramanuja (11th c.), who gave Bhakti philosophical grounding; Kabir (15th c.), who dissolved boundaries between Hindu and Muslim devotion; Mirabai (16th c.), whose songs of longing for Krishna defied social convention; and Tukaram (17th c.), the Marathi grocer-saint whose *abhangs* are still sung today.
+
+## Core Teachings and Practice
+
+Bhakti's central teaching is that the divine is intimately present and responsive to love. The practitioner cultivates an intensely personal relationship with God — as beloved, parent, friend, or child — and through that relationship, the boundaries of the separate self gradually dissolve.
+
+Practice takes many forms: chanting the names of God (*kirtan* and *japa*), singing devotional hymns, worship (*puja*), pilgrimage, and constant remembrance of the divine throughout daily life. The Bhakti path values sincerity and emotional authenticity over technical precision — a broken heart offered to God is worth more than a perfect ritual performed without feeling.

--- a/data/traditions/chan-buddhism.mdx
+++ b/data/traditions/chan-buddhism.mdx
@@ -1,0 +1,36 @@
+---
+name: Chan Buddhism
+slug: chan-buddhism
+family: Buddhist
+origin_century: 5
+summary: The Chinese school of meditation Buddhism that synthesized Indian Mahayana teachings with Taoist sensibility, later transmitted to Japan as Zen.
+connections:
+  - tradition_slug: zen
+    connection_type: branch_of
+    strength: 3
+    description: Zen is the direct Japanese continuation of Chinese Chan Buddhism, transmitted to Japan in the 12th–13th centuries by monks like Eisai and Dogen.
+  - tradition_slug: theravada
+    connection_type: influenced_by
+    strength: 2
+    description: Chan inherited core Buddhist teachings on meditation and liberation from the broader Buddhist tradition, including practices preserved in the Theravada canon.
+  - tradition_slug: taoism
+    connection_type: influenced_by
+    strength: 2
+    description: Chan Buddhism was profoundly shaped by Taoist ideas of naturalness, spontaneity, and harmony with the Way, giving it a distinctly Chinese character.
+---
+
+# Chan Buddhism
+
+Chan is the Chinese school of meditation Buddhism — the tradition that would later cross the sea to become Japanese Zen, Korean Seon, and Vietnamese Thien. The word *Chan* itself is a Chinese rendering of the Sanskrit *dhyana* (meditation), pointing to the tradition's central commitment to direct meditative experience over scriptural study.
+
+## Origins and History
+
+Chan tradition credits Bodhidharma, an Indian monk who arrived in China around 520 CE, as its founding patriarch. The famous story of Bodhidharma sitting in silent meditation facing a wall for nine years at the Shaolin monastery captures the tradition's radical emphasis on practice over doctrine. Whether or not the historical details are precise, Chan emerged in the 6th and 7th centuries as a distinctive synthesis of Indian Buddhist meditation with Chinese philosophical sensibility — particularly the Taoist appreciation for naturalness, paradox, and what cannot be captured in words.
+
+The tradition flowered spectacularly during the Tang Dynasty (618–907 CE), producing legendary masters like Huineng, Mazu, and Linji, whose radical teaching methods — shouts, paradoxical dialogues, and unexpected physical gestures — became Chan's hallmark.
+
+## Core Teachings and Practice
+
+Chan's core insight is that Buddha-nature is already present in every being — it need not be created or acquired, only recognized. The tradition emphasizes *sudden awakening*: the possibility that insight can arise in a flash, cutting through layers of conceptual thinking in a single moment. Yet most Chan teachers also acknowledge that gradual cultivation — daily sitting, ethical conduct, and study — creates the conditions in which such awakening can occur.
+
+Sitting meditation (*zuochan*) remains the foundation of practice, complemented by mindful work, walking meditation, and the dynamic teacher-student encounter. Through its Japanese, Korean, and Vietnamese branches, Chan's influence extends across East Asian culture and, in the modern era, around the world.

--- a/data/traditions/christian-mysticism.mdx
+++ b/data/traditions/christian-mysticism.mdx
@@ -1,0 +1,36 @@
+---
+name: Christian Mysticism
+slug: christian-mysticism
+family: Christian Contemplative
+origin_century: 3
+summary: The contemplative stream within Christianity emphasizing direct experiential knowledge of God through prayer, silence, and inner transformation.
+connections:
+  - tradition_slug: hesychasm
+    connection_type: branch_of
+    strength: 3
+    description: Hesychasm developed as a specific contemplative method within the broader Christian mystical tradition, focusing on stillness and the Jesus Prayer in Eastern Orthodox practice.
+  - tradition_slug: quaker-inner-light
+    connection_type: influenced_by
+    strength: 2
+    description: The Quaker emphasis on direct inner experience of the divine draws on the broader Christian mystical tradition.
+  - tradition_slug: gnosticism
+    connection_type: related_to
+    strength: 1
+    description: Christian Mysticism and Gnosticism share an emphasis on direct spiritual knowledge, though they diverged sharply — Gnosticism was declared heretical while mysticism found a home within orthodox Christianity.
+---
+
+# Christian Mysticism
+
+Christian Mysticism is the contemplative heart of the Christian tradition — the stream concerned not with belief about God but with direct experiential knowledge of the divine. From the Desert Fathers of 3rd-century Egypt to the centering prayer movement of today, Christian mystics have explored silence, surrender, and inner transformation.
+
+## Origins and History
+
+The contemplative dimension appeared early. The Desert Fathers and Mothers of 3rd and 4th-century Egypt — Antony, Macarius, Evagrius — withdrew into the wilderness to practice radical simplicity of prayer and attention. Their sayings form a foundational contemplative literature.
+
+The tradition continued through Pseudo-Dionysius (5th–6th c.), whose apophatic theology insisted God transcends all concepts; Meister Eckhart (13th–14th c.), whose radical sermons on detachment were both celebrated and condemned; Teresa of Avila and John of the Cross (16th c.), who mapped the interior landscape of prayer with extraordinary precision; and the anonymous author of *The Cloud of Unknowing* (14th c.).
+
+## Core Teachings and Practice
+
+Christian mystics teach that beyond religious observance lies a transformative encounter with the living God — requiring silence, humility, and willingness to release one's ideas about the divine. The path typically moves through stages: purgation (letting go), illumination (growing awareness of God's presence), and union (communion with God).
+
+Contemporary practice draws on this heritage through centering prayer (Thomas Keating), lectio divina, and contemplative prayer groups. The tradition insists that contemplative experience is available to anyone willing to sit in silence and attend to the still, small voice within.

--- a/data/traditions/classical-yoga.mdx
+++ b/data/traditions/classical-yoga.mdx
@@ -1,0 +1,32 @@
+---
+name: Classical Yoga (Patanjali)
+slug: classical-yoga
+family: Hindu
+origin_century: -2
+summary: The systematic path of meditation and self-discipline codified by Patanjali in the Yoga Sutras, outlining eight limbs from ethical conduct to meditative absorption.
+connections:
+  - tradition_slug: advaita-vedanta
+    connection_type: related_to
+    strength: 2
+    description: Both are classical Indian darshanas sharing contemplative goals, though Yoga is dualistic (purusha/prakriti) while Advaita is non-dual.
+  - tradition_slug: theravada
+    connection_type: related_to
+    strength: 1
+    description: Patanjali's Yoga and early Buddhist meditation share roots in ancient Indian contemplative culture, with parallel emphases on concentration, ethics, and liberation.
+---
+
+# Classical Yoga (Patanjali)
+
+When most people hear "yoga," they think of postures. But Patanjali's *Yoga Sutras* — Classical Yoga — is primarily a contemplative discipline: a systematic path of meditation aimed at stilling the mind and revealing the true nature of the self.
+
+## Origins and History
+
+The *Yoga Sutras*, composed around the 2nd century BCE (dating debated), are 196 terse aphorisms codifying a tradition likely much older than the text itself. Patanjali organized practices developing in India for centuries, drawing on Samkhya philosophy, early Buddhist meditation, and the contemplative traditions of the Upanishads.
+
+The text lays out an eight-limbed (*ashtanga*) path moving from external conduct to increasingly subtle inner awareness. For most of its history, the *Yoga Sutras* was one philosophical text among many. Its modern prominence as *the* foundational yoga text is largely a 20th-century development.
+
+## Core Teachings and Practice
+
+Patanjali defines yoga as *chitta vritti nirodha* — the cessation of the fluctuations of the mind. When the mind becomes still, the true self (*purusha*) is revealed, free from identification with thoughts, emotions, and the body.
+
+The eight limbs provide a comprehensive framework: ethical restraints (*yama*), observances (*niyama*), posture (*asana*), breath control (*pranayama*), sense withdrawal (*pratyahara*), concentration (*dharana*), meditation (*dhyana*), and absorption (*samadhi*). While modern yoga culture emphasizes asana, Patanjali's system places its center of gravity in the final three — concentration, meditation, and the profound stillness of samadhi.

--- a/data/traditions/dzogchen.mdx
+++ b/data/traditions/dzogchen.mdx
@@ -13,6 +13,14 @@ connections:
     connection_type: related_to
     strength: 1
     description: Both emphasize recognizing one's true nature directly, though Dzogchen operates within a Buddhist framework and Advaita within Hinduism.
+  - tradition_slug: tantra
+    connection_type: influenced_by
+    strength: 2
+    description: Dzogchen incorporates tantric methods and perspectives, particularly in its use of direct awareness practices and the integration of all experience as the path.
+  - tradition_slug: tibetan-buddhism-gelug
+    connection_type: related_to
+    strength: 2
+    description: Both are Tibetan Buddhist traditions, though Dzogchen (Nyingma) emphasizes direct introduction to the nature of mind while Gelug emphasizes the graduated path.
 ---
 
 # Dzogchen

--- a/data/traditions/gnosticism.mdx
+++ b/data/traditions/gnosticism.mdx
@@ -1,0 +1,32 @@
+---
+name: Gnosticism
+slug: gnosticism
+family: Other
+origin_century: 1
+summary: An ancient family of spiritual traditions emphasizing direct experiential knowledge (gnosis) of the divine as the path to liberation from the material world.
+connections:
+  - tradition_slug: christian-mysticism
+    connection_type: related_to
+    strength: 1
+    description: Gnosticism and Christian Mysticism share an emphasis on direct spiritual knowledge, though they diverged sharply in their metaphysics and institutional standing.
+  - tradition_slug: kabbalah
+    connection_type: related_to
+    strength: 1
+    description: Gnosticism and Kabbalah share structural similarities — emanation cosmologies, hidden divine realms, the idea that knowledge itself is redemptive — suggesting possible historical cross-pollination.
+---
+
+# Gnosticism
+
+Gnosticism is a family of ancient spiritual traditions united by a radical claim: that the deepest truths about reality are hidden, and that what we take to be the ordinary world is a kind of prison — a realm of ignorance from which we can be liberated only through direct spiritual knowledge (*gnosis*). It is one of the most enigmatic traditions in the contemplative landscape.
+
+## Origins and History
+
+Gnosticism flourished in the first through third centuries CE, emerging alongside and in dialogue with early Christianity, Judaism, and Hellenistic philosophy. For centuries, Gnostic teachings were known primarily through their opponents — early Church Fathers who condemned them as heresy. The 1945 discovery of the Nag Hammadi library in Egypt transformed our understanding, revealing a diverse body of literature including the *Gospel of Thomas*, the *Gospel of Philip*, and the *Apocryphon of John*.
+
+Gnostic cosmologies vary enormously, but many share a basic narrative: the true God is utterly transcendent; the material world was created by a lesser, ignorant being (the *Demiurge*); and human beings carry within them a divine spark trapped in matter. Liberation comes through *gnosis* — not intellectual knowledge but a transformative inner awakening to one's true divine origin.
+
+## Core Teachings and Practice
+
+The Gnostic path is fundamentally one of recognition — remembering what has been forgotten. The practitioner does not seek to earn divine favor but to awaken from cosmic amnesia, recognizing the divine light present within them all along.
+
+Specific practices are harder to reconstruct than myths and doctrines. Evidence suggests Gnostic communities practiced baptism, anointing, sacred meals, and contemplative exercises involving visualization and the ascent of the soul through celestial realms. What is clear is that gnosis was understood not as belief but as experience — a direct encounter with the divine that transforms the knower.

--- a/data/traditions/hesychasm.mdx
+++ b/data/traditions/hesychasm.mdx
@@ -1,0 +1,28 @@
+---
+name: Hesychasm
+slug: hesychasm
+family: Christian Contemplative
+origin_century: 4
+summary: The Eastern Orthodox contemplative tradition of inner stillness centered on the Jesus Prayer and continuous prayer of the heart.
+connections:
+  - tradition_slug: christian-mysticism
+    connection_type: branch_of
+    strength: 3
+    description: Hesychasm is a specific contemplative method within the broader tradition of Christian Mysticism, developed primarily in the Eastern Orthodox churches.
+---
+
+# Hesychasm
+
+Hesychasm — from the Greek *hesychia*, meaning stillness — is the contemplative tradition of Eastern Orthodox Christianity. Its central practice is the Jesus Prayer ("Lord Jesus Christ, Son of God, have mercy on me"), repeated continuously until it descends from the lips to the mind to the heart, becoming a living current of prayer beneath all activity.
+
+## Origins and History
+
+The roots reach back to the Desert Fathers of 4th-century Egypt and Palestine, who cultivated continuous prayer and watchful attention (*nepsis*). The tradition developed over centuries in the monasteries of Sinai, Palestine, and Mount Athos, shaped by Evagrius Ponticus (4th c.), John Climacus (7th c.), and Symeon the New Theologian (10th–11th c.).
+
+It reached its most systematic expression with Gregory Palamas (14th c.), who defended Hesychast practice by arguing that the light experienced by advanced practitioners was the uncreated light of God — the same light that shone during Christ's Transfiguration. His theology of the divine energies became official Orthodox teaching.
+
+## Core Teachings and Practice
+
+Practice centers on the Jesus Prayer combined with attention to the breath and a postural practice of bowing the head toward the heart. The practitioner cultivates *nepsis* — vigilant watchfulness over the mind — and seeks to gather scattered attention into the heart, the spiritual center of the person.
+
+The tradition describes a progression from oral prayer to mental prayer to prayer of the heart (self-acting, flowing continuously beneath conscious awareness). The goal is *theosis* — divinization, the participation of the human person in the divine life — not as an abstract concept but as a lived, embodied transformation.

--- a/data/traditions/jainism.mdx
+++ b/data/traditions/jainism.mdx
@@ -1,0 +1,32 @@
+---
+name: Jainism
+slug: jainism
+family: Other
+origin_century: -6
+summary: One of the world's oldest contemplative traditions, emphasizing radical non-violence (ahimsa), ascetic discipline, and the liberation of the soul through self-purification.
+connections:
+  - tradition_slug: theravada
+    connection_type: related_to
+    strength: 1
+    description: Jainism and early Buddhism emerged in the same region and era (the Ganges plain, 6th–5th c. BCE), sharing emphases on renunciation, meditation, and liberation from the cycle of rebirth.
+  - tradition_slug: classical-yoga
+    connection_type: related_to
+    strength: 1
+    description: Jainism and Classical Yoga share contemplative parallels — ethical restraints, meditation, and progressive purification of consciousness — reflecting common roots in ancient Indian ascetic culture.
+---
+
+# Jainism
+
+Jainism is one of the world's oldest living contemplative traditions — a path of radical non-violence, rigorous self-discipline, and the progressive purification of the soul. In a landscape often dominated by Buddhist and Hindu traditions, Jainism offers a distinctive and uncompromising vision of liberation.
+
+## Origins and History
+
+Jainism traces its lineage through 24 *Tirthankaras* ("ford-makers") — enlightened teachers who discovered and taught the path across vast cosmic cycles. The historical founder is Mahavira (c. 599–527 BCE), a contemporary of the Buddha who renounced his princely life to pursue liberation through extreme asceticism and meditation. After twelve years of wandering practice, he achieved *kevala jnana* — omniscient knowledge.
+
+Jainism developed into two major branches: the *Digambara* ("sky-clad") and the *Shvetambara* ("white-clad"). Both share the same core philosophy and contemplative practices, differing primarily in matters of monastic discipline.
+
+## Core Teachings and Practice
+
+Jainism's central principle is *ahimsa* — non-violence carried to its most radical expression. Jain monks sweep the path before them to avoid stepping on insects, strain their water, and wear mouth-coverings to protect airborne organisms. This reflects a metaphysical conviction: every living being possesses a soul (*jiva*), and violence creates *karma* that binds the soul to the cycle of rebirth.
+
+Contemplative practice centers on meditation (*dhyana*), self-study (*svadhyaya*), and progressive renunciation. The tradition's ethical framework — truthfulness, non-stealing, celibacy, and non-possessiveness — is understood as the necessary foundation for inner purification. The goal is *moksha*: the complete liberation of the soul from all karmic bondage, resulting in infinite knowledge, perception, bliss, and energy.

--- a/data/traditions/kabbalah.mdx
+++ b/data/traditions/kabbalah.mdx
@@ -1,0 +1,32 @@
+---
+name: Kabbalah
+slug: kabbalah
+family: Other
+origin_century: 12
+summary: The mystical tradition of Judaism exploring the hidden dimensions of Torah, the structure of divine emanation, and the soul's journey toward union with God.
+connections:
+  - tradition_slug: gnosticism
+    connection_type: related_to
+    strength: 1
+    description: Kabbalah and Gnosticism share structural features — emanation cosmologies, hidden divine realms, and the redemptive power of esoteric knowledge — though direct historical links are debated.
+  - tradition_slug: sufism
+    connection_type: related_to
+    strength: 1
+    description: Kabbalah and Sufism developed in proximity in medieval Spain and the Middle East, and scholars have noted parallels in their contemplative practices and metaphysical frameworks.
+---
+
+# Kabbalah
+
+Kabbalah is the mystical tradition of Judaism — a vast body of contemplative teaching exploring the hidden dimensions of Torah, the nature of God, and the soul's journey toward the divine. The word *Kabbalah* means "that which is received," pointing to the tradition's self-understanding as a secret teaching transmitted from master to student.
+
+## Origins and History
+
+While Kabbalists trace their tradition to Sinai, the historical Kabbalah emerged in 12th-century Provence and 13th-century Spain. The foundational text is the *Zohar* ("Book of Splendor"), a mystical commentary on Torah composed by Moses de Leon in late 13th-century Castile, though traditionally attributed to the 2nd-century sage Rabbi Shimon bar Yochai.
+
+After the Spanish expulsion of 1492, Kabbalah's center shifted to Safed, where Isaac Luria (1534–1572) developed a revolutionary cosmology centered on divine contraction (*tzimtzum*), the shattering of primordial vessels, and the human task of *tikkun* (repair) — gathering scattered sparks of divine light trapped in the material world.
+
+## Core Teachings and Practice
+
+Kabbalistic cosmology describes reality as structured by the *sefirot* — ten divine emanations through which the infinite God (*Ein Sof*) manifests the world. These form the "Tree of Life" — a map of divine and human consciousness.
+
+Practice includes meditative focus on the *sefirot*, contemplative prayer with specific *kavvanot* (intentions), sacred text study as spiritual practice, and ethical refinement understood as alignment with the divine attributes. The tradition has always been surrounded by caution — traditionally reserved for mature scholars — reflecting both the depth of its teachings and the recognition that powerful contemplative frameworks require adequate preparation.

--- a/data/traditions/kashmir-shaivism.mdx
+++ b/data/traditions/kashmir-shaivism.mdx
@@ -9,6 +9,10 @@ connections:
     connection_type: diverged_from
     strength: 3
     description: Both are non-dual Hindu traditions, but Kashmir Shaivism diverged from Advaita by seeing the world as a real expression of consciousness rather than illusion, offering a more world-affirming view.
+  - tradition_slug: tantra
+    connection_type: branch_of
+    strength: 3
+    description: Kashmir Shaivism is one of the most philosophically refined expressions of Hindu Tantra, developing tantric principles into a comprehensive non-dual philosophy.
 ---
 
 # Kashmir Shaivism

--- a/data/traditions/modern-non-dual.mdx
+++ b/data/traditions/modern-non-dual.mdx
@@ -1,0 +1,36 @@
+---
+name: Modern Non-Dual
+slug: modern-non-dual
+family: Modern Secular
+origin_century: 20
+summary: A contemporary contemplative movement drawing on Advaita Vedanta and other non-dual traditions, emphasizing direct recognition of awareness as one's true nature.
+connections:
+  - tradition_slug: advaita-vedanta
+    connection_type: influenced_by
+    strength: 3
+    description: Modern Non-Dual teachings draw most directly from Advaita Vedanta, particularly through the lineage of Ramana Maharshi and Nisargadatta Maharaj.
+  - tradition_slug: zen
+    connection_type: influenced_by
+    strength: 1
+    description: Some Modern Non-Dual teachers draw on Zen's emphasis on direct pointing and the inadequacy of conceptual understanding.
+  - tradition_slug: dzogchen
+    connection_type: related_to
+    strength: 1
+    description: Modern Non-Dual teachings share Dzogchen's emphasis on recognizing the natural state of awareness, though typically without the Tibetan Buddhist framework.
+---
+
+# Modern Non-Dual
+
+The Modern Non-Dual movement is a contemporary contemplative phenomenon that strips the ancient insight of non-duality — that awareness and its contents are not fundamentally separate — from its traditional religious contexts and offers it in a direct, accessible form. It is less a single tradition than a loosely connected family of teachers and approaches sharing a common orientation.
+
+## Origins and History
+
+The movement's roots lie in the 20th-century encounter between Indian non-dual teachings and Western seekers. Ramana Maharshi (1879–1950), who taught self-inquiry ("Who am I?"), and Nisargadatta Maharaj (1897–1981), whose dialogues in *I Am That* became a touchstone, are among its most important sources. Jiddu Krishnamurti (1895–1986) — who dissolved the spiritual organization built around him and spent decades pointing toward freedom beyond all systems — is another foundational figure.
+
+From these roots, a diverse ecosystem of teachers emerged. Some maintained close ties to Advaita Vedanta; others pushed toward radical simplicity, rejecting practices, paths, and even the concept of a seeker. Contemporary figures like Rupert Spira and Eckhart Tolle have brought non-dual perspectives to wide audiences.
+
+## Core Teachings and Practice
+
+The central teaching is deceptively simple: what you are, at the deepest level, is awareness itself — not the contents of awareness but the knowing presence in which all experience appears. This awareness is not something to be achieved but recognized as already present.
+
+Practice varies widely. Some teachers emphasize self-inquiry, others guided meditation on awareness, and still others simply point — through dialogue, silence, or presence — toward what is already the case. The movement's relationship to traditional practice is complex: some teachers value meditation and ethics as supports, while others argue that any practice implies a separation between seeker and sought that is itself the fundamental illusion.

--- a/data/traditions/quaker-inner-light.mdx
+++ b/data/traditions/quaker-inner-light.mdx
@@ -1,0 +1,28 @@
+---
+name: Quaker Inner Light
+slug: quaker-inner-light
+family: Christian Contemplative
+origin_century: 17
+summary: The Religious Society of Friends' contemplative tradition centered on silent worship and the belief that divine light is present within every person.
+connections:
+  - tradition_slug: christian-mysticism
+    connection_type: influenced_by
+    strength: 2
+    description: The Quaker tradition draws on the broader Christian mystical heritage, particularly its emphasis on direct inner experience of God beyond doctrinal formulation.
+---
+
+# Quaker Inner Light
+
+The Religious Society of Friends — the Quakers — emerged in 17th-century England with a radical proposition: that every person carries within them a direct connection to the divine, requiring no priest, sacrament, or creed. This "Inner Light" or "that of God in everyone" is the foundation of Quaker worship, ethics, and social witness.
+
+## Origins and History
+
+George Fox (1624–1691) experienced spiritual openings that led him to reject the established church. "There is one, even Christ Jesus, that can speak to thy condition," he reported — and from that direct experience, he began teaching that true worship happens in the silence of gathered friends, waiting for the movement of the Spirit.
+
+Early Quakers were persecuted fiercely for their refusal to observe religious conventions, swear oaths, or defer to social hierarchy. The tradition spread to America, where William Penn's "Holy Experiment" in Pennsylvania became one of the earliest expressions of religious tolerance in the New World.
+
+## Core Teachings and Practice
+
+Quaker worship in its traditional form is strikingly simple: a group sits together in silence, without liturgy, music, or a predetermined speaker. Participants listen inwardly, and anyone moved to speak may do so — the expectation being that genuine ministry arises from the immediate action of the divine.
+
+This practice of corporate silence is both contemplative and communal. Quakers speak of the gathered meeting "settling into" a shared depth, where the silence becomes alive. The tradition values the fruits of contemplation over metaphysical speculation, expressing its spiritual life through commitment to simplicity, peace, integrity, equality, and community.

--- a/data/traditions/secular-mindfulness.mdx
+++ b/data/traditions/secular-mindfulness.mdx
@@ -1,0 +1,40 @@
+---
+name: Secular Mindfulness (MBSR)
+slug: secular-mindfulness
+family: Modern Secular
+origin_century: 20
+summary: The adaptation of Buddhist mindfulness practices for clinical and secular contexts, pioneered by Jon Kabat-Zinn's Mindfulness-Based Stress Reduction program.
+connections:
+  - tradition_slug: theravada
+    connection_type: influenced_by
+    strength: 2
+    description: MBSR drew directly from Theravada Vipassana meditation practices, adapting core mindfulness techniques for clinical and secular settings.
+  - tradition_slug: vipassana-movement
+    connection_type: influenced_by
+    strength: 2
+    description: Jon Kabat-Zinn trained with Vipassana Movement teachers including Jack Kornfield and studied with Thich Nhat Hanh, directly informing the development of MBSR.
+  - tradition_slug: zen
+    connection_type: influenced_by
+    strength: 1
+    description: Kabat-Zinn also practiced Zen, and its emphasis on present-moment awareness influenced the spirit of MBSR.
+  - tradition_slug: classical-yoga
+    connection_type: influenced_by
+    strength: 1
+    description: MBSR incorporates yoga postures and body awareness practices alongside meditation, drawing on the hatha yoga tradition.
+---
+
+# Secular Mindfulness (MBSR)
+
+Secular Mindfulness represents one of the most significant cultural transfers in contemplative history: the adaptation of Buddhist meditation practices for clinical, educational, and corporate settings, stripped of their religious context and reframed in the language of science and well-being.
+
+## Origins and History
+
+In 1979, Jon Kabat-Zinn — a molecular biologist who had trained in Vipassana meditation and Zen — founded the Stress Reduction Clinic at the University of Massachusetts Medical Center. His eight-week MBSR program taught chronic pain patients to meditate, practice yoga, and cultivate moment-to-moment awareness. The results attracted clinical research, and MBSR gradually gained credibility within mainstream medicine.
+
+The movement accelerated as research proliferated. Mindfulness-Based Cognitive Therapy (MBCT) was developed for depression relapse prevention. Programs entered schools, prisons, the military, and corporate settings. By the 2010s, mindfulness had become a cultural phenomenon.
+
+## Core Teachings and Practice
+
+Secular mindfulness teaches the cultivation of non-judgmental, present-moment awareness. The core practices — body scan meditation, sitting meditation, mindful movement, and informal mindfulness — are drawn from Buddhist meditation but presented without Buddhist metaphysics.
+
+The MBSR curriculum unfolds over eight weeks: participants learn to observe physical sensations, thoughts, and emotions with curiosity rather than reactivity. The emphasis is on relating differently to experience — not eliminating stress or pain but changing one's relationship to them. Critics note that this secular translation may lose something essential; proponents argue that making these practices widely accessible is itself a form of compassionate service.

--- a/data/traditions/sufism.mdx
+++ b/data/traditions/sufism.mdx
@@ -1,0 +1,36 @@
+---
+name: Sufism
+slug: sufism
+family: Islamic Contemplative
+origin_century: 8
+summary: The mystical dimension of Islam emphasizing direct experience of the divine through devotion, remembrance, and purification of the heart.
+connections:
+  - tradition_slug: bhakti
+    connection_type: related_to
+    strength: 1
+    description: Sufism and Bhakti share a deep emphasis on ecstatic devotional love as a path to the divine, and the two traditions likely influenced each other in medieval India.
+  - tradition_slug: christian-mysticism
+    connection_type: related_to
+    strength: 1
+    description: Sufism and Christian Mysticism share emphases on inner purification, stages of prayer, and direct experiential knowledge of God, with some historical interchange.
+  - tradition_slug: kabbalah
+    connection_type: related_to
+    strength: 1
+    description: Sufism and Kabbalah developed in proximity in medieval Spain and the Middle East, with scholars noting parallels in their contemplative practices and metaphysical frameworks.
+---
+
+# Sufism
+
+Sufism is the contemplative heart of Islam — the tradition of seekers who pursue not merely obedience to divine law but intimate, experiential knowledge of the divine. The word *Sufi* may derive from *suf* (wool), referring to the simple garments of early Muslim ascetics, or from *safa* (purity).
+
+## Origins and History
+
+Sufism emerged in the 8th and 9th centuries CE as a response to what some perceived as increasing legalism in the expanding Islamic empire. Early figures like Hasan al-Basri (d. 728), Rabia al-Adawiyya (d. 801) — who taught that God should be loved for God's own sake — and Junayd of Baghdad (d. 910) established the tradition's core themes of renunciation, love, and inner transformation.
+
+The tradition produced extraordinary contemplative literature: al-Ghazali's *Revival of the Religious Sciences* (11th c.), Ibn Arabi's vision of the "unity of being" (13th c.), and the incomparable poetry of Rumi, Hafiz, and Attar.
+
+## Core Teachings and Practice
+
+Sufism teaches that the human heart is a mirror that, when polished through practice, can reflect the light of God. The *nafs* (ego-self) must be purified through stages until the practitioner becomes transparent to the divine presence.
+
+Central practices include *dhikr* (remembrance of God through divine names), *sama* (spiritual listening, including the Mevlevi whirling ceremony), meditation (*muraqaba*), and the cultivation of *adab* (spiritual courtesy). The teacher-student relationship is paramount: the *shaykh* guides the seeker through the spiritual path, providing practices, correction, and the transmission of *baraka* (spiritual presence).

--- a/data/traditions/tai-chi-qigong.mdx
+++ b/data/traditions/tai-chi-qigong.mdx
@@ -1,0 +1,32 @@
+---
+name: Tai Chi/Qigong
+slug: tai-chi-qigong
+family: Taoist
+origin_century: 12
+summary: Embodied contemplative practices rooted in Taoist philosophy, using slow movement, breath, and awareness to cultivate vital energy and harmony.
+connections:
+  - tradition_slug: taoism
+    connection_type: branch_of
+    strength: 3
+    description: Tai Chi and Qigong are direct practical expressions of Taoist philosophy, applying its principles of harmony, balance, and qi cultivation through embodied movement.
+  - tradition_slug: classical-yoga
+    connection_type: related_to
+    strength: 1
+    description: Both are embodied contemplative practices working with breath and subtle energy, though from different cultural and philosophical contexts.
+---
+
+# Tai Chi/Qigong
+
+Tai Chi and Qigong are contemplative practices of the body in motion — slow, deliberate movement synchronized with breath and awareness. Rooted in Taoist philosophy and traditional Chinese medicine, they represent one of humanity's oldest experiments in using the body as a vehicle for cultivating health, awareness, and spiritual harmony.
+
+## Origins and History
+
+Qigong ("energy cultivation") is the broader and older category — a vast family of practices involving breath, movement, and meditation aimed at cultivating *qi* (vital energy). Evidence suggests movement-based qi cultivation existed in China as far back as the 2nd century BCE.
+
+Tai Chi Chuan ("supreme ultimate fist") is traditionally attributed to the Taoist monk Zhang Sanfeng during the Song Dynasty (12th–13th century), though this origin is debated. Tai Chi integrates martial arts, qigong, and Taoist philosophy into a unified system of slow, flowing movement. The major family styles — Chen, Yang, Wu, and Sun — developed between the 17th and 20th centuries.
+
+## Core Teachings and Practice
+
+Both practices are grounded in the Taoist understanding that health and well-being depend on the free flow of qi through the body. Practice involves slow, mindful movement coordinated with deep breathing and focused attention. Tai Chi's flowing forms embody the Taoist principles of *yin* and *yang*, yielding and firmness, emptiness and fullness.
+
+Both traditions emphasize *song* (relaxation without collapse) and the gradual development of sensitivity to the body's subtle energies. In the modern world, they are practiced by millions for health, stress reduction, and contemplative development.

--- a/data/traditions/tantra.mdx
+++ b/data/traditions/tantra.mdx
@@ -1,0 +1,36 @@
+---
+name: Tantra
+slug: tantra
+family: Hindu
+origin_century: 5
+summary: A broad family of esoteric traditions using ritual, embodiment, and the transformation of ordinary experience as paths to liberation.
+connections:
+  - tradition_slug: kashmir-shaivism
+    connection_type: branch_of
+    strength: 3
+    description: Kashmir Shaivism is one of the most philosophically refined expressions of Hindu Tantra, developing tantric principles into a comprehensive non-dual philosophy.
+  - tradition_slug: dzogchen
+    connection_type: influenced_by
+    strength: 2
+    description: Dzogchen and other Tibetan Buddhist practices were influenced by tantric methods, particularly direct awareness practices and the embrace of all experience.
+  - tradition_slug: classical-yoga
+    connection_type: related_to
+    strength: 1
+    description: Tantra shares some methods with Classical Yoga (breath work, subtle body practices) while differing in its embrace of the body and sensory experience as vehicles for liberation.
+---
+
+# Tantra
+
+Tantra is one of the most misunderstood contemplative traditions. In the West, it is often reduced to its sexual associations, but the tantric traditions are vast — encompassing elaborate ritual systems, sophisticated philosophies of consciousness, subtle body practices, and radical approaches to liberation that embrace rather than renounce the full spectrum of human experience.
+
+## Origins and History
+
+Tantric texts and practices began emerging around the 5th century CE, though their roots likely extend further back. The movement developed across both Hindu and Buddhist contexts, producing remarkable diversity. Hindu Tantra gave rise to Kashmir Shaivism, Shri Vidya, and the Kaula lineages; Buddhist Tantra produced the Vajrayana traditions of Tibet and the Shingon school of Japan.
+
+What united these diverse traditions was a set of shared innovations: *mantra* (sacred sound), *yantra* and *mandala* (sacred geometry), *mudra* (gesture), deity visualization, and practices working with the subtle body — the system of *chakras*, *nadis* (channels), and *kundalini* (vital energy).
+
+## Core Teachings and Practice
+
+Tantra's revolutionary insight is that liberation does not require withdrawal from the world. The body, the senses, and even desire can become vehicles for awakening when approached with the right understanding and method. Where ascetic traditions seek liberation *from* embodied experience, Tantra seeks liberation *through* it.
+
+Tantric practice is typically received through initiation (*diksha*) from a qualified teacher and involves meditation, mantra recitation, visualization, breath work, and ritual. The tradition places great emphasis on the teacher-student relationship and on careful transmission of practices suited to each individual's capacity.

--- a/data/traditions/taoism.mdx
+++ b/data/traditions/taoism.mdx
@@ -1,0 +1,36 @@
+---
+name: Taoism
+slug: taoism
+family: Taoist
+origin_century: -5
+summary: An ancient Chinese philosophical and contemplative tradition rooted in harmony with the Tao — the nameless, formless source and pattern of all things.
+connections:
+  - tradition_slug: chan-buddhism
+    connection_type: influenced_by
+    strength: 2
+    description: Taoist ideas of naturalness, emptiness, and spontaneity profoundly shaped Chan Buddhism as it developed in China.
+  - tradition_slug: zen
+    connection_type: influenced_by
+    strength: 2
+    description: Through its formative influence on Chan Buddhism, Taoism indirectly shaped Zen's aesthetic sensibility and emphasis on naturalness.
+  - tradition_slug: tai-chi-qigong
+    connection_type: branch_of
+    strength: 3
+    description: Tai Chi and Qigong grew directly from Taoist philosophy and its emphasis on cultivating vital energy in harmony with the Tao.
+---
+
+# Taoism
+
+Taoism is the contemplative heart of Chinese civilization — a tradition that teaches not by adding concepts but by subtracting them, pointing toward the nameless source that precedes all things. "The Tao that can be spoken is not the eternal Tao," begins the *Tao Te Ching*, and in that paradoxical opening, the tradition reveals its essential character.
+
+## Origins and History
+
+Taoism's philosophical foundations are attributed to Laozi (traditionally 6th century BCE) and Zhuangzi (4th century BCE), though both figures are wrapped in legend. The *Tao Te Ching*, attributed to Laozi, is one of the most translated texts in history — 81 brief, enigmatic chapters on the nature of reality, governance, and living in harmony with the Way.
+
+Zhuangzi's writings are wilder and more playful — full of talking animals, dream sequences, and stories of artisans whose skill comes not from effort but from complete alignment with the natural flow. Together, these texts established a tradition emphasizing *wu wei* (non-forcing action), simplicity, and the relativity of human judgments.
+
+## Core Teachings and Practice
+
+The Tao — the Way — is the nameless, formless reality that gives rise to all things and to which all things return. It cannot be grasped by the intellect, but it can be harmonized with through simplicity, receptivity, and attention.
+
+Taoist contemplative practice includes seated meditation (*zuowang* — "sitting and forgetting"), breath cultivation (*qigong*), internal alchemy (*neidan*), and the embodied movement practices that became Tai Chi. The common thread is the cultivation of *qi* (vital energy) and the alignment of body, breath, and mind with the natural rhythms of the Tao.

--- a/data/traditions/theravada.mdx
+++ b/data/traditions/theravada.mdx
@@ -9,6 +9,18 @@ connections:
     connection_type: related_to
     strength: 2
     description: Both emphasize meditation practice as central, though Theravada preserves the earlier Pali canon teachings while Zen developed within the later Mahayana tradition.
+  - tradition_slug: vipassana-movement
+    connection_type: branch_of
+    strength: 3
+    description: The Vipassana Movement emerged directly from Theravada Buddhism, reviving its insight meditation practices for lay practitioners beginning in 19th-century Burma.
+  - tradition_slug: secular-mindfulness
+    connection_type: influenced_by
+    strength: 2
+    description: Theravada mindfulness practices, particularly vipassana, were the primary source for secular mindfulness programs like MBSR.
+  - tradition_slug: jainism
+    connection_type: related_to
+    strength: 1
+    description: Theravada Buddhism and Jainism emerged in the same region and era, sharing emphases on renunciation, meditation, and liberation from the cycle of rebirth.
 ---
 
 # Theravada Buddhism

--- a/data/traditions/tibetan-buddhism-gelug.mdx
+++ b/data/traditions/tibetan-buddhism-gelug.mdx
@@ -1,0 +1,36 @@
+---
+name: Tibetan Buddhism (Gelug)
+slug: tibetan-buddhism-gelug
+family: Buddhist
+origin_century: 14
+summary: The "Virtuous" school of Tibetan Buddhism founded by Tsongkhapa, emphasizing monastic discipline, analytical meditation, and the graduated path to enlightenment.
+connections:
+  - tradition_slug: theravada
+    connection_type: influenced_by
+    strength: 2
+    description: The Gelug school draws on the Theravada emphasis on monastic discipline and systematic study, integrating these within a Mahayana and Vajrayana framework.
+  - tradition_slug: dzogchen
+    connection_type: related_to
+    strength: 2
+    description: Both are Tibetan Buddhist traditions, though Gelug emphasizes the graduated path and analytical meditation while Dzogchen points directly to the nature of mind.
+  - tradition_slug: classical-yoga
+    connection_type: influenced_by
+    strength: 1
+    description: Tibetan Buddhist contemplative practices share structural parallels with Patanjali's systematic approach, likely through cross-pollination in ancient Indian universities like Nalanda.
+---
+
+# Tibetan Buddhism (Gelug)
+
+The Gelug school — the "Virtuous Ones" — is the youngest and largest of the four major schools of Tibetan Buddhism. Founded by the great scholar-practitioner Tsongkhapa (1357–1419), it is the tradition of the Dalai Lamas and the dominant school of Tibetan monastic education.
+
+## Origins and History
+
+Tsongkhapa was a prodigious Tibetan scholar who studied with masters from all the existing schools before synthesizing their teachings into a comprehensive system. Concerned that tantric practice had become divorced from ethical discipline and philosophical rigor, he called for a return to the foundations: strict monastic conduct, deep study of Indian Buddhist philosophy, and a systematic, graduated approach to the path.
+
+His magnum opus, the *Lamrim Chenmo* ("Great Treatise on the Stages of the Path"), laid out a step-by-step path from the concerns of an ordinary person all the way to full buddhahood. The Gelug school grew rapidly, establishing the great monastic universities of Ganden, Drepung, and Sera near Lhasa — institutions that at their height housed thousands of monks engaged in rigorous philosophical debate.
+
+## Core Teachings and Practice
+
+The Gelug path is characterized by its emphasis on the *lamrim* (graduated path), which organizes the entire Buddhist teaching into a sequence of meditations suited to practitioners at different levels. Analytical meditation — using reasoning to generate genuine insight and emotional transformation — is as important as single-pointed concentration.
+
+The school also preserves an extensive system of Vajrayana (tantric) practice, but insists that tantra must be grounded in a solid foundation of ethics, study, and philosophical understanding. The famous Gelug debate tradition, in which monks vigorously test each other's understanding through formalized argument, reflects this commitment to intellectual rigor as a complement to contemplative experience.

--- a/data/traditions/vipassana-movement.mdx
+++ b/data/traditions/vipassana-movement.mdx
@@ -1,0 +1,32 @@
+---
+name: Vipassana Movement
+slug: vipassana-movement
+family: Buddhist
+origin_century: 19
+summary: The modern revival of insight meditation rooted in Burmese Theravada Buddhism, emphasizing direct mindfulness practice accessible to laypeople.
+connections:
+  - tradition_slug: theravada
+    connection_type: branch_of
+    strength: 3
+    description: The Vipassana Movement emerged directly from Theravada Buddhism, reviving and simplifying its insight meditation practices for lay practitioners beginning in 19th-century Burma.
+  - tradition_slug: secular-mindfulness
+    connection_type: influenced_by
+    strength: 2
+    description: The Vipassana Movement was a primary source for secular mindfulness programs like MBSR, which adapted its core meditation techniques for clinical settings.
+---
+
+# Vipassana Movement
+
+The Vipassana Movement refers to the modern revival of insight meditation (*vipassana*) that began in 19th-century Burma and has since become one of the most widely practiced contemplative traditions in the world. It represents a democratization of Buddhist meditation — making practices once reserved for monastics accessible to ordinary laypeople.
+
+## Origins and History
+
+While vipassana has been part of Buddhist practice for millennia, the modern movement began when Burmese monks in the late 19th and early 20th centuries started teaching meditation directly to laypeople. Key figures include Ledi Sayadaw (1846–1923), who wrote accessible meditation manuals, and his student lineage that produced S.N. Goenka, whose ten-day silent retreats have introduced millions worldwide to the practice.
+
+A parallel stream flowed through Mahasi Sayadaw (1904–1982), whose "noting" technique influenced Western teachers including Joseph Goldstein, Sharon Salzberg, and Jack Kornfield, who founded the Insight Meditation Society in 1975.
+
+## Core Teachings and Practice
+
+The movement distills Theravada Buddhist practice to its contemplative essence: sustained, careful attention to present-moment experience. Practitioners sit in silence and observe bodily sensations, thoughts, and emotions as they arise and pass away, cultivating direct insight into impermanence, suffering, and the constructed nature of the self.
+
+What distinguishes the movement is its emphasis on accessibility and its relative independence from the broader cultural framework of traditional Theravada Buddhism. Whether through Goenka's structured ten-day retreats or the more flexible approach of Western insight meditation teachers, the movement has made the heart of the Buddhist contemplative path available to people of any background.

--- a/data/traditions/zen.mdx
+++ b/data/traditions/zen.mdx
@@ -13,6 +13,14 @@ connections:
     connection_type: related_to
     strength: 1
     description: Both point to the nature of mind as already awake, though Zen emphasizes seated meditation (zazen) while Dzogchen works more with awareness in all activities.
+  - tradition_slug: chan-buddhism
+    connection_type: branch_of
+    strength: 3
+    description: Zen is the direct Japanese transmission of Chinese Chan Buddhism, brought to Japan by monks like Eisai (Rinzai) and Dogen (Soto) in the 12th–13th centuries.
+  - tradition_slug: taoism
+    connection_type: influenced_by
+    strength: 2
+    description: Through its Chan Buddhist origins, Zen absorbed Taoist sensibilities of naturalness, spontaneity, and the limits of conceptual thinking.
 ---
 
 # Zen


### PR DESCRIPTION
## Summary
- Expands the tradition dataset from 5 to 22 traditions, covering all 7 family types (Buddhist, Hindu, Taoist, Christian Contemplative, Islamic Contemplative, Modern Secular, Other)
- Each tradition has complete frontmatter (name, slug, family, summary, origin_century, connections) and 2-3 paragraphs of editorially sensitive content
- Defines 10 `branch_of` and 21 `influenced_by` connections with historically grounded descriptions
- Updates existing 5 traditions with connections to newly created traditions

Closes #25

## New traditions
**Buddhist:** Tibetan Buddhism (Gelug), Chan Buddhism, Vipassana Movement
**Hindu:** Bhakti, Classical Yoga (Patanjali), Tantra
**Taoist:** Taoism, Tai Chi/Qigong
**Christian Contemplative:** Christian Mysticism, Hesychasm, Quaker Inner Light
**Islamic Contemplative:** Sufism
**Modern Secular:** Secular Mindfulness (MBSR), Modern Non-Dual
**Other:** Gnosticism, Kabbalah, Jainism

## Test plan
- [x] `npm run build` passes (42 static pages generated)
- [x] All 22 tradition pages render at `/traditions/[slug]`
- [x] At least 5 `branch_of` connections (have 10)
- [x] At least 8 `influenced_by` connections (have 21)
- [ ] Manual review of editorial content for sensitivity and accuracy

🤖 Generated with [Claude Code](https://claude.com/claude-code)