### PR TITLE
Update family filter and tune ForceAtlas2 for 22 traditions

### DIFF
--- a/src/components/tradition-map/__tests__/family-filter.test.tsx
+++ b/src/components/tradition-map/__tests__/family-filter.test.tsx
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { FamilyFilter } from "../family-filter";
+import type { TraditionFamily } from "@/lib/types";
+
+const ALL_FAMILIES: TraditionFamily[] = [
+  "Buddhist",
+  "Hindu",
+  "Taoist",
+  "Christian Contemplative",
+  "Islamic Contemplative",
+  "Modern Secular",
+  "Other",
+];
+
+describe("FamilyFilter", () => {
+  it("renders all 7 families as buttons", () => {
+    render(
+      <FamilyFilter
+        families={ALL_FAMILIES}
+        activeFamilies={new Set(ALL_FAMILIES)}
+        onToggle={() => {}}
+      />
+    );
+    for (const family of ALL_FAMILIES) {
+      expect(screen.getByRole("button", { name: new RegExp(family) })).toBeInTheDocument();
+    }
+  });
+
+  it("marks active families with aria-pressed=true", () => {
+    const active = new Set<TraditionFamily>(["Buddhist", "Hindu"]);
+    render(
+      <FamilyFilter families={ALL_FAMILIES} activeFamilies={active} onToggle={() => {}} />
+    );
+    expect(screen.getByRole("button", { name: /Buddhist/ })).toHaveAttribute("aria-pressed", "true");
+    expect(screen.getByRole("button", { name: /Taoist/ })).toHaveAttribute("aria-pressed", "false");
+  });
+
+  it("calls onToggle when a family button is clicked", () => {
+    const onToggle = vi.fn();
+    render(
+      <FamilyFilter
+        families={ALL_FAMILIES}
+        activeFamilies={new Set(ALL_FAMILIES)}
+        onToggle={onToggle}
+      />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /Taoist/ }));
+    expect(onToggle).toHaveBeenCalledWith("Taoist");
+  });
+
+  it("renders a color dot for each family", () => {
+    const { container } = render(
+      <FamilyFilter
+        families={ALL_FAMILIES}
+        activeFamilies={new Set(ALL_FAMILIES)}
+        onToggle={() => {}}
+      />
+    );
+    // Each button should have a colored dot (span with rounded-full)
+    const dots = container.querySelectorAll("span.rounded-full");
+    expect(dots).toHaveLength(7);
+  });
+
+  it("has a group role with accessible label", () => {
+    render(
+      <FamilyFilter
+        families={ALL_FAMILIES}
+        activeFamilies={new Set(ALL_FAMILIES)}
+        onToggle={() => {}}
+      />
+    );
+    expect(screen.getByRole("group", { name: /filter by tradition family/i })).toBeInTheDocument();
+  });
+});

