### PR TITLE
Add suggest-an-edit feedback link to tradition pages

### DIFF
--- a/src/app/traditions/[slug]/page.tsx
+++ b/src/app/traditions/[slug]/page.tsx
@@ -13,6 +13,7 @@ import {
   getCentersByTradition,
   getRelatedTraditions,
 } from "@/lib/data";
+import { SuggestEditLink } from "@/components/suggest-edit-link";
 import { traditionJsonLd, SITE_URL } from "@/lib/seo";
 
 export function generateStaticParams() {
@@ -141,6 +142,8 @@ export default async function TraditionPage({ params }: { params: Promise<{ slug
           </div>
         </section>
       )}
+
+      <SuggestEditLink traditionName={tradition.name} />
     </PageLayout>
   );
 }

--- a/src/components/__tests__/suggest-edit-link.test.tsx
+++ b/src/components/__tests__/suggest-edit-link.test.tsx
@@ -1,0 +1,52 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SuggestEditLink } from "../suggest-edit-link";
+
+describe("SuggestEditLink", () => {
+  it("renders the suggest-an-edit text", () => {
+    render(<SuggestEditLink traditionName="Zen Buddhism" />);
+    const link = screen.getByRole("link", { name: /suggest an edit/i });
+    expect(link).toBeDefined();
+    expect(screen.getByText(/see something wrong/i)).toBeDefined();
+  });
+
+  it("links to GitHub new issue with pre-filled title", () => {
+    render(<SuggestEditLink traditionName="Zen Buddhism" />);
+    const link = screen.getByRole("link", { name: /suggest an edit/i });
+    const href = link.getAttribute("href");
+    expect(href).toContain("github.com/meninoebom/lineage/issues/new");
+    expect(href).toContain("title=Suggestion+for+Zen+Buddhism");
+  });
+
+  it("includes pre-filled body with prompts", () => {
+    render(<SuggestEditLink traditionName="Zen Buddhism" />);
+    const link = screen.getByRole("link", { name: /suggest an edit/i });
+    const href = link.getAttribute("href");
+    expect(href).toContain("What+should+be+changed");
+    expect(href).toContain("What+is+the+correct+information");
+    expect(href).toContain("Source");
+  });
+
+  it("includes community-suggestion label", () => {
+    render(<SuggestEditLink traditionName="Zen Buddhism" />);
+    const link = screen.getByRole("link", { name: /suggest an edit/i });
+    const href = link.getAttribute("href");
+    expect(href).toContain("labels=community-suggestion");
+  });
+
+  it("opens in new tab with security attributes", () => {
+    render(<SuggestEditLink traditionName="Zen Buddhism" />);
+    const link = screen.getByRole("link", { name: /suggest an edit/i });
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("encodes tradition names with special characters", () => {
+    render(<SuggestEditLink traditionName="Dvaita Vedānta" />);
+    const link = screen.getByRole("link", { name: /suggest an edit/i });
+    const href = link.getAttribute("href");
+    expect(href).toContain("Suggestion+for+Dvaita+Ved");
+    // Should be a valid URL (no raw spaces)
+    expect(href).not.toContain(" ");
+  });
+});

--- a/src/components/suggest-edit-link.tsx
+++ b/src/components/suggest-edit-link.tsx
@@ -1,0 +1,44 @@
+interface SuggestEditLinkProps {
+  traditionName: string;
+}
+
+function buildGitHubIssueUrl(traditionName: string): string {
+  const title = `Suggestion for ${traditionName}`;
+  const body = `## Tradition
+${traditionName}
+
+## What should be changed?
+
+
+## What is the correct information?
+
+
+## Source (if available):
+
+`;
+
+  const params = new URLSearchParams({
+    title,
+    body,
+    labels: "community-suggestion",
+  });
+
+  // URLSearchParams encodes spaces as +, which is valid for query strings
+  return `https://github.com/meninoebom/lineage/issues/new?${params.toString()}`;
+}
+
+export function SuggestEditLink({ traditionName }: SuggestEditLinkProps) {
+  return (
+    <p className="mt-12 text-sm font-sans text-muted-foreground">
+      See something wrong?{" "}
+      <a
+        href={buildGitHubIssueUrl(traditionName)}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="underline decoration-muted-foreground/40 underline-offset-2 hover:decoration-muted-foreground transition-colors"
+      >
+        Suggest an edit
+      </a>
+    </p>
+  );
+}


### PR DESCRIPTION
Closes #39

## Summary
- Add `SuggestEditLink` component that renders a "See something wrong? Suggest an edit" link
- Link opens a pre-filled GitHub issue with tradition name, edit prompts, and `community-suggestion` label
- Integrated at the bottom of every tradition page
- Created `community-suggestion` label in the repo

## Acceptance criteria
- [x] "Suggest an edit" link on every tradition page
- [x] Link opens GitHub new issue with pre-filled title and body
- [x] Issue pre-labeled `community-suggestion`
- [x] Link opens in new tab (`target="_blank"`, `rel="noopener noreferrer"`)
- [x] Styling is subtle (text-sm, muted, sans-serif)
- [x] `community-suggestion` label exists in repo
- [x] `npm run build` passes

## Test plan
- [x] 6 unit tests covering rendering, URL construction, security attributes, and special character encoding

🤖 Generated with [Claude Code](https://claude.com/claude-code)