### PR TITLE
Add bridge traditions and strengthen map connections

### DIFF
--- a/data/traditions/advaita-vedanta.mdx
+++ b/data/traditions/advaita-vedanta.mdx
@@ -5,6 +5,10 @@ family: Hindu
 origin_century: 8
 summary: The "non-dual" school of Hindu philosophy teaching that the individual self (Atman) and ultimate reality (Brahman) are one and the same.
 connections:
+  - tradition_slug: vedanta
+    connection_type: branch_of
+    strength: 3
+    description: Advaita is the non-dual school within the broader Vedanta tradition, systematized by Shankara in the 8th century.
   - tradition_slug: kashmir-shaivism
     connection_type: related_to
     strength: 3

--- a/data/traditions/chan-buddhism.mdx
+++ b/data/traditions/chan-buddhism.mdx
@@ -9,10 +9,14 @@ connections:
     connection_type: branch_of
     strength: 3
     description: Zen is the direct Japanese continuation of Chinese Chan Buddhism, transmitted to Japan in the 12th–13th centuries by monks like Eisai and Dogen.
+  - tradition_slug: mahayana
+    connection_type: branch_of
+    strength: 3
+    description: Chan developed within the Mahayana framework, particularly its Buddha-nature teachings, synthesized with Chinese Taoist sensibility.
   - tradition_slug: theravada
     connection_type: influenced_by
-    strength: 2
-    description: Chan inherited core Buddhist teachings on meditation and liberation from the broader Buddhist tradition, including practices preserved in the Theravada canon.
+    strength: 1
+    description: Chan inherited core Buddhist teachings on meditation from the broader tradition, including practices preserved in the Theravada canon.
   - tradition_slug: taoism
     connection_type: influenced_by
     strength: 2

--- a/data/traditions/gnosticism.mdx
+++ b/data/traditions/gnosticism.mdx
@@ -13,6 +13,10 @@ connections:
     connection_type: related_to
     strength: 1
     description: Gnosticism and Kabbalah share structural similarities — emanation cosmologies, hidden divine realms, the idea that knowledge itself is redemptive — suggesting possible historical cross-pollination.
+  - tradition_slug: neoplatonism
+    connection_type: related_to
+    strength: 2
+    description: Gnosticism and Neoplatonism were contemporary movements in late antiquity sharing emanation cosmology, though Plotinus sharply criticized Gnostic world-rejection.
 ---
 
 # Gnosticism

--- a/data/traditions/mahayana.mdx
+++ b/data/traditions/mahayana.mdx
@@ -1,0 +1,38 @@
+---
+name: Mahayana Buddhism
+slug: mahayana
+family: Buddhist
+summary: The "Great Vehicle" — a broad movement emphasizing universal liberation and the bodhisattva path.
+origin_century: 1
+connections:
+  - tradition_slug: theravada
+    connection_type: diverged_from
+    description: Mahayana emerged partly as a critique of what it saw as Theravada's narrow focus on individual liberation, reinterpreting core teachings toward universal awakening.
+    strength: 3
+  - tradition_slug: chan-buddhism
+    connection_type: branch_of
+    description: Chan developed within the Mahayana framework, combining its Buddha-nature teachings with Chinese philosophical sensibility.
+    strength: 3
+  - tradition_slug: tibetan-buddhism-gelug
+    connection_type: branch_of
+    description: Tibetan Buddhism builds on Mahayana philosophy, particularly Nagarjuna's Madhyamaka and the bodhisattva ideal.
+    strength: 3
+  - tradition_slug: vajrayana
+    connection_type: branch_of
+    description: Vajrayana arose as an esoteric elaboration of Mahayana Buddhism, adding tantric methods to the bodhisattva path.
+    strength: 3
+  - tradition_slug: zen
+    connection_type: influenced_by
+    description: Zen inherits Mahayana's core insight that Buddha-nature is present in all beings, expressed through its emphasis on direct realization.
+    strength: 2
+  - tradition_slug: dzogchen
+    connection_type: related_to
+    description: Dzogchen shares Mahayana's recognition of innate awareness but approaches it through distinct Nyingma and Bon lineages.
+    strength: 1
+---
+
+Mahayana Buddhism — the "Great Vehicle" — represents the broadest current within Buddhism, encompassing the vast majority of Buddhist practitioners in East and Central Asia. Emerging around the 1st century CE, Mahayana introduced transformative ideas that reshaped Buddhist thought: the bodhisattva ideal (seeking enlightenment for the benefit of all beings), the concept of sunyata (emptiness) as elaborated by Nagarjuna, and the radical claim that Buddha-nature is present in all sentient beings.
+
+Where Theravada emphasized the arhat's individual liberation through disciplined practice, Mahayana expanded the horizon. The bodhisattva delays final nirvana to help all beings awaken — a shift from personal renunciation to cosmic compassion. This philosophical move opened Buddhism to devotional practices, elaborate cosmologies, and the rich literary tradition of sutras like the Heart Sutra, the Lotus Sutra, and the Prajnaparamita literature.
+
+Mahayana is not a single school but a vast umbrella. Within it arose Pure Land devotionalism, the philosophical rigor of Madhyamaka and Yogacara, the meditative intensity of Chan and Zen, and the esoteric elaborations of Vajrayana. Nearly every Buddhist tradition practiced today outside of Southeast Asia traces its philosophical foundations to Mahayana developments. It is, in a sense, the trunk from which most of Buddhism's contemporary branches grow.