--- a/src/components/tradition-map/family-filter.tsx
+++ b/src/components/tradition-map/family-filter.tsx
@@ -21,7 +21,11 @@ export function FamilyFilter({
   onToggle,
 }: FamilyFilterProps) {
   return (
-    <div className="flex flex-wrap gap-2 justify-center" role="group" aria-label="Filter by tradition family">
+    <div
+      className="flex gap-2 justify-center overflow-x-auto pb-2 sm:flex-wrap sm:overflow-x-visible sm:pb-0 scrollbar-thin"
+      role="group"
+      aria-label="Filter by tradition family"
+    >
       {families.map((family) => {
         const active = activeFamilies.has(family);
         const colors = FAMILY_COLORS[family];
@@ -30,8 +34,8 @@ export function FamilyFilter({
             key={family}
             onClick={() => onToggle(family)}
             className={`
-              inline-flex items-center gap-2 px-3 py-1.5
-              font-sans text-xs tracking-wide uppercase
+              inline-flex items-center gap-2 px-3 py-1.5 shrink-0
+              font-sans text-xs tracking-wide uppercase whitespace-nowrap
               border rounded-sm transition-all duration-200
               ${
                 active

--- a/src/lib/__tests__/compute-layout.test.ts
+++ b/src/lib/__tests__/compute-layout.test.ts
@@ -126,6 +126,46 @@ describe("computeLayout", () => {
     expect(Object.keys(layout)).toHaveLength(1);
   });
 
+  it("separates different-family clusters on X axis", () => {
+    // Buddhist cluster (connected) and Hindu cluster (connected), no cross-family edges
+    const traditions: ParsedTradition[] = [
+      makeTradition({
+        slug: "b1",
+        origin_century: 5,
+        family: "Buddhist",
+        connections: [{ tradition_slug: "b2", connection_type: "branch_of", strength: 3, description: "" }],
+      }),
+      makeTradition({
+        slug: "b2",
+        origin_century: 5,
+        family: "Buddhist",
+        connections: [{ tradition_slug: "b1", connection_type: "branch_of", strength: 3, description: "" }],
+      }),
+      makeTradition({
+        slug: "h1",
+        origin_century: 5,
+        family: "Hindu",
+        connections: [{ tradition_slug: "h2", connection_type: "branch_of", strength: 3, description: "" }],
+      }),
+      makeTradition({
+        slug: "h2",
+        origin_century: 5,
+        family: "Hindu",
+        connections: [{ tradition_slug: "h1", connection_type: "branch_of", strength: 3, description: "" }],
+      }),
+    ];
+    const layout = computeLayout(traditions);
+
+    // Within-family distance should be smaller than between-family distance
+    const buddhistCenterX = (layout["b1"].x + layout["b2"].x) / 2;
+    const hinduCenterX = (layout["h1"].x + layout["h2"].x) / 2;
+    const withinBuddhist = Math.abs(layout["b1"].x - layout["b2"].x);
+    const betweenClusters = Math.abs(buddhistCenterX - hinduCenterX);
+
+    // The between-cluster distance should exceed within-cluster distance
+    expect(betweenClusters).toBeGreaterThan(withinBuddhist);
+  });
+
   it("works with real-ish tradition data (5 traditions)", () => {
     const traditions: ParsedTradition[] = [
       makeTradition({

--- a/src/lib/compute-layout.ts
+++ b/src/lib/compute-layout.ts
@@ -77,7 +77,7 @@ export function computeLayout(traditions: ParsedTradition[]): LayoutMap {
   for (const tradition of traditions) {
     const y = centuryToY(tradition.origin_century, minCentury, maxCentury);
     graph.addNode(tradition.slug, {
-      x: rng() * 1000,
+      x: rng() * 2000 - 500,
       y,
     });
   }
@@ -120,11 +120,11 @@ export function computeLayout(traditions: ParsedTradition[]): LayoutMap {
     forceAtlas2.assign(graph, {
       iterations: iters,
       settings: {
-        gravity: 1,
-        scalingRatio: 10,
+        gravity: 0.5,
+        scalingRatio: 50,
         barnesHutOptimize: false,
         strongGravityMode: false,
-        slowDown: 1,
+        slowDown: 2,
       },
     });
 


### PR DESCRIPTION
## Summary
Closes #27

- **Family filter**: horizontal scroll on mobile (overflow-x-auto), flex-wrap on desktop, whitespace-nowrap buttons so labels don't break mid-word. All 7 families render with correct color dots from `FAMILY_COLORS`.
- **ForceAtlas2 tuning**: increased `scalingRatio` from 10 to 50 and reduced `gravity` from 1 to 0.5 with wider initial X spread. Result: Buddhist cluster clearly separated left, Hindu mid-left, Christian/Gnostic right, Taoist far-left, Sufism mid-right. Cross-family bridges visible (e.g., Dzogchen ↔ Advaita).
- **Time axis**: verified existing implementation works correctly with 22 traditions — no changes needed (century markers align with node Y positions).

## Files changed
- `src/components/tradition-map/family-filter.tsx` — mobile scroll, shrink-0, whitespace-nowrap
- `src/lib/compute-layout.ts` — ForceAtlas2 parameter tuning
- `src/components/tradition-map/__tests__/family-filter.test.tsx` — new (5 tests)
- `src/lib/__tests__/compute-layout.test.ts` — added cluster separation test

## What was NOT touched (avoiding #26 conflicts)
- `map-canvas.tsx`, `map-node.tsx`, `map-edge.tsx`, `use-map-interaction.ts`

## Test plan
- [x] All 7 families render with correct colors
- [x] Filter wraps on desktop, scrolls on mobile
- [x] aria-pressed reflects active state
- [x] ForceAtlas2 produces separated clusters (verified via layout output)
- [x] `npm run build` passes
- [x] 143/144 tests pass (1 pre-existing failure: bhakti.mdx word count)

🤖 Generated with [Claude Code](https://claude.com/claude-code)