### PR TITLE
Add Bookshop.org affiliate helper and update book URLs

### DIFF
--- a/data/resources/awakening-buddha-within.json
+++ b/data/resources/awakening-buddha-within.json
@@ -2,11 +2,18 @@
   "title": "Awakening the Buddha Within",
   "slug": "awakening-buddha-within",
   "type": "book",
-  "url": "https://bookshop.org/p/books/awakening-the-buddha-within-tibetan-wisdom-for-the-western-world-lama-surya-das/6693556",
+  "url": "https://bookshop.org/p/books/awakening-the-buddha-within-tibetan-wisdom-for-the-western-world-lama-surya-das/6693556?aid=LINEAGE",
   "author": "Lama Surya Das",
   "year": 1997,
   "description": "Accessible guide to Tibetan Buddhist practice by an American-born lama, integrating Dzogchen teachings with Western sensibilities.",
-  "traditions": ["tibetan-buddhism-gelug", "dzogchen"],
-  "teachers": ["lama-surya-das"],
-  "centers": ["dzogchen-center"]
+  "traditions": [
+    "tibetan-buddhism-gelug",
+    "dzogchen"
+  ],
+  "teachers": [
+    "lama-surya-das"
+  ],
+  "centers": [
+    "dzogchen-center"
+  ]
 }

--- a/data/resources/awakening-of-the-heart.json
+++ b/data/resources/awakening-of-the-heart.json
@@ -2,11 +2,14 @@
   "title": "Awakening of the Heart",
   "slug": "awakening-of-the-heart",
   "type": "book",
-  "url": "https://bookshop.org/p/books/awakening-of-the-heart-essential-buddhist-sutras-and-commentaries-thich-nhat-hanh/6693559",
+  "url": "https://bookshop.org/p/books/awakening-of-the-heart-essential-buddhist-sutras-and-commentaries-thich-nhat-hanh/6693559?aid=LINEAGE",
   "author": "Thich Nhat Hanh",
   "year": 2012,
   "description": "Collection of essential Buddhist sutras with commentary by Thich Nhat Hanh, presenting foundational Mahayana teachings in accessible language.",
-  "traditions": ["mahayana", "zen"],
+  "traditions": [
+    "mahayana",
+    "zen"
+  ],
   "teachers": [],
   "centers": []
 }

--- a/data/resources/be-as-you-are.json
+++ b/data/resources/be-as-you-are.json
@@ -2,11 +2,13 @@
   "title": "Be As You Are: The Teachings of Sri Ramana Maharshi",
   "slug": "be-as-you-are",
   "type": "book",
-  "url": "https://bookshop.org/p/books/be-as-you-are-the-teachings-of-sri-ramana-maharshi-ramana-maharshi/6693488",
+  "url": "https://bookshop.org/p/books/be-as-you-are-the-teachings-of-sri-ramana-maharshi-ramana-maharshi/6693488?aid=LINEAGE",
   "author": "David Godman",
   "year": 1985,
   "description": "Thematically organized compilation of Ramana Maharshi's teachings on self-inquiry, edited by scholar David Godman.",
-  "traditions": ["advaita-vedanta"],
+  "traditions": [
+    "advaita-vedanta"
+  ],
   "teachers": [],
   "centers": []
 }

--- a/data/resources/bhagavad-gita.json
+++ b/data/resources/bhagavad-gita.json
@@ -2,11 +2,15 @@
   "title": "The Bhagavad Gita",
   "slug": "bhagavad-gita",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-bhagavad-gita-eknath-easwaran/6693574",
+  "url": "https://bookshop.org/p/books/the-bhagavad-gita-eknath-easwaran/6693574?aid=LINEAGE",
   "author": "Eknath Easwaran",
   "year": 1985,
   "description": "Easwaran's acclaimed translation of the Hindu scripture exploring karma yoga, bhakti yoga, and jnana yoga through the dialogue between Krishna and Arjuna.",