--- a/data/traditions/neoplatonism.mdx
+++ b/data/traditions/neoplatonism.mdx
@@ -1,0 +1,34 @@
+---
+name: Neoplatonism
+slug: neoplatonism
+family: Other
+summary: A philosophical and contemplative tradition built on Plotinus's vision of reality emanating from the One.
+origin_century: 3
+connections:
+  - tradition_slug: gnosticism
+    connection_type: related_to
+    description: Neoplatonism and Gnosticism were contemporary movements sharing emanation cosmology, though Plotinus sharply criticized Gnostic world-rejection.
+    strength: 2
+  - tradition_slug: christian-mysticism
+    connection_type: influenced_by
+    description: Christian mystical theology was profoundly shaped by Neoplatonism through Pseudo-Dionysius, Augustine, and Meister Eckhart — the apophatic tradition of knowing God through negation.
+    strength: 3
+  - tradition_slug: sufism
+    connection_type: influenced_by
+    description: Islamic Neoplatonism (through Al-Kindi, Al-Farabi, and Ibn Sina) deeply influenced Sufi metaphysics, particularly the concept of divine emanation and the soul's return to its source.
+    strength: 2
+  - tradition_slug: kabbalah
+    connection_type: influenced_by
+    description: The Kabbalistic Sefirot (ten emanations from Ein Sof) closely mirrors Neoplatonic emanation theory, likely through shared late-antique philosophical currents.
+    strength: 2
+  - tradition_slug: hesychasm
+    connection_type: influenced_by
+    description: Eastern Orthodox contemplative theology absorbed Neoplatonic themes through the Cappadocian Fathers and Pseudo-Dionysius, shaping hesychast understanding of divine light and deification.
+    strength: 2
+---
+
+Neoplatonism is not typically listed among "contemplative traditions," yet it may be the single most important philosophical influence on Western mysticism. Founded by Plotinus in 3rd century Alexandria, Neoplatonism offered a comprehensive vision of reality as emanation from the One — an ineffable, transcendent source from which all existence flows in descending levels of being, and to which the soul can return through contemplative ascent.
+
+Plotinus's practical teaching was deeply contemplative. The Enneads describe states of mystical union with the One that are strikingly similar to accounts in Eastern traditions — the dissolution of the subject-object distinction, the recognition of one's deepest identity as inseparable from the absolute. His student Porphyry records that Plotinus experienced this union several times during his life.
+
+The tradition's influence is difficult to overstate. Through Pseudo-Dionysius the Areopagite (likely a 5th-century Syrian monk), Neoplatonic ideas entered Christian theology and became the foundation of the apophatic (negative) mystical tradition — knowing God through what God is not. Through Arabic translations, Neoplatonism entered Islamic philosophy and profoundly shaped Sufi metaphysics. Through medieval Jewish thinkers, emanation theory influenced the development of Kabbalah's Sefirot system. Neoplatonism is the hidden river running beneath all three Abrahamic mystical traditions.

--- a/data/traditions/sufism.mdx
+++ b/data/traditions/sufism.mdx
@@ -17,6 +17,10 @@ connections:
     connection_type: related_to
     strength: 1
     description: Sufism and Kabbalah developed in proximity in medieval Spain and the Middle East, with scholars noting parallels in their contemplative practices and metaphysical frameworks.
+  - tradition_slug: neoplatonism
+    connection_type: influenced_by
+    strength: 2
+    description: Islamic Neoplatonism (through Al-Kindi, Al-Farabi, Ibn Sina) deeply shaped Sufi metaphysics, particularly concepts of divine emanation and the soul's return to its source.
 ---
 
 # Sufism

--- a/data/traditions/theravada.mdx
+++ b/data/traditions/theravada.mdx
@@ -17,6 +17,10 @@ connections:
     connection_type: influenced_by
     strength: 2
     description: Theravada mindfulness practices, particularly vipassana, were the primary source for secular mindfulness programs like MBSR.
