### PR TITLE
Add Resource type, data loaders, and seed data

### DIFF
--- a/data/resources/access-to-insight.json
+++ b/data/resources/access-to-insight.json
@@ -1,0 +1,12 @@
+{
+  "title": "Access to Insight",
+  "slug": "access-to-insight",
+  "type": "website",
+  "url": "https://accesstoinsight.org",
+  "author": null,
+  "year": 1993,
+  "description": "Comprehensive online library of Theravada Buddhist texts including suttas, commentaries, and practice guides translated from Pali.",
+  "traditions": ["theravada"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/awakening-buddha-within.json
+++ b/data/resources/awakening-buddha-within.json
@@ -1,0 +1,12 @@
+{
+  "title": "Awakening the Buddha Within",
+  "slug": "awakening-buddha-within",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/awakening-the-buddha-within-tibetan-wisdom-for-the-western-world-lama-surya-das/6693556",
+  "author": "Lama Surya Das",
+  "year": 1997,
+  "description": "Accessible guide to Tibetan Buddhist practice by an American-born lama, integrating Dzogchen teachings with Western sensibilities.",
+  "traditions": ["tibetan-buddhism-gelug", "dzogchen"],
+  "teachers": ["lama-surya-das"],
+  "centers": ["dzogchen-center"]
+}

--- a/data/resources/awakening-of-the-heart.json
+++ b/data/resources/awakening-of-the-heart.json
@@ -1,0 +1,12 @@
+{
+  "title": "Awakening of the Heart",
+  "slug": "awakening-of-the-heart",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/awakening-of-the-heart-essential-buddhist-sutras-and-commentaries-thich-nhat-hanh/6693559",
+  "author": "Thich Nhat Hanh",
+  "year": 2012,
+  "description": "Collection of essential Buddhist sutras with commentary by Thich Nhat Hanh, presenting foundational Mahayana teachings in accessible language.",
+  "traditions": ["mahayana", "zen"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/be-as-you-are.json
+++ b/data/resources/be-as-you-are.json
@@ -1,0 +1,12 @@
+{
+  "title": "Be As You Are: The Teachings of Sri Ramana Maharshi",
+  "slug": "be-as-you-are",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/be-as-you-are-the-teachings-of-sri-ramana-maharshi-ramana-maharshi/6693488",
+  "author": "David Godman",
+  "year": 1985,
+  "description": "Thematically organized compilation of Ramana Maharshi's teachings on self-inquiry, edited by scholar David Godman.",
+  "traditions": ["advaita-vedanta"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/bhagavad-gita.json
+++ b/data/resources/bhagavad-gita.json
@@ -1,0 +1,12 @@
+{
+  "title": "The Bhagavad Gita",
+  "slug": "bhagavad-gita",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/the-bhagavad-gita-eknath-easwaran/6693574",
+  "author": "Eknath Easwaran",
+  "year": 1985,
+  "description": "Easwaran's acclaimed translation of the Hindu scripture exploring karma yoga, bhakti yoga, and jnana yoga through the dialogue between Krishna and Arjuna.",
+  "traditions": ["vedanta", "bhakti", "classical-yoga"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/breath-by-breath.json
+++ b/data/resources/breath-by-breath.json
@@ -1,0 +1,12 @@
+{
+  "title": "Breath by Breath",
+  "slug": "breath-by-breath",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/breath-by-breath-the-liberating-practice-of-insight-meditation-larry-rosenberg/6425012",
+  "author": "Larry Rosenberg",
+  "year": 1998,
+  "description": "Detailed guide to anapanasati (mindfulness of breathing) practice in the Theravada tradition, written by a teacher at the Insight Meditation Center.",
+  "traditions": ["theravada", "vipassana-movement"],
+  "teachers": ["gil-fronsdal"],
+  "centers": ["insight-meditation-center", "spirit-rock"]
+}

--- a/data/resources/cloud-of-unknowing.json
+++ b/data/resources/cloud-of-unknowing.json
@@ -1,0 +1,12 @@
+{
+  "title": "The Cloud of Unknowing",
+  "slug": "cloud-of-unknowing",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/the-cloud-of-unknowing-and-the-book-of-privy-counseling-anonymous/7101802",
+  "author": null,
+  "year": 1375,
+  "description": "Anonymous 14th-century mystical text guiding the contemplative toward direct experience of God through 'unknowing' — releasing conceptual thought.",
+  "traditions": ["christian-mysticism"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/cutting-through-spiritual-materialism.json
+++ b/data/resources/cutting-through-spiritual-materialism.json
@@ -1,0 +1,12 @@
+{
+  "title": "Cutting Through Spiritual Materialism",
+  "slug": "cutting-through-spiritual-materialism",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/cutting-through-spiritual-materialism-chogyam-trungpa/6425064",
+  "author": "Chogyam Trungpa",
+  "year": 1973,
+  "description": "Classic warning against ego's tendency to co-opt the spiritual path, from one of the first Tibetan masters to teach extensively in the West.",
+  "traditions": ["vajrayana"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/dharma-seed.json
+++ b/data/resources/dharma-seed.json
@@ -1,0 +1,12 @@
+{
+  "title": "Dharma Seed",
+  "slug": "dharma-seed",
+  "type": "podcast",
+  "url": "https://dharmaseed.org",
+  "author": null,
+  "year": 1983,
+  "description": "Vast archive of dharma talks from Theravada and Insight Meditation teachers including Joseph Goldstein, Jack Kornfield, and Gil Fronsdal.",
+  "traditions": ["theravada", "vipassana-movement"],
+  "teachers": ["gil-fronsdal"],
+  "centers": ["spirit-rock", "insight-meditation-center"]
+}

--- a/data/resources/essential-rumi.json
+++ b/data/resources/essential-rumi.json
@@ -1,0 +1,12 @@
+{
+  "title": "The Essential Rumi",
+  "slug": "essential-rumi",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/the-essential-rumi-new-expanded-edition-jalal-al-din-rumi/6425038",
+  "author": "Coleman Barks",
+  "year": 1995,
+  "description": "Popular English translations of the 13th-century Sufi mystic Rumi's poetry, exploring divine love, longing, and spiritual transformation.",
+  "traditions": ["sufism"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/heart-of-the-buddhas-teaching.json
+++ b/data/resources/heart-of-the-buddhas-teaching.json
@@ -1,0 +1,12 @@
+{
+  "title": "The Heart of the Buddha's Teaching",
+  "slug": "heart-of-the-buddhas-teaching",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/the-heart-of-the-buddha-s-teaching-transforming-suffering-into-peace-joy-and-liberation-thich-nhat-hanh/6693941",
+  "author": "Thich Nhat Hanh",
+  "year": 1998,
+  "description": "Accessible introduction to the core teachings of Buddhism, covering the Four Noble Truths, the Eightfold Path, and key Mahayana concepts.",
+  "traditions": ["mahayana", "zen"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/i-am-that.json
+++ b/data/resources/i-am-that.json
@@ -1,0 +1,12 @@
+{
+  "title": "I Am That",
+  "slug": "i-am-that",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/i-am-that-talks-with-sri-nisargadatta-maharaj-nisargadatta-maharaj/11710637",
+  "author": "Nisargadatta Maharaj",
+  "year": 1973,
+  "description": "Transcribed dialogues with the Advaita Vedanta master Nisargadatta Maharaj, exploring the nature of consciousness and self-inquiry.",
+  "traditions": ["advaita-vedanta", "modern-non-dual"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/interior-castle.json
+++ b/data/resources/interior-castle.json
@@ -1,0 +1,12 @@
+{
+  "title": "The Interior Castle",
+  "slug": "interior-castle",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/interior-castle-teresa-of-avila/11380218",
+  "author": "Teresa of Avila",
+  "year": 1577,
+  "description": "Teresa of Avila's masterwork mapping seven stages of spiritual development as mansions within a crystal castle, a landmark of Christian mystical literature.",
+  "traditions": ["christian-mysticism"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/joy-of-living.json
+++ b/data/resources/joy-of-living.json
@@ -1,0 +1,12 @@
+{
+  "title": "The Joy of Living",
+  "slug": "joy-of-living",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/the-joy-of-living-unlocking-the-secret-and-science-of-happiness-yongey-mingyur-rinpoche/6693832",
+  "author": "Yongey Mingyur Rinpoche",
+  "year": 2007,
+  "description": "Tibetan Buddhist master bridges meditation practice and modern neuroscience, offering practical tools for transforming anxiety into contentment.",
+  "traditions": ["tibetan-buddhism-gelug", "vajrayana"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/mindfulness-in-plain-english.json
+++ b/data/resources/mindfulness-in-plain-english.json
@@ -1,0 +1,12 @@
+{
+  "title": "Mindfulness in Plain English",
+  "slug": "mindfulness-in-plain-english",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/mindfulness-in-plain-english-bhante-henepola-gunaratana/6693860",
+  "author": "Bhante Gunaratana",
+  "year": 1991,
+  "description": "Clear, practical guide to Vipassana meditation from a Sri Lankan Theravada monk, widely regarded as one of the best introductions to meditation.",
+  "traditions": ["theravada", "vipassana-movement"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/mingyur-rinpoche-happiness-is-here.json
+++ b/data/resources/mingyur-rinpoche-happiness-is-here.json
@@ -1,0 +1,12 @@
+{
+  "title": "Yongey Mingyur Rinpoche: Happiness Is Here and Now",
+  "slug": "mingyur-rinpoche-happiness-is-here",
+  "type": "video",
+  "url": "https://www.youtube.com/watch?v=C_T7UPBkNI0",
+  "author": "Yongey Mingyur Rinpoche",
+  "year": 2018,
+  "description": "Tibetan Buddhist master teaches how awareness and panic can coexist, using humor and directness to convey meditation essentials.",
+  "traditions": ["tibetan-buddhism-gelug", "vajrayana"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/nature-of-consciousness.json
+++ b/data/resources/nature-of-consciousness.json
@@ -1,0 +1,12 @@
+{
+  "title": "The Nature of Consciousness",
+  "slug": "nature-of-consciousness",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/the-nature-of-consciousness-essays-on-the-unity-of-mind-and-matter-rupert-spira/9494962",
+  "author": "Rupert Spira",
+  "year": 2017,
+  "description": "Essays exploring the non-dual nature of experience, arguing that consciousness is the fundamental reality underlying all perception.",
+  "traditions": ["advaita-vedanta", "modern-non-dual"],
+  "teachers": ["rupert-spira"],
+  "centers": []
+}

--- a/data/resources/philokalia.json
+++ b/data/resources/philokalia.json
@@ -1,0 +1,12 @@
+{
+  "title": "The Philokalia",
+  "slug": "philokalia",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/the-philokalia-volume-1-the-complete-text-g-e-h-palmer/15914905",
+  "author": null,
+  "year": 1782,
+  "description": "Collection of texts on contemplative prayer by Eastern Orthodox monks spanning the 4th to 15th centuries, central to the Hesychast tradition.",
+  "traditions": ["hesychasm", "christian-mysticism"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/rupert-spira-the-nature-of-experience.json
+++ b/data/resources/rupert-spira-the-nature-of-experience.json
@@ -1,0 +1,12 @@
+{
+  "title": "Rupert Spira: The Nature of Experience",
+  "slug": "rupert-spira-the-nature-of-experience",
+  "type": "video",
+  "url": "https://www.youtube.com/watch?v=XhLgSrecbII",
+  "author": "Rupert Spira",
+  "year": 2019,
+  "description": "Talk exploring how all experience is made of consciousness, using direct investigation rather than belief or philosophy.",
+  "traditions": ["advaita-vedanta", "modern-non-dual"],
+  "teachers": ["rupert-spira"],
+  "centers": []
+}

--- a/data/resources/shiva-sutras.json
+++ b/data/resources/shiva-sutras.json
@@ -1,0 +1,12 @@
+{
+  "title": "Shiva Sutras: The Supreme Awakening",
+  "slug": "shiva-sutras",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/siva-sutras-the-supreme-awakening-swami-lakshmanjoo/9920064",
+  "author": "Swami Lakshmanjoo",
+  "year": 2007,
+  "description": "Commentary on the foundational text of Kashmir Shaivism by the last living master of the tradition, revealing the nature of consciousness and liberation.",
+  "traditions": ["kashmir-shaivism"],
+  "teachers": ["sally-kempton"],
+  "centers": []
+}

--- a/data/resources/tao-te-ching.json
+++ b/data/resources/tao-te-ching.json
@@ -1,0 +1,12 @@
+{
+  "title": "Tao Te Ching",
+  "slug": "tao-te-ching",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/tao-te-ching-laozi/18692155",
+  "author": "Laozi",
+  "year": null,
+  "description": "Foundational text of Taoism, offering 81 brief chapters on the nature of the Tao, non-action (wu wei), and the art of living in harmony with reality.",
+  "traditions": ["taoism"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/tibetan-book-of-living-and-dying.json
+++ b/data/resources/tibetan-book-of-living-and-dying.json
@@ -1,0 +1,12 @@
+{
+  "title": "The Tibetan Book of Living and Dying",
+  "slug": "tibetan-book-of-living-and-dying",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/the-tibetan-book-of-living-and-dying-sogyal-rinpoche/6425008",
+  "author": "Sogyal Rinpoche",
+  "year": 1992,
+  "description": "Modern presentation of Tibetan Buddhist teachings on death, dying, and the nature of mind, drawing on the Bardo Thodol tradition.",
+  "traditions": ["tibetan-buddhism-gelug", "vajrayana"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/waking-up-app.json
+++ b/data/resources/waking-up-app.json
@@ -1,0 +1,12 @@
+{
+  "title": "Waking Up with Sam Harris",
+  "slug": "waking-up-app",
+  "type": "podcast",
+  "url": "https://www.wakingup.com",
+  "author": "Sam Harris",
+  "year": 2018,
+  "description": "Meditation app and podcast exploring mindfulness, consciousness, and non-dual awareness from a secular, science-informed perspective.",
+  "traditions": ["secular-mindfulness", "advaita-vedanta"],
+  "teachers": ["rupert-spira"],
+  "centers": []
+}

--- a/data/resources/way-of-zen.json
+++ b/data/resources/way-of-zen.json
@@ -1,0 +1,12 @@
+{
+  "title": "The Way of Zen",
+  "slug": "way-of-zen",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/the-way-of-zen-alan-watts/6693942",
+  "author": "Alan Watts",
+  "year": 1957,
+  "description": "Influential introduction to Zen Buddhism for Western audiences, tracing its roots from Indian Buddhism through Chinese Chan to Japanese Zen.",
+  "traditions": ["zen", "chan-buddhism"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/yoga-sutras-of-patanjali.json
+++ b/data/resources/yoga-sutras-of-patanjali.json
@@ -1,0 +1,12 @@
+{
+  "title": "The Yoga Sutras of Patanjali",
+  "slug": "yoga-sutras-of-patanjali",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/the-yoga-sutras-of-patanjali-sri-swami-satchidananda/6425182",
+  "author": "Patanjali",
+  "year": null,
+  "description": "Foundational text of Classical Yoga, systematizing the philosophy and practice of yoga into 196 concise aphorisms.",
+  "traditions": ["classical-yoga"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/zohar.json
+++ b/data/resources/zohar.json
@@ -1,0 +1,12 @@
+{
+  "title": "The Zohar: Pritzker Edition",
+  "slug": "zohar",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/the-zohar-pritzker-edition-volume-one-daniel-c-matt/8211563",
+  "author": "Daniel C. Matt",
+  "year": 2003,
+  "description": "Definitive English translation of the central text of Kabbalah, a 13th-century mystical commentary on the Torah exploring the hidden dimensions of reality.",
+  "traditions": ["kabbalah"],
+  "teachers": [],
+  "centers": []
+}

--- a/src/lib/__tests__/data.test.ts
+++ b/src/lib/__tests__/data.test.ts
@@ -11,6 +11,11 @@ import {
   getTeachersByTradition,
   getCentersByTradition,
   getRelatedTraditions,
+  getAllResources,
+  getResource,
+  getResourcesByTradition,
+  getResourcesByTeacher,
+  getResourcesByCenter,
 } from "../data";
 
 describe("getAllTeachers", () => {
@@ -123,6 +128,109 @@ describe("getRelatedTraditions", () => {
 
   it("returns empty array for unknown tradition", () => {
     expect(getRelatedTraditions("nonexistent")).toEqual([]);
+  });
+});
+
+// -- Resources --
+
+describe("getAllResources", () => {
+  it("returns all resources as typed array", () => {
+    const resources = getAllResources();
+    expect(resources.length).toBeGreaterThanOrEqual(25);
+    for (const r of resources) {
+      expect(r.slug).toBeDefined();
+      expect(r.title).toBeDefined();
+      expect(["book", "podcast", "video", "article", "website"]).toContain(r.type);
+      expect(typeof r.url).toBe("string");
+      expect(typeof r.description).toBe("string");
+      expect(Array.isArray(r.traditions)).toBe(true);
+      expect(Array.isArray(r.teachers)).toBe(true);
+      expect(Array.isArray(r.centers)).toBe(true);
+    }
+  });
+});
+
+describe("getResource", () => {
+  it("returns a resource by slug", () => {
+    const resource = getResource("heart-of-the-buddhas-teaching");
+    expect(resource).toBeDefined();
+    expect(resource!.title).toBe("The Heart of the Buddha's Teaching");
+    expect(resource!.type).toBe("book");
+    expect(resource!.traditions).toContain("mahayana");
+  });
+
+  it("returns undefined for unknown slug", () => {
+    expect(getResource("nonexistent")).toBeUndefined();
+  });
+});
+
+describe("getResourcesByTradition", () => {
+  it("returns resources tagged to a tradition", () => {
+    const resources = getResourcesByTradition("zen");
+    expect(resources.length).toBeGreaterThanOrEqual(1);
+    for (const r of resources) {
+      expect(r.traditions).toContain("zen");
+    }
+  });
+
+  it("returns empty array for unknown tradition", () => {
+    expect(getResourcesByTradition("nonexistent")).toEqual([]);
+  });
+});
+
+describe("getResourcesByTeacher", () => {
+  it("returns resources tagged to a teacher", () => {
+    const resources = getResourcesByTeacher("rupert-spira");
+    expect(resources.length).toBeGreaterThanOrEqual(1);
+    for (const r of resources) {
+      expect(r.teachers).toContain("rupert-spira");
+    }
+  });
+
+  it("returns empty array for unknown teacher", () => {
+    expect(getResourcesByTeacher("nonexistent")).toEqual([]);
+  });
+});
+
+describe("getResourcesByCenter", () => {
+  it("returns resources tagged to a center", () => {
+    const resources = getResourcesByCenter("spirit-rock");
+    expect(resources.length).toBeGreaterThanOrEqual(1);
+    for (const r of resources) {
+      expect(r.centers).toContain("spirit-rock");
+    }
+  });
+
+  it("returns empty array for unknown center", () => {
+    expect(getResourcesByCenter("nonexistent")).toEqual([]);
+  });
+});
+
+describe("resource validation", () => {
+  const tmpDir = join(process.cwd(), "data", "resources");
+  const malformedFile = join(tmpDir, "_test-malformed.json");
+  const invalidShapeFile = join(tmpDir, "_test-invalid-shape.json");
+
+  beforeEach(() => {
+    writeFileSync(malformedFile, "{ not valid json !!!");
+    writeFileSync(invalidShapeFile, JSON.stringify({ title: 123, oops: true }));
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    try { rmSync(malformedFile); } catch {}
+    try { rmSync(invalidShapeFile); } catch {}
+    vi.restoreAllMocks();
+  });
+
+  it("skips malformed resource files", () => {
+    const resources = getAllResources();
+    expect(resources.every((r) => !r.slug.startsWith("_test"))).toBe(true);
+    expect(console.warn).toHaveBeenCalled();
+  });
+
+  it("rejects path traversal on getResource", () => {
+    expect(() => getResource("../../etc/passwd")).toThrow("Invalid slug");
   });
 });
 

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -1,7 +1,7 @@
 import { readdirSync, readFileSync, existsSync } from "fs";
 import { join } from "path";
 import matter from "gray-matter";
-import type { Teacher, Center, TraditionConnection } from "./types";
+import type { Teacher, Center, Resource, TraditionConnection } from "./types";
 
 const DATA_DIR = join(process.cwd(), "data");
 
@@ -41,6 +41,25 @@ function isCenter(obj: unknown): obj is Center {
     typeof c.country === "string" &&
     Array.isArray(c.traditions) &&
     Array.isArray(c.teachers)
+  );
+}
+
+const VALID_RESOURCE_TYPES = ["book", "podcast", "video", "article", "website"];
+
+function isResource(obj: unknown): obj is Resource {
+  const r = obj as Record<string, unknown>;
+  return (
+    typeof r.title === "string" &&
+    typeof r.slug === "string" &&
+    typeof r.type === "string" &&
+    VALID_RESOURCE_TYPES.includes(r.type as string) &&
+    typeof r.url === "string" &&
+    (r.author === null || typeof r.author === "string") &&
+    (r.year === null || typeof r.year === "number") &&
+    typeof r.description === "string" &&
+    Array.isArray(r.traditions) &&
+    Array.isArray(r.teachers) &&
+    Array.isArray(r.centers)
   );
 }
 
@@ -111,6 +130,28 @@ export function getAllCenters(): Center[] {
 
 export function getCenter(slug: string): Center | undefined {
   return loadOneJson("centers", slug, isCenter);
+}
+
+// -- Resources --
+
+export function getAllResources(): Resource[] {
+  return loadAllJson("resources", isResource);
+}
+
+export function getResource(slug: string): Resource | undefined {
+  return loadOneJson("resources", slug, isResource);
+}
+
+export function getResourcesByTradition(traditionSlug: string): Resource[] {
+  return getAllResources().filter((r) => r.traditions.includes(traditionSlug));
+}
+
+export function getResourcesByTeacher(teacherSlug: string): Resource[] {
+  return getAllResources().filter((r) => r.teachers.includes(teacherSlug));
+}
+
+export function getResourcesByCenter(centerSlug: string): Resource[] {
+  return getAllResources().filter((r) => r.centers.includes(centerSlug));
 }
 
 // -- Traditions --

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -39,6 +39,21 @@ export interface Teacher {
   centers: string[];
 }
 
+export type ResourceType = "book" | "podcast" | "video" | "article" | "website";
+
+export interface Resource {
+  title: string;
+  slug: string;
+  type: ResourceType;
+  url: string;
+  author: string | null;
+  year: number | null;
+  description: string;
+  traditions: string[];
+  teachers: string[];
+  centers: string[];
+}
+
 export interface Center {
   name: string;
   slug: string;


### PR DESCRIPTION
## Summary
Closes #35

- Adds `ResourceType` union and `Resource` interface to `src/lib/types.ts`
- Adds `isResource` runtime validator and five loader functions (`getAllResources`, `getResource`, `getResourcesByTradition`, `getResourcesByTeacher`, `getResourcesByCenter`) to `src/lib/data.ts`
- Creates 26 curated seed resources in `data/resources/` covering books, videos, podcasts, and a website across all major contemplative traditions
- Resources are cross-referenced to existing tradition slugs, teacher slugs, and center slugs
- Comprehensive tests for all loader functions including validation and error handling

## Test plan
- [x] All 29 data.test.ts tests pass (11 new resource tests)
- [x] `npm run build` succeeds
- [x] Runtime validation rejects malformed/invalid resource files
- [x] Path traversal protection works for `getResource`
- [x] Cross-reference queries (by tradition, teacher, center) return correct results

🤖 Generated with [Claude Code](https://claude.com/claude-code)