### PR TITLE
Audit and fix SEO metadata across all pages

### DIFF
--- a/src/app/about/page.tsx
+++ b/src/app/about/page.tsx
@@ -1,11 +1,19 @@
 import type { Metadata } from "next";
 import { PageLayout } from "@/components/page-layout";
 import { Breadcrumbs } from "@/components/breadcrumbs";
+import { SITE_URL } from "@/lib/seo";
+
+const description =
+  "What Lineage is, how it's built, and how you can contribute to this community-driven map of contemplative traditions.";
 
 export const metadata: Metadata = {
-  title: "About — Lineage",
-  description:
-    "What Lineage is, how it's built, and how you can contribute to this community-driven map of contemplative traditions.",
+  title: "About",
+  description,
+  openGraph: {
+    title: "About",
+    description,
+    url: `${SITE_URL}/about`,
+  },
 };
 
 export default function AboutPage() {

--- a/src/app/centers/page.tsx
+++ b/src/app/centers/page.tsx
@@ -3,6 +3,7 @@ import { PageLayout } from "@/components/page-layout";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { getAllCenters, getAllTraditions } from "@/lib/data";
 import { CentersClient } from "@/components/centers-client";
+import { SITE_URL } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "Centers",
@@ -12,6 +13,7 @@ export const metadata: Metadata = {
     title: "Centers",
     description:
       "Find contemplative practice centers by tradition and location.",
+    url: `${SITE_URL}/centers`,
   },
 };
 

--- a/src/app/map/page.tsx
+++ b/src/app/map/page.tsx
@@ -2,11 +2,19 @@ import type { Metadata } from "next";
 import { PageLayout } from "@/components/page-layout";
 import { getAllTraditions, getAllResources } from "@/lib/data";
 import { TraditionMap } from "@/components/tradition-map";
+import { SITE_URL } from "@/lib/seo";
+
+const description =
+  "An interactive map of contemplative traditions — how they connect, diverge, and speak to one another across history.";
 
 export const metadata: Metadata = {
-  title: "Interactive Map — Lineage",
-  description:
-    "An interactive map of contemplative traditions — how they connect, diverge, and speak to one another across history.",
+  title: "Interactive Map",
+  description,
+  openGraph: {
+    title: "Interactive Map",
+    description,
+    url: `${SITE_URL}/map`,
+  },
 };
 
 export default function MapPage() {

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,11 +1,19 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { PageLayout } from "@/components/page-layout";
+import { SITE_URL } from "@/lib/seo";
+
+const description =
+  "An editorial guide to contemplative traditions, teachers, and meditation centers. Explore how Buddhist, Hindu, Christian, Sufi, and secular paths connect.";
 
 export const metadata: Metadata = {
-  title: "Lineage — A Map of Contemplative Traditions",
-  description:
-    "An editorial guide to contemplative traditions, teachers, and meditation centers. Explore how Buddhist, Hindu, Christian, Sufi, and secular paths connect.",
+  title: { absolute: "Lineage — A Map of Contemplative Traditions" },
+  description,
+  openGraph: {
+    title: "Lineage — A Map of Contemplative Traditions",
+    description,
+    url: SITE_URL,
+  },
 };
 
 const sections = [

--- a/src/app/search/page.tsx
+++ b/src/app/search/page.tsx
@@ -3,11 +3,19 @@ import { PageLayout } from "@/components/page-layout";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { SearchClient } from "@/components/search-client";
 import { getAllTeachers, getAllCenters, getAllTraditions } from "@/lib/data";
+import { SITE_URL } from "@/lib/seo";
+
+const description =
+  "Find contemplative teachers and meditation centers by tradition and location.";
 
 export const metadata: Metadata = {
-  title: "Search — Lineage",
-  description:
-    "Find contemplative teachers and meditation centers by tradition and location.",
+  title: "Search",
+  description,
+  openGraph: {
+    title: "Search",
+    description,
+    url: `${SITE_URL}/search`,
+  },
 };
 
 export default function SearchPage() {

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -11,8 +11,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
 
   const staticPages: MetadataRoute.Sitemap = [
     { url: SITE_URL, lastModified: now, changeFrequency: "weekly", priority: 1 },
+    { url: `${SITE_URL}/about`, lastModified: now, changeFrequency: "monthly", priority: 0.5 },
+    { url: `${SITE_URL}/map`, lastModified: now, changeFrequency: "weekly", priority: 0.8 },
+    { url: `${SITE_URL}/search`, lastModified: now, changeFrequency: "weekly", priority: 0.6 },
     { url: `${SITE_URL}/traditions`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
     { url: `${SITE_URL}/teachers`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
+    { url: `${SITE_URL}/centers`, lastModified: now, changeFrequency: "weekly", priority: 0.9 },
   ];
 
   const traditionPages: MetadataRoute.Sitemap = getAllTraditions().map((t) => ({

--- a/src/app/teachers/page.tsx
+++ b/src/app/teachers/page.tsx
@@ -5,6 +5,7 @@ import { Breadcrumbs } from "@/components/breadcrumbs";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { getAllTeachers, getTradition } from "@/lib/data";
+import { SITE_URL } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "Teachers",
@@ -12,6 +13,7 @@ export const metadata: Metadata = {
   openGraph: {
     title: "Teachers",
     description: "Browse contemplative teachers by tradition and location.",
+    url: `${SITE_URL}/teachers`,
   },
 };
 

--- a/src/app/traditions/page.tsx
+++ b/src/app/traditions/page.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { getAllTraditions } from "@/lib/data";
 import type { ParsedTradition } from "@/lib/data";
+import { SITE_URL } from "@/lib/seo";
 
 export const metadata: Metadata = {
   title: "Traditions",
@@ -15,6 +16,7 @@ export const metadata: Metadata = {
     title: "Traditions",
     description:
       "Explore contemplative traditions — Buddhist, Hindu, Taoist, Christian, Islamic, and more.",
+    url: `${SITE_URL}/traditions`,
   },
 };
 


### PR DESCRIPTION
## Summary
- **Fix title duplication bug**: Pages like "About — Lineage" were rendering as "About — Lineage — Lineage" due to conflict with the layout's `%s — Lineage` title template. Removed manual suffixes; homepage now uses `title.absolute`.
- **Add missing Open Graph tags**: Homepage, about, map, and search pages had no OG tags. Added title, description, and url to all four. Also added missing `url` field to traditions, teachers, and centers index pages.
- **Complete the sitemap**: Added `/about`, `/map`, `/search`, and `/centers` to `sitemap.ts` — these static pages were previously missing.

Closes #58

## Test plan
- [ ] Run `npm run build` — passes
- [ ] Inspect rendered HTML `<title>` tags to confirm no duplication (e.g. "About — Lineage", not "About — Lineage — Lineage")
- [ ] Check `<meta property="og:*">` tags on homepage, about, map, search pages
- [ ] Verify `/sitemap.xml` output includes all static pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)