+  - tradition_slug: mahayana
+    connection_type: diverged_from
+    strength: 3
+    description: Mahayana arose partly as a reinterpretation of Theravada's focus on individual liberation, expanding the Buddhist vision toward universal awakening.
   - tradition_slug: jainism
     connection_type: related_to
     strength: 1

--- a/data/traditions/tibetan-buddhism-gelug.mdx
+++ b/data/traditions/tibetan-buddhism-gelug.mdx
@@ -5,10 +5,18 @@ family: Buddhist
 origin_century: 14
 summary: The "Virtuous" school of Tibetan Buddhism founded by Tsongkhapa, emphasizing monastic discipline, analytical meditation, and the graduated path to enlightenment.
 connections:
+  - tradition_slug: mahayana
+    connection_type: branch_of
+    strength: 3
+    description: The Gelug school is rooted in Mahayana philosophy, particularly Nagarjuna's Madhyamaka, integrating it with monastic discipline and analytical meditation.
+  - tradition_slug: vajrayana
+    connection_type: branch_of
+    strength: 3
+    description: Tibetan Buddhism incorporates the full Vajrayana system of tantric practice within its graduated path framework.
   - tradition_slug: theravada
     connection_type: influenced_by
-    strength: 2
-    description: The Gelug school draws on the Theravada emphasis on monastic discipline and systematic study, integrating these within a Mahayana and Vajrayana framework.
+    strength: 1
+    description: The Gelug school draws on monastic discipline paralleling Theravada, though through a Mahayana and Vajrayana lens.
   - tradition_slug: dzogchen
     connection_type: related_to
     strength: 2

--- a/data/traditions/vajrayana.mdx
+++ b/data/traditions/vajrayana.mdx
@@ -1,0 +1,34 @@
+---
+name: Vajrayana Buddhism
+slug: vajrayana
+family: Buddhist
+summary: The "Diamond Vehicle" — tantric Buddhism using visualization, mantra, and ritual to accelerate awakening.
+origin_century: 5
+connections:
+  - tradition_slug: mahayana
+    connection_type: branch_of
+    description: Vajrayana emerged within Mahayana Buddhism, accepting its philosophical framework while adding tantric methods as a faster path to enlightenment.
+    strength: 3
+  - tradition_slug: tibetan-buddhism-gelug
+    connection_type: branch_of
+    description: Tibetan Buddhism is the most complete living repository of Vajrayana practice, preserving the full system of tantric initiation and practice.
+    strength: 3
+  - tradition_slug: dzogchen
+    connection_type: related_to
+    description: Dzogchen is sometimes classified within Vajrayana's highest tantras, though it claims to transcend tantra entirely through direct recognition of awareness.
+    strength: 2
+  - tradition_slug: tantra
+    connection_type: related_to
+    description: Buddhist and Hindu Tantra share methods (visualization, subtle body work, mantra) but differ in philosophical framework — Buddhist Tantra is grounded in emptiness, Hindu Tantra in Shakti.
+    strength: 2
+  - tradition_slug: kashmir-shaivism
+    connection_type: related_to
+    description: Both traditions work with subtle energy and non-dual recognition, reflecting centuries of cross-pollination in medieval India.
+    strength: 1
+---
+
+Vajrayana — the "Diamond Vehicle" or "Thunderbolt Vehicle" — is the tantric expression of Buddhism that emerged in India around the 5th century CE. It accepts Mahayana's philosophical foundations (emptiness, compassion, bodhisattva ideal) but adds a radical technology of transformation: visualization of deities, mantra recitation, ritual practice, and sophisticated work with subtle body energies. Where Mahayana might require many lifetimes to achieve enlightenment, Vajrayana claims to offer a path achievable within a single lifetime — at the cost of greater intensity and risk.
+
+The historical development of Vajrayana involved deep exchange with Hindu tantric traditions in medieval India. Mahasiddhas — realized practitioners who lived outside monastic conventions — developed practices drawing on both Buddhist philosophy and tantric methodology. Figures like Tilopa, Naropa, and Padmasambhava carried these teachings from India to Tibet, where they were systematized into the elaborate practice lineages that survive today.
+
+Vajrayana's relationship to Hindu Tantra is one of the most fascinating cross-pollinations in contemplative history. Both traditions work with similar technologies (mantra, mandala, subtle body, deity yoga) but embed them in fundamentally different metaphysics. Buddhist Tantra transforms experience through the recognition of emptiness; Hindu Tantra transforms experience through the recognition of Shakti (divine creative power). The methods overlap; the philosophical ground differs profoundly.

