### PR TITLE
Add resources section to teacher and center pages

### DIFF
--- a/src/app/centers/[slug]/page.tsx
+++ b/src/app/centers/[slug]/page.tsx
@@ -5,7 +5,8 @@ import { Breadcrumbs } from "@/components/breadcrumbs";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { JsonLd } from "@/components/json-ld";
-import { getAllCenters, getCenter, getTeacher, getTradition } from "@/lib/data";
+import { ResourceList } from "@/components/resource-list";
+import { getAllCenters, getCenter, getTeacher, getTradition, getResourcesByCenter } from "@/lib/data";
 import { centerJsonLd, SITE_URL } from "@/lib/seo";
 
 export function generateStaticParams() {
@@ -36,6 +37,7 @@ export default async function CenterPage({ params }: { params: Promise<{ slug: s
   const center = getCenter(slug);
   if (!center) notFound();
 
+  const resources = getResourcesByCenter(slug);
   const traditions = center.traditions
     .map((s) => getTradition(s))
     .filter((t): t is NonNullable<typeof t> => t != null);
@@ -85,6 +87,9 @@ export default async function CenterPage({ params }: { params: Promise<{ slug: s
           <h2 className="mb-4">About</h2>
           <p className="leading-relaxed text-secondary-foreground">{center.description}</p>
         </section>
+
+        {/* Resources */}
+        <ResourceList resources={resources} />
 
         {/* Teachers */}
         {teachers.length > 0 && (

--- a/src/app/teachers/[slug]/page.tsx
+++ b/src/app/teachers/[slug]/page.tsx
@@ -5,7 +5,8 @@ import { Breadcrumbs } from "@/components/breadcrumbs";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { JsonLd } from "@/components/json-ld";
-import { getAllTeachers, getTeacher, getCenter, getTradition } from "@/lib/data";
+import { ResourceList } from "@/components/resource-list";
+import { getAllTeachers, getTeacher, getCenter, getTradition, getResourcesByTeacher } from "@/lib/data";
 import { teacherJsonLd, SITE_URL } from "@/lib/seo";
 
 export function generateStaticParams() {
@@ -36,6 +37,7 @@ export default async function TeacherPage({ params }: { params: Promise<{ slug: 
   const teacher = getTeacher(slug);
   if (!teacher) notFound();
 
+  const resources = getResourcesByTeacher(slug);
   const traditions = teacher.traditions
     .map((s) => getTradition(s))
     .filter((t): t is NonNullable<typeof t> => t != null);
@@ -85,6 +87,9 @@ export default async function TeacherPage({ params }: { params: Promise<{ slug: 
           <h2 className="mb-4">About</h2>
           <p className="leading-relaxed text-secondary-foreground">{teacher.bio}</p>
         </section>
+
+        {/* Resources */}
+        <ResourceList resources={resources} />
 
         {/* Centers */}
         {centers.length > 0 && (


### PR DESCRIPTION
Closes #37

## Summary
- Wire up `ResourceList` component on teacher profile pages using `getResourcesByTeacher()`
- Wire up `ResourceList` component on center profile pages using `getResourcesByCenter()`
- Resources section renders below bio/description, above centers/teachers
- Section is absent when no resources exist (ResourceList returns null)

## Test plan
- [ ] Visit teacher pages with resources (rupert-spira, gil-fronsdal, lama-surya-das, sally-kempton) — resources section visible
- [ ] Visit teacher pages without resources — no resources section
- [ ] Visit center pages with resources (spirit-rock, insight-meditation-center, dzogchen-center) — resources section visible
- [ ] Visit center pages without resources — no resources section
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)