### PR TITLE
Add resources section to tradition pages

### DIFF
--- a/src/app/traditions/[slug]/page.tsx
+++ b/src/app/traditions/[slug]/page.tsx
@@ -12,7 +12,9 @@ import {
   getTeachersByTradition,
   getCentersByTradition,
   getRelatedTraditions,
+  getResourcesByTradition,
 } from "@/lib/data";
+import { ResourceList } from "@/components/resource-list";
 import { SuggestEditLink } from "@/components/suggest-edit-link";
 import { traditionJsonLd, SITE_URL } from "@/lib/seo";
 
@@ -44,6 +46,7 @@ export default async function TraditionPage({ params }: { params: Promise<{ slug
   const teachers = getTeachersByTradition(slug);
   const centers = getCentersByTradition(slug);
   const related = getRelatedTraditions(slug);
+  const resources = getResourcesByTradition(slug);
 
   return (
     <PageLayout>
@@ -142,6 +145,8 @@ export default async function TraditionPage({ params }: { params: Promise<{ slug
           </div>
         </section>
       )}
+
+      <ResourceList resources={resources} />
 
       <SuggestEditLink traditionName={tradition.name} />
     </PageLayout>

--- a/src/components/__tests__/resource-list.test.tsx
+++ b/src/components/__tests__/resource-list.test.tsx
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { ResourceList } from "../resource-list";
+import type { Resource } from "@/lib/types";
+
+const makeResource = (overrides: Partial<Resource> = {}): Resource => ({
+  title: "Test Resource",
+  slug: "test-resource",
+  type: "book",
+  url: "https://example.com/book",
+  author: "Test Author",
+  year: 2020,
+  description: "A test description.",
+  traditions: ["zen"],
+  teachers: [],
+  centers: [],
+  ...overrides,
+});
+
+describe("ResourceList", () => {
+  it("renders nothing when resources array is empty", () => {
+    const { container } = render(<ResourceList resources={[]} />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders section heading 'Resources'", () => {
+    render(<ResourceList resources={[makeResource()]} />);
+    expect(screen.getByRole("heading", { level: 2 })).toHaveTextContent("Resources");
+  });
+
+  it("groups resources by type with correct headings", () => {
+    const resources = [
+      makeResource({ title: "Book One", type: "book", slug: "book-one" }),
+      makeResource({ title: "Video One", type: "video", slug: "video-one" }),
+      makeResource({ title: "Book Two", type: "book", slug: "book-two" }),
+    ];
+    render(<ResourceList resources={resources} />);
+
+    expect(screen.getByText("Books")).toBeDefined();
+    expect(screen.getByText("Videos")).toBeDefined();
+    expect(screen.queryByText("Podcasts")).toBeNull();
+    expect(screen.queryByText("Articles")).toBeNull();
+    expect(screen.queryByText("Websites")).toBeNull();
+  });
+
+  it("renders title, author, and description for each resource", () => {
+    render(
+      <ResourceList
+        resources={[makeResource({ title: "My Book", author: "Jane Doe", description: "Great book." })]}
+      />
+    );
+    expect(screen.getByText("My Book")).toBeDefined();
+    expect(screen.getByText("Jane Doe")).toBeDefined();
+    expect(screen.getByText("Great book.")).toBeDefined();
+  });
+
+  it("omits author when null", () => {
+    render(
+      <ResourceList resources={[makeResource({ author: null })]} />
+    );
+    expect(screen.getByText("Test Resource")).toBeDefined();
+    // Should not crash or show "null"
+    expect(screen.queryByText("null")).toBeNull();
+  });
+
+  it("renders external links with target and rel attributes", () => {
+    render(
+      <ResourceList
+        resources={[makeResource({ title: "Linked Book", url: "https://example.com/linked" })]}
+      />
+    );
+    const link = screen.getByRole("link", { name: /Linked Book/ });
+    expect(link.getAttribute("href")).toBe("https://example.com/linked");
+    expect(link.getAttribute("target")).toBe("_blank");
+    expect(link.getAttribute("rel")).toBe("noopener noreferrer");
+  });
+
+  it("renders all five type categories when present", () => {
+    const resources: Resource[] = [
+      makeResource({ type: "book", slug: "b1", title: "B1" }),
+      makeResource({ type: "video", slug: "v1", title: "V1" }),
+      makeResource({ type: "podcast", slug: "p1", title: "P1" }),
+      makeResource({ type: "article", slug: "a1", title: "A1" }),
+      makeResource({ type: "website", slug: "w1", title: "W1" }),
+    ];
+    render(<ResourceList resources={resources} />);
+
+    expect(screen.getByText("Books")).toBeDefined();
+    expect(screen.getByText("Videos")).toBeDefined();
+    expect(screen.getByText("Podcasts")).toBeDefined();
+    expect(screen.getByText("Articles")).toBeDefined();
+    expect(screen.getByText("Websites")).toBeDefined();
+  });
+});

--- a/src/components/resource-list.tsx
+++ b/src/components/resource-list.tsx
@@ -1,0 +1,67 @@
+import type { Resource, ResourceType } from "@/lib/types";
+
+const TYPE_ORDER: ResourceType[] = ["book", "video", "podcast", "article", "website"];
+
+const TYPE_LABELS: Record<ResourceType, string> = {
+  book: "Books",
+  video: "Videos",
+  podcast: "Podcasts",
+  article: "Articles",
+  website: "Websites",
+};
+
+interface ResourceListProps {
+  resources: Resource[];
+}
+
+export function ResourceList({ resources }: ResourceListProps) {
+  if (resources.length === 0) return null;
+
+  const grouped = TYPE_ORDER.reduce<Partial<Record<ResourceType, Resource[]>>>(
+    (acc, type) => {
+      const items = resources.filter((r) => r.type === type);
+      if (items.length > 0) acc[type] = items;
+      return acc;
+    },
+    {}
+  );
+
+  return (
+    <section className="mb-12">
+      <h2 className="mb-6">Resources</h2>
+
+      {TYPE_ORDER.filter((type) => grouped[type]).map((type) => (
+        <div key={type} className="mb-8 last:mb-0">
+          <h3 className="font-sans text-sm font-semibold uppercase tracking-widest text-muted-foreground mb-4">
+            {TYPE_LABELS[type]}
+          </h3>
+          <div className="space-y-4">
+            {grouped[type]!.map((resource) => (
+              <a
+                key={resource.slug}
+                href={resource.url}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="block rounded-lg border border-border bg-card p-4 transition-shadow hover:shadow-md"
+              >
+                <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:gap-3">
+                  <span className="font-serif text-base font-medium text-foreground">
+                    {resource.title}
+                  </span>
+                  {resource.author && (
+                    <span className="font-sans text-sm text-muted-foreground">
+                      {resource.author}
+                    </span>
+                  )}
+                </div>
+                <p className="mt-1 font-sans text-sm leading-relaxed text-muted-foreground">
+                  {resource.description}
+                </p>
+              </a>
+            ))}
+          </div>
+        </div>
+      ))}
+    </section>
+  );
+}


### PR DESCRIPTION
Closes #36

## Summary
- Add `ResourceList` component that renders resources grouped by type (Books, Videos, Podcasts, Articles, Websites) with Lapham's editorial styling
- Integrate into tradition pages — section renders below related traditions, absent when no resources exist
- External links open in new tab with proper `target="_blank" rel="noopener noreferrer"`
- 7 tests covering: empty state, grouping, rendering, link attributes, null author handling

## Test plan
- [x] `ResourceList` renders nothing for empty resources array
- [x] Groups resources by type with correct headings
- [x] Shows title, author, description for each resource
- [x] Omits author gracefully when null
- [x] External links have correct target and rel attributes
- [x] Only shows type headings that have resources
- [x] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)