--- a/data/traditions/vedanta.mdx
+++ b/data/traditions/vedanta.mdx
@@ -1,0 +1,38 @@
+---
+name: Vedanta
+slug: vedanta
+family: Hindu
+summary: The philosophical tradition interpreting the Upanishads — exploring the nature of Brahman and the self.
+origin_century: -4
+connections:
+  - tradition_slug: advaita-vedanta
+    connection_type: branch_of
+    description: Advaita is the non-dual school of Vedanta, systematized by Shankara, arguing that Brahman alone is real and the individual self is identical with it.
+    strength: 3
+  - tradition_slug: bhakti
+    connection_type: related_to
+    description: Devotional Vedanta schools (Ramanuja's Vishishtadvaita, Madhva's Dvaita) provided the philosophical foundation for Bhakti movements, arguing that the soul maintains relationship with God.
+    strength: 2
+  - tradition_slug: classical-yoga
+    connection_type: related_to
+    description: Vedanta and Yoga are complementary darshanas — Vedanta provides the philosophical understanding, Yoga provides the practical methodology.
+    strength: 2
+  - tradition_slug: kashmir-shaivism
+    connection_type: related_to
+    description: Kashmir Shaivism engages deeply with Vedantic concepts while offering a distinct non-dual framework centered on Shiva-consciousness rather than Brahman.
+    strength: 1
+  - tradition_slug: modern-non-dual
+    connection_type: influenced_by
+    description: Modern non-dual teachers like Ramana Maharshi and Nisargadatta drew primarily from Advaita Vedanta, making Vedantic self-inquiry accessible outside traditional Hindu frameworks.
+    strength: 2
+  - tradition_slug: jainism
+    connection_type: related_to
+    description: Vedanta and Jainism both emerged from the broader śramaṇa and Vedic milieu of ancient India, sharing concerns about liberation while differing fundamentally on the nature of self and reality.
+    strength: 1
+---
+
+Vedanta — literally "the end of the Vedas" — is the most influential philosophical tradition in Hinduism and arguably the most sophisticated system of metaphysical inquiry produced in India. Rooted in the Upanishads (composed roughly 800-200 BCE), Vedanta asks the fundamental question: what is the nature of Brahman (ultimate reality), and what is its relationship to Atman (the individual self)?
+
+The tradition's genius lies in its pluralism. Multiple schools of Vedanta offer radically different answers to this question while all claiming fidelity to the same source texts. Shankara's Advaita (non-dualism) argues that Brahman alone is real and individual selfhood is illusion. Ramanuja's Vishishtadvaita (qualified non-dualism) insists the soul is real but inseparable from God, like waves from the ocean. Madhva's Dvaita (dualism) maintains that God and souls are eternally distinct. These aren't minor disagreements — they represent fundamentally different visions of reality, relationship, and liberation.
+
+Vedanta's influence extends far beyond academic philosophy. It provided the intellectual foundation for devotional movements (Bhakti), informed the practice methodology of Yoga, and became the primary philosophical export of Hinduism to the modern world through figures like Vivekananda, Ramana Maharshi, and the modern non-dual movement. When Westerners encounter "Hindu philosophy," they are almost always encountering some form of Vedanta.

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "prebuild": "tsx scripts/compute-layout.ts",
-    "build": "next build",
+    "prebuild": "npx tsx scripts/compute-layout.ts",
+    "build": "npm run prebuild && next build",
     "start": "npx serve out",
     "lint": "eslint",
     "test": "vitest run",


### PR DESCRIPTION
## Summary
- Adds 4 critical "hub" traditions that connect existing clusters: **Mahayana**, **Vajrayana**, **Neoplatonism**, **Vedanta**
- Updates 6 existing traditions with connections to bridge nodes
- Fixes `prebuild` script (uses `npx tsx`, chains into `build`)
- Total: 26 traditions, significantly more connected graph

## Why these 4?
- **Mahayana** fills the 1000-year gap between Theravada and Chan/Zen/Tibetan
- **Vajrayana** explains tantric Buddhism as distinct from Hindu Tantra
- **Neoplatonism** is the hidden river connecting all three Abrahamic mystical traditions
- **Vedanta** contextualizes Advaita within the broader Hindu philosophical landscape

## Test plan
- [ ] `npm run build` passes (26 tradition pages generated)
- [ ] `/map` shows 26 traditions with denser connections
- [ ] New tradition pages render at `/traditions/mahayana`, etc.
- [ ] Existing tradition pages still render correctly
- [ ] ForceAtlas2 layout produces clear clusters with bridge nodes visible between them

🤖 Generated with [Claude Code](https://claude.com/claude-code)