-  "traditions": ["vedanta", "bhakti", "classical-yoga"],
+  "traditions": [
+    "vedanta",
+    "bhakti",
+    "classical-yoga"
+  ],
   "teachers": [],
   "centers": []
 }

--- a/data/resources/breath-by-breath.json
+++ b/data/resources/breath-by-breath.json
@@ -2,11 +2,19 @@
   "title": "Breath by Breath",
   "slug": "breath-by-breath",
   "type": "book",
-  "url": "https://bookshop.org/p/books/breath-by-breath-the-liberating-practice-of-insight-meditation-larry-rosenberg/6425012",
+  "url": "https://bookshop.org/p/books/breath-by-breath-the-liberating-practice-of-insight-meditation-larry-rosenberg/6425012?aid=LINEAGE",
   "author": "Larry Rosenberg",
   "year": 1998,
   "description": "Detailed guide to anapanasati (mindfulness of breathing) practice in the Theravada tradition, written by a teacher at the Insight Meditation Center.",
-  "traditions": ["theravada", "vipassana-movement"],
-  "teachers": ["gil-fronsdal"],
-  "centers": ["insight-meditation-center", "spirit-rock"]
+  "traditions": [
+    "theravada",
+    "vipassana-movement"
+  ],
+  "teachers": [
+    "gil-fronsdal"
+  ],
+  "centers": [
+    "insight-meditation-center",
+    "spirit-rock"
+  ]
 }

--- a/data/resources/cloud-of-unknowing.json
+++ b/data/resources/cloud-of-unknowing.json
@@ -2,11 +2,13 @@
   "title": "The Cloud of Unknowing",
   "slug": "cloud-of-unknowing",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-cloud-of-unknowing-and-the-book-of-privy-counseling-anonymous/7101802",
+  "url": "https://bookshop.org/p/books/the-cloud-of-unknowing-and-the-book-of-privy-counseling-anonymous/7101802?aid=LINEAGE",
   "author": null,
   "year": 1375,
-  "description": "Anonymous 14th-century mystical text guiding the contemplative toward direct experience of God through 'unknowing' — releasing conceptual thought.",
-  "traditions": ["christian-mysticism"],
+  "description": "Anonymous 14th-century mystical text guiding the contemplative toward direct experience of God through 'unknowing' \u2014 releasing conceptual thought.",
+  "traditions": [
+    "christian-mysticism"
+  ],
   "teachers": [],
   "centers": []
 }

--- a/data/resources/cutting-through-spiritual-materialism.json
+++ b/data/resources/cutting-through-spiritual-materialism.json
@@ -2,11 +2,13 @@
   "title": "Cutting Through Spiritual Materialism",
   "slug": "cutting-through-spiritual-materialism",
   "type": "book",
-  "url": "https://bookshop.org/p/books/cutting-through-spiritual-materialism-chogyam-trungpa/6425064",
+  "url": "https://bookshop.org/p/books/cutting-through-spiritual-materialism-chogyam-trungpa/6425064?aid=LINEAGE",
   "author": "Chogyam Trungpa",
   "year": 1973,
   "description": "Classic warning against ego's tendency to co-opt the spiritual path, from one of the first Tibetan masters to teach extensively in the West.",
-  "traditions": ["vajrayana"],
+  "traditions": [
+    "vajrayana"
+  ],
   "teachers": [],
   "centers": []
 }

--- a/data/resources/essential-rumi.json
+++ b/data/resources/essential-rumi.json
@@ -2,11 +2,13 @@
   "title": "The Essential Rumi",
   "slug": "essential-rumi",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-essential-rumi-new-expanded-edition-jalal-al-din-rumi/6425038",
+  "url": "https://bookshop.org/p/books/the-essential-rumi-new-expanded-edition-jalal-al-din-rumi/6425038?aid=LINEAGE",
   "author": "Coleman Barks",
   "year": 1995,
   "description": "Popular English translations of the 13th-century Sufi mystic Rumi's poetry, exploring divine love, longing, and spiritual transformation.",
-  "traditions": ["sufism"],
+  "traditions": [
+    "sufism"
+  ],
   "teachers": [],
   "centers": []
 }

--- a/data/resources/heart-of-the-buddhas-teaching.json
+++ b/data/resources/heart-of-the-buddhas-teaching.json
@@ -2,11 +2,15 @@
   "title": "The Heart of the Buddha's Teaching",
   "slug": "heart-of-the-buddhas-teaching",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-heart-of-the-buddha-s-teaching-transforming-suffering-into-peace-joy-and-liberation-thich-nhat-hanh/6693941",
+  "url": "https://bookshop.org/p/books/the-heart-of-the-buddha-s-teaching-transforming-suffering-into-peace-joy-and-liberation-thich-nhat-hanh/6693941?aid=LINEAGE",
   "author": "Thich Nhat Hanh",
   "year": 1998,
   "description": "Accessible introduction to the core teachings of Buddhism, covering the Four Noble Truths, the Eightfold Path, and key Mahayana concepts.",
-  "traditions": ["early-buddhism", "mahayana", "zen"],
+  "traditions": [
+    "early-buddhism",
+    "mahayana",
+    "zen"
+  ],
   "teachers": [],
   "centers": []
 }

--- a/data/resources/i-am-that.json
+++ b/data/resources/i-am-that.json
@@ -2,11 +2,14 @@
   "title": "I Am That",
   "slug": "i-am-that",
   "type": "book",
-  "url": "https://bookshop.org/p/books/i-am-that-talks-with-sri-nisargadatta-maharaj-nisargadatta-maharaj/11710637",
+  "url": "https://bookshop.org/p/books/i-am-that-talks-with-sri-nisargadatta-maharaj-nisargadatta-maharaj/11710637?aid=LINEAGE",
   "author": "Nisargadatta Maharaj",
   "year": 1973,
   "description": "Transcribed dialogues with the Advaita Vedanta master Nisargadatta Maharaj, exploring the nature of consciousness and self-inquiry.",
-  "traditions": ["advaita-vedanta", "modern-non-dual"],
+  "traditions": [
+    "advaita-vedanta",
+    "modern-non-dual"
+  ],
   "teachers": [],
   "centers": []
 }

--- a/data/resources/interior-castle.json
+++ b/data/resources/interior-castle.json
@@ -2,11 +2,13 @@
   "title": "The Interior Castle",
   "slug": "interior-castle",
   "type": "book",
-  "url": "https://bookshop.org/p/books/interior-castle-teresa-of-avila/11380218",
+  "url": "https://bookshop.org/p/books/interior-castle-teresa-of-avila/11380218?aid=LINEAGE",
   "author": "Teresa of Avila",
   "year": 1577,
   "description": "Teresa of Avila's masterwork mapping seven stages of spiritual development as mansions within a crystal castle, a landmark of Christian mystical literature.",
-  "traditions": ["christian-mysticism"],
+  "traditions": [
+    "christian-mysticism"
+  ],
   "teachers": [],
   "centers": []
 }

--- a/data/resources/joy-of-living.json
+++ b/data/resources/joy-of-living.json
@@ -2,11 +2,14 @@
   "title": "The Joy of Living",
   "slug": "joy-of-living",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-joy-of-living-unlocking-the-secret-and-science-of-happiness-yongey-mingyur-rinpoche/6693832",
+  "url": "https://bookshop.org/p/books/the-joy-of-living-unlocking-the-secret-and-science-of-happiness-yongey-mingyur-rinpoche/6693832?aid=LINEAGE",
   "author": "Yongey Mingyur Rinpoche",
   "year": 2007,
   "description": "Tibetan Buddhist master bridges meditation practice and modern neuroscience, offering practical tools for transforming anxiety into contentment.",
-  "traditions": ["tibetan-buddhism-gelug", "vajrayana"],
+  "traditions": [
+    "tibetan-buddhism-gelug",
+    "vajrayana"
+  ],
   "teachers": [],
   "centers": []
 }

--- a/data/resources/mindfulness-in-plain-english.json
+++ b/data/resources/mindfulness-in-plain-english.json
@@ -2,11 +2,14 @@
   "title": "Mindfulness in Plain English",
   "slug": "mindfulness-in-plain-english",
   "type": "book",
-  "url": "https://bookshop.org/p/books/mindfulness-in-plain-english-bhante-henepola-gunaratana/6693860",
+  "url": "https://bookshop.org/p/books/mindfulness-in-plain-english-bhante-henepola-gunaratana/6693860?aid=LINEAGE",
   "author": "Bhante Gunaratana",
   "year": 1991,
   "description": "Clear, practical guide to Vipassana meditation from a Sri Lankan Theravada monk, widely regarded as one of the best introductions to meditation.",
-  "traditions": ["theravada", "vipassana-movement"],
+  "traditions": [
+    "theravada",
+    "vipassana-movement"
+  ],
   "teachers": [],
   "centers": []
 }

--- a/data/resources/nature-of-consciousness.json
+++ b/data/resources/nature-of-consciousness.json
@@ -2,11 +2,16 @@
   "title": "The Nature of Consciousness",
   "slug": "nature-of-consciousness",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-nature-of-consciousness-essays-on-the-unity-of-mind-and-matter-rupert-spira/9494962",
+  "url": "https://bookshop.org/p/books/the-nature-of-consciousness-essays-on-the-unity-of-mind-and-matter-rupert-spira/9494962?aid=LINEAGE",
   "author": "Rupert Spira",
   "year": 2017,
   "description": "Essays exploring the non-dual nature of experience, arguing that consciousness is the fundamental reality underlying all perception.",
-  "traditions": ["advaita-vedanta", "modern-non-dual"],
-  "teachers": ["rupert-spira"],
+  "traditions": [
+    "advaita-vedanta",
+    "modern-non-dual"
+  ],
+  "teachers": [
+    "rupert-spira"
+  ],
   "centers": []
 }

--- a/data/resources/philokalia.json
+++ b/data/resources/philokalia.json
@@ -2,11 +2,14 @@
   "title": "The Philokalia",
   "slug": "philokalia",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-philokalia-volume-1-the-complete-text-g-e-h-palmer/15914905",
+  "url": "https://bookshop.org/p/books/the-philokalia-volume-1-the-complete-text-g-e-h-palmer/15914905?aid=LINEAGE",
   "author": null,
   "year": 1782,
   "description": "Collection of texts on contemplative prayer by Eastern Orthodox monks spanning the 4th to 15th centuries, central to the Hesychast tradition.",
-  "traditions": ["hesychasm", "christian-mysticism"],
+  "traditions": [
+    "hesychasm",
+    "christian-mysticism"
+  ],
   "teachers": [],
   "centers": []
 }

--- a/data/resources/shiva-sutras.json
+++ b/data/resources/shiva-sutras.json
@@ -2,11 +2,15 @@
   "title": "Shiva Sutras: The Supreme Awakening",
   "slug": "shiva-sutras",
   "type": "book",
-  "url": "https://bookshop.org/p/books/siva-sutras-the-supreme-awakening-swami-lakshmanjoo/9920064",
+  "url": "https://bookshop.org/p/books/siva-sutras-the-supreme-awakening-swami-lakshmanjoo/9920064?aid=LINEAGE",
   "author": "Swami Lakshmanjoo",
   "year": 2007,
   "description": "Commentary on the foundational text of Kashmir Shaivism by the last living master of the tradition, revealing the nature of consciousness and liberation.",
-  "traditions": ["kashmir-shaivism"],
-  "teachers": ["sally-kempton"],
+  "traditions": [
+    "kashmir-shaivism"
+  ],
+  "teachers": [
+    "sally-kempton"
+  ],
   "centers": []
 }

--- a/data/resources/tao-te-ching.json
+++ b/data/resources/tao-te-ching.json
@@ -2,11 +2,13 @@
   "title": "Tao Te Ching",
   "slug": "tao-te-ching",
   "type": "book",
-  "url": "https://bookshop.org/p/books/tao-te-ching-laozi/18692155",
+  "url": "https://bookshop.org/p/books/tao-te-ching-laozi/18692155?aid=LINEAGE",
   "author": "Laozi",
   "year": null,
   "description": "Foundational text of Taoism, offering 81 brief chapters on the nature of the Tao, non-action (wu wei), and the art of living in harmony with reality.",
-  "traditions": ["taoism"],
+  "traditions": [
+    "taoism"
+  ],
   "teachers": [],
   "centers": []
 }

--- a/data/resources/tibetan-book-of-living-and-dying.json
+++ b/data/resources/tibetan-book-of-living-and-dying.json
@@ -2,11 +2,14 @@
   "title": "The Tibetan Book of Living and Dying",
   "slug": "tibetan-book-of-living-and-dying",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-tibetan-book-of-living-and-dying-sogyal-rinpoche/6425008",
+  "url": "https://bookshop.org/p/books/the-tibetan-book-of-living-and-dying-sogyal-rinpoche/6425008?aid=LINEAGE",
   "author": "Sogyal Rinpoche",
   "year": 1992,
   "description": "Modern presentation of Tibetan Buddhist teachings on death, dying, and the nature of mind, drawing on the Bardo Thodol tradition.",
-  "traditions": ["tibetan-buddhism-gelug", "vajrayana"],
+  "traditions": [
+    "tibetan-buddhism-gelug",
+    "vajrayana"
+  ],
   "teachers": [],
   "centers": []
 }

--- a/data/resources/way-of-zen.json
+++ b/data/resources/way-of-zen.json
@@ -2,11 +2,14 @@
   "title": "The Way of Zen",
   "slug": "way-of-zen",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-way-of-zen-alan-watts/6693942",
+  "url": "https://bookshop.org/p/books/the-way-of-zen-alan-watts/6693942?aid=LINEAGE",
   "author": "Alan Watts",
   "year": 1957,
   "description": "Influential introduction to Zen Buddhism for Western audiences, tracing its roots from Indian Buddhism through Chinese Chan to Japanese Zen.",
-  "traditions": ["zen", "chan-buddhism"],
+  "traditions": [
+    "zen",
+    "chan-buddhism"
+  ],
   "teachers": [],
   "centers": []
 }

--- a/data/resources/yoga-sutras-of-patanjali.json
+++ b/data/resources/yoga-sutras-of-patanjali.json
@@ -2,11 +2,13 @@
   "title": "The Yoga Sutras of Patanjali",
   "slug": "yoga-sutras-of-patanjali",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-yoga-sutras-of-patanjali-sri-swami-satchidananda/6425182",
+  "url": "https://bookshop.org/p/books/the-yoga-sutras-of-patanjali-sri-swami-satchidananda/6425182?aid=LINEAGE",
   "author": "Patanjali",
   "year": null,
   "description": "Foundational text of Classical Yoga, systematizing the philosophy and practice of yoga into 196 concise aphorisms.",
-  "traditions": ["classical-yoga"],
+  "traditions": [
+    "classical-yoga"
+  ],
   "teachers": [],
   "centers": []
 }

--- a/data/resources/zohar.json
+++ b/data/resources/zohar.json
@@ -2,11 +2,13 @@
   "title": "The Zohar: Pritzker Edition",
   "slug": "zohar",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-zohar-pritzker-edition-volume-one-daniel-c-matt/8211563",
+  "url": "https://bookshop.org/p/books/the-zohar-pritzker-edition-volume-one-daniel-c-matt/8211563?aid=LINEAGE",
   "author": "Daniel C. Matt",
   "year": 2003,
   "description": "Definitive English translation of the central text of Kabbalah, a 13th-century mystical commentary on the Torah exploring the hidden dimensions of reality.",
-  "traditions": ["kabbalah"],
+  "traditions": [
+    "kabbalah"
+  ],
   "teachers": [],
   "centers": []
 }

--- a/src/lib/__tests__/affiliate.test.ts
+++ b/src/lib/__tests__/affiliate.test.ts
@@ -1,0 +1,34 @@
+import { bookshopAffiliateUrl, BOOKSHOP_AFFILIATE_ID } from "../affiliate";
+
+describe("bookshopAffiliateUrl", () => {
+  it("appends affiliate ID to a Bookshop.org URL", () => {
+    const url = "https://bookshop.org/p/books/some-book/123456";
+    const result = bookshopAffiliateUrl(url);
+    expect(result).toBe(`${url}?aid=${BOOKSHOP_AFFILIATE_ID}`);
+  });
+
+  it("replaces an existing aid parameter", () => {
+    const url = "https://bookshop.org/p/books/some-book/123456?aid=OLD";
+    const result = bookshopAffiliateUrl(url);
+    expect(result).toBe(
+      `https://bookshop.org/p/books/some-book/123456?aid=${BOOKSHOP_AFFILIATE_ID}`
+    );
+  });
+
+  it("preserves other query parameters", () => {
+    const url = "https://bookshop.org/p/books/some-book/123456?ref=homepage";
+    const result = bookshopAffiliateUrl(url);
+    expect(result).toContain("ref=homepage");
+    expect(result).toContain(`aid=${BOOKSHOP_AFFILIATE_ID}`);
+  });
+
+  it("returns non-Bookshop URLs unchanged", () => {
+    const url = "https://amazon.com/some-book";
+    expect(bookshopAffiliateUrl(url)).toBe(url);
+  });
+
+  it("returns non-Bookshop URLs unchanged (YouTube)", () => {
+    const url = "https://www.youtube.com/watch?v=abc123";
+    expect(bookshopAffiliateUrl(url)).toBe(url);
+  });
+});

--- a/src/lib/affiliate.ts
+++ b/src/lib/affiliate.ts
@@ -1,0 +1,22 @@
+/**
+ * Affiliate link utilities for Bookshop.org.
+ *
+ * The affiliate ID is a placeholder until the real Bookshop.org
+ * affiliate account is set up.
+ */
+
+export const BOOKSHOP_AFFILIATE_ID = "LINEAGE";
+
+/**
+ * Appends the affiliate query parameter to a Bookshop.org URL.
+ * Non-Bookshop URLs are returned unchanged.
+ */
+export function bookshopAffiliateUrl(baseUrl: string): string {
+  if (!baseUrl.includes("bookshop.org")) {
+    return baseUrl;
+  }
+
+  const url = new URL(baseUrl);
+  url.searchParams.set("aid", BOOKSHOP_AFFILIATE_ID);
+  return url.toString();
+}


### PR DESCRIPTION
## Summary
- Created `src/lib/affiliate.ts` with `bookshopAffiliateUrl()` helper and `BOOKSHOP_AFFILIATE_ID` constant (placeholder: `LINEAGE`)
- Added 5 tests covering affiliate URL generation, parameter replacement, preservation of other params, and passthrough for non-Bookshop URLs
- Updated all 21 book resource JSON files in `data/resources/` to include `?aid=LINEAGE` affiliate parameter
- Non-book resources (websites, videos, podcasts) left unchanged

Closes #59

## Test plan
- [x] `npm test` passes (5 new affiliate tests)
- [x] `npm run build` succeeds
- [ ] Verify affiliate links render correctly on resource pages
- [ ] Replace `LINEAGE` placeholder with real affiliate ID after Bookshop.org signup

🤖 Generated with [Claude Code](https://claude.com/claude-code)