### PR TITLE
Add 44 book resources for traditions and teachers

### DIFF
--- a/data/resources/a-brief-introduction-to-jainism-and-sikhism.json
+++ b/data/resources/a-brief-introduction-to-jainism-and-sikhism.json
@@ -1,0 +1,14 @@
+{
+  "title": "A Brief Introduction to Jainism and Sikhism",
+  "slug": "a-brief-introduction-to-jainism-and-sikhism",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/a-brief-introduction-to-jainism-and-sikhism-christopher-partridge/11572546?aid=LINEAGE",
+  "author": "Christopher Partridge",
+  "year": 2018,
+  "description": "An accessible overview of Jainism covering its history, core doctrines of non-violence and liberation, and its continuing relevance in the modern world.",
+  "traditions": [
+    "jainism"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/a-path-with-heart.json
+++ b/data/resources/a-path-with-heart.json
@@ -1,0 +1,17 @@
+{
+  "title": "A Path with Heart",
+  "slug": "a-path-with-heart",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/a-path-with-heart-a-guide-through-the-perils-and-promises-of-spiritual-life-jack-kornfield/10788678?aid=LINEAGE",
+  "author": "Jack Kornfield",
+  "year": 1993,
+  "description": "A guide through the perils and promises of spiritual life, offering practical wisdom on meditation and the integration of spiritual practice into daily life.",
+  "traditions": [
+    "vipassana-movement",
+    "theravada"
+  ],
+  "teachers": [
+    "jack-kornfield"
+  ],
+  "centers": []
+}

--- a/data/resources/a-testament-of-devotion.json
+++ b/data/resources/a-testament-of-devotion.json
@@ -1,0 +1,14 @@
+{
+  "title": "A Testament of Devotion",
+  "slug": "a-testament-of-devotion",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/a-testament-of-devotion-thomas-r-kelly/7944644?aid=LINEAGE",
+  "author": "Thomas R. Kelly",
+  "year": 1941,
+  "description": "A Quaker spiritual classic of five essays urging readers to center their lives on God's presence and discover the peace of the inner spiritual journey.",
+  "traditions": [
+    "quaker-inner-light"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/be-here-now.json
+++ b/data/resources/be-here-now.json
@@ -1,0 +1,18 @@
+{
+  "title": "Be Here Now",
+  "slug": "be-here-now",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/be-here-now-ram-dass/6556749?aid=LINEAGE",
+  "author": "Ram Dass",
+  "year": 1971,
+  "description": "A countercultural classic that launched the mindfulness revolution, chronicling Richard Alpert's transformation into Ram Dass and introducing Eastern spirituality to the West.",
+  "traditions": [
+    "bhakti",
+    "vedanta",
+    "modern-non-dual"
+  ],
+  "teachers": [
+    "ram-dass"
+  ],
+  "centers": []
+}

--- a/data/resources/bhakti-yoga.json
+++ b/data/resources/bhakti-yoga.json
@@ -1,0 +1,15 @@
+{
+  "title": "Bhakti Yoga: Tales and Teachings from the Bhagavata Purana",
+  "slug": "bhakti-yoga",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/bhakti-yoga-tales-and-teachings-from-the-bhagavata-purana-edwin-f-bryant/8047746?aid=LINEAGE",
+  "author": "Edwin F. Bryant",
+  "year": 2017,
+  "description": "An accessible exploration of bhakti devotional practice through tales and teachings from the Bhagavata Purana, a foundational text of the bhakti tradition.",
+  "traditions": [
+    "bhakti",
+    "vedanta"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/full-catastrophe-living.json
+++ b/data/resources/full-catastrophe-living.json
@@ -1,0 +1,16 @@
+{
+  "title": "Full Catastrophe Living",
+  "slug": "full-catastrophe-living",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/full-catastrophe-living-using-the-wisdom-of-your-body-and-mind-to-face-stress-pain-and-illness-jon-kabat-zinn/9119077?aid=LINEAGE",
+  "author": "Jon Kabat-Zinn",
+  "year": 1990,
+  "description": "The definitive guide to mindfulness-based stress reduction (MBSR), showing how to use meditation and yoga to counteract stress, pain, and illness.",
+  "traditions": [
+    "secular-mindfulness"
+  ],
+  "teachers": [
+    "jon-kabat-zinn"
+  ],
+  "centers": []
+}

--- a/data/resources/gnosticism-new-light.json
+++ b/data/resources/gnosticism-new-light.json
@@ -1,0 +1,15 @@
+{
+  "title": "Gnosticism: New Light on the Ancient Tradition of Inner Knowing",
+  "slug": "gnosticism-new-light",
+  "type": "book",
+  "url": "https://bookshop.org/books/gnosticism-new-light-on-the-ancient-tradition-of-inner-knowing/9780835608169?aid=LINEAGE",
+  "author": "Stephan A. Hoeller",
+  "year": 2002,
+  "description": "An accessible overview of Gnosticism from antiquity to the present, illuminating its core teaching that direct experiential knowledge of the divine is available to all.",
+  "traditions": [
+    "gnosticism",
+    "neoplatonism"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/jainism-at-a-glance.json
+++ b/data/resources/jainism-at-a-glance.json
@@ -1,0 +1,14 @@
+{
+  "title": "Jainism at a Glance",
+  "slug": "jainism-at-a-glance",
+  "type": "book",
+  "url": "https://bookshop.org/books/jainism-at-a-glance-a-religion-of-non-violence/9781452841854?aid=LINEAGE",
+  "author": "Subhash C. Jain",
+  "year": 2013,
+  "description": "Traces the antiquity of Jainism and delineates its basic principles including the nature of the soul, doctrine of karma, and the path of salvation.",
+  "traditions": [
+    "jainism"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/kabbalah-very-short-introduction.json
+++ b/data/resources/kabbalah-very-short-introduction.json
@@ -1,0 +1,14 @@
+{
+  "title": "Kabbalah: A Very Short Introduction",
+  "slug": "kabbalah-very-short-introduction",
+  "type": "book",
+  "url": "https://bookshop.org/books/kabbalah-a-very-short-introduction/9780195327052?aid=LINEAGE",
+  "author": "Joseph Dan",
+  "year": 2006,
+  "description": "A concise and authoritative introduction to the history, major ideas, and key figures of the Kabbalistic tradition of Jewish mysticism.",
+  "traditions": [
+    "kabbalah"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/kashmir-shaivism-secret-supreme.json
+++ b/data/resources/kashmir-shaivism-secret-supreme.json
@@ -1,0 +1,15 @@
+{
+  "title": "Kashmir Shaivism: The Secret Supreme",
+  "slug": "kashmir-shaivism-secret-supreme",
+  "type": "book",
+  "url": "https://bookshop.org/books/kashmir-shaivism-the-secret-supreme/9781587611568?aid=LINEAGE",
+  "author": "Swami Lakshmanjoo",
+  "year": 1988,
+  "description": "Teachings from the last living master of an unbroken oral lineage of Kashmir Shaivism, revealing the philosophical heart of this non-dual tantric tradition.",
+  "traditions": [
+    "kashmir-shaivism",
+    "tantra"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/light-on-yoga.json
+++ b/data/resources/light-on-yoga.json
@@ -1,0 +1,14 @@
+{
+  "title": "Light on Yoga",
+  "slug": "light-on-yoga",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/light-on-yoga/18792550?aid=LINEAGE",
+  "author": "B.K.S. Iyengar",
+  "year": 1966,
+  "description": "The definitive guide to yoga practice, widely called the bible of yoga, with complete descriptions and illustrations of asanas and pranayama.",
+  "traditions": [
+    "classical-yoga"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/lovingkindness.json
+++ b/data/resources/lovingkindness.json
@@ -1,0 +1,17 @@
+{
+  "title": "Lovingkindness: The Revolutionary Art of Happiness",
+  "slug": "lovingkindness",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/lovingkindness-the-revolutionary-art-of-happiness-sharon-salzberg/2812982772c48a3c?aid=LINEAGE",
+  "author": "Sharon Salzberg",
+  "year": 1995,
+  "description": "Draws on Buddhist teachings and guided meditation exercises to show how the practice of lovingkindness can cultivate love, compassion, and joy.",
+  "traditions": [
+    "vipassana-movement",
+    "theravada"
+  ],
+  "teachers": [
+    "sharon-salzberg"
+  ],
+  "centers": []
+}

--- a/data/resources/mindfulness-a-practical-guide-to-awakening.json
+++ b/data/resources/mindfulness-a-practical-guide-to-awakening.json
@@ -1,0 +1,18 @@
+{
+  "title": "Mindfulness: A Practical Guide to Awakening",
+  "slug": "mindfulness-a-practical-guide-to-awakening",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/mindfulness-a-practical-guide-to-awakening-joseph-goldstein/9259626?aid=LINEAGE",
+  "author": "Joseph Goldstein",
+  "year": 2013,
+  "description": "A comprehensive guide to mindfulness meditation rooted in the Satipatthana Sutta, distilling four decades of teaching and practice.",
+  "traditions": [
+    "vipassana-movement",
+    "theravada",
+    "early-buddhism"
+  ],
+  "teachers": [
+    "joseph-goldstein"
+  ],
+  "centers": []
+}

--- a/data/resources/neoplatonism.json
+++ b/data/resources/neoplatonism.json
@@ -1,0 +1,14 @@
+{
+  "title": "Neoplatonism",
+  "slug": "neoplatonism",
+  "type": "book",
+  "url": "https://bookshop.org/books/neoplatonism/9780520254985?aid=LINEAGE",
+  "author": "Pauliina Remes",
+  "year": 2008,
+  "description": "An accessible introduction to Neoplatonic philosophy covering Plotinus, Porphyry, Iamblichus, and Proclus, and their enduring influence on Western thought.",
+  "traditions": [
+    "neoplatonism"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/plotinus-introduction-to-the-enneads.json
+++ b/data/resources/plotinus-introduction-to-the-enneads.json
@@ -1,0 +1,14 @@
+{
+  "title": "Plotinus: An Introduction to the Enneads",
+  "slug": "plotinus-introduction-to-the-enneads",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/plotinus-an-introduction-to-the-enneads-dominic-j-o-meara/9760754?aid=LINEAGE",
+  "author": "Dominic J. O'Meara",
+  "year": 1993,
+  "description": "An accessible introduction to the philosophy of Plotinus, the founder of Neoplatonism, placing his thinking within its intellectual context.",
+  "traditions": [
+    "neoplatonism"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/quaker-spirituality.json
+++ b/data/resources/quaker-spirituality.json
@@ -1,0 +1,14 @@
+{
+  "title": "Quaker Spirituality: Selected Writings",
+  "slug": "quaker-spirituality",
+  "type": "book",
+  "url": "https://bookshop.org/books/quaker-spirituality-selected-writings/9780809135059?aid=LINEAGE",
+  "author": "Douglas V. Steere",
+  "year": 1984,
+  "description": "A collection of essential Quaker writings spanning four centuries, exploring the tradition of silent worship and the experience of the Inner Light.",
+  "traditions": [
+    "quaker-inner-light"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/radical-acceptance.json
+++ b/data/resources/radical-acceptance.json
@@ -1,0 +1,17 @@
+{
+  "title": "Radical Acceptance",
+  "slug": "radical-acceptance",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/radical-acceptance-embracing-your-life-with-the-heart-of-a-buddha-tara-brach/73f251c91e30fe7a?aid=LINEAGE",
+  "author": "Tara Brach",
+  "year": 2003,
+  "description": "Combines Buddhist teachings with Western psychology to offer a path to emotional healing through embracing our lives with the heart of a Buddha.",
+  "traditions": [
+    "vipassana-movement",
+    "secular-mindfulness"
+  ],
+  "teachers": [
+    "tara-brach"
+  ],
+  "centers": []
+}

--- a/data/resources/tai-chi-classics.json
+++ b/data/resources/tai-chi-classics.json
@@ -1,0 +1,15 @@
+{
+  "title": "Tai Chi Classics",
+  "slug": "tai-chi-classics",
+  "type": "book",
+  "url": "https://bookshop.org/books/tai-chi-classics/9781590302613?aid=LINEAGE",
+  "author": "Waysun Liao",
+  "year": 1977,
+  "description": "Translations and commentary on the original tai chi texts, revealing the philosophical and practical foundations of this ancient internal art.",
+  "traditions": [
+    "tai-chi-qigong",
+    "taoism"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/tantra-illuminated.json
+++ b/data/resources/tantra-illuminated.json
@@ -1,0 +1,15 @@
+{
+  "title": "Tantra Illuminated",
+  "slug": "tantra-illuminated",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/tantra-illuminated-the-philosophy-history-and-practice-of-a-timeless-tradition-christopher-d-wallis/0037e20101308c70?aid=LINEAGE",
+  "author": "Christopher D. Wallis",
+  "year": 2012,
+  "description": "An accessible introduction to the philosophy, history, and practice of Tantra, drawing on primary Sanskrit sources to reveal its rich teachings.",
+  "traditions": [
+    "tantra",
+    "kashmir-shaivism"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/that-which-is.json
+++ b/data/resources/that-which-is.json
@@ -1,0 +1,14 @@
+{
+  "title": "That Which Is: Tattvartha Sutra",
+  "slug": "that-which-is",
+  "type": "book",
+  "url": "https://bookshop.org/books/that-which-is-tattvartha-sutra/9780300165227?aid=LINEAGE",
+  "author": "Umasvati",
+  "year": 200,
+  "description": "The only Jain text accepted as authoritative by all sects, presenting the foundational doctrines of Jainism including karma, the soul, and liberation.",
+  "traditions": [
+    "jainism"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/the-complete-book-of-tai-chi-chuan.json
+++ b/data/resources/the-complete-book-of-tai-chi-chuan.json
@@ -1,0 +1,15 @@
+{
+  "title": "The Complete Book of Tai Chi Chuan",
+  "slug": "the-complete-book-of-tai-chi-chuan",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/the-complete-book-of-tai-chi-chuan-a-comprehensive-guide-to-the-principles-and-practice-wong-kiew-kit/11027389?aid=LINEAGE",
+  "author": "Wong Kiew Kit",
+  "year": 1996,
+  "description": "A comprehensive guide to the principles and practice of Tai Chi Chuan, covering its benefits for physical, mental, spiritual, and emotional development.",
+  "traditions": [
+    "tai-chi-qigong",
+    "taoism"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/the-conference-of-the-birds.json
+++ b/data/resources/the-conference-of-the-birds.json
@@ -1,0 +1,14 @@
+{
+  "title": "The Conference of the Birds",
+  "slug": "the-conference-of-the-birds",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/the-conference-of-the-birds-the-selected-sufi-poetry-of-farid-ud-din-attar-farid-ud-din-attar/3eb4f199a7e7159b?aid=LINEAGE",
+  "author": "Farid ud-Din Attar",
+  "year": 1177,
+  "description": "A masterwork of Sufi poetry in which the birds of the world undertake a perilous journey through seven valleys to find their king, allegorizing the soul's search for God.",
+  "traditions": [
+    "sufism"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/the-crystal-and-the-way-of-light.json
+++ b/data/resources/the-crystal-and-the-way-of-light.json
@@ -1,0 +1,15 @@
+{
+  "title": "The Crystal and the Way of Light",
+  "slug": "the-crystal-and-the-way-of-light",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/the-crystal-and-the-way-of-light-sutra-tantra-and-dzogchen-chogyal-namkhai-norbu/f288c91749ae0172?aid=LINEAGE",
+  "author": "Chogyal Namkhai Norbu",
+  "year": 1986,
+  "description": "An accessible introduction to Dzogchen by a revered Tibetan master, interweaving his life story with teachings on the base, path, and fruit of practice.",
+  "traditions": [
+    "dzogchen",
+    "vajrayana"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/the-end-of-your-world.json
+++ b/data/resources/the-end-of-your-world.json
@@ -1,0 +1,17 @@
+{
+  "title": "The End of Your World",
+  "slug": "the-end-of-your-world",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/the-end-of-your-world-uncensored-straight-talk-on-the-nature-of-enlightenment-adyashanti/10792613?aid=LINEAGE",
+  "author": "Adyashanti",
+  "year": 2008,
+  "description": "Uncensored straight talk on what happens after spiritual awakening, addressing common pitfalls and the journey from nonabiding to abiding realization.",
+  "traditions": [
+    "zen",
+    "modern-non-dual"
+  ],
+  "teachers": [
+    "adyashanti"
+  ],
+  "centers": []
+}

--- a/data/resources/the-essential-kabbalah.json
+++ b/data/resources/the-essential-kabbalah.json
@@ -1,0 +1,14 @@
+{
+  "title": "The Essential Kabbalah",
+  "slug": "the-essential-kabbalah",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/the-essential-kabbalah-the-heart-of-jewish-mysticism-revised-daniel-c-matt/6438429?aid=LINEAGE",
+  "author": "Daniel C. Matt",
+  "year": 1995,
+  "description": "The perfect introduction to Kabbalism, presenting its most essential teachings with expert translations and clear explanations of the Ten Sefirot and the Zohar.",
+  "traditions": [
+    "kabbalah"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/the-gnostic-gospels.json
+++ b/data/resources/the-gnostic-gospels.json
@@ -1,0 +1,14 @@
+{
+  "title": "The Gnostic Gospels",
+  "slug": "the-gnostic-gospels",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/the-gnostic-gospels-elaine-pagels/6719485?aid=LINEAGE",
+  "author": "Elaine Pagels",
+  "year": 1979,
+  "description": "A landmark exploration of the Nag Hammadi texts that reveals a radically different view of early Christianity. Winner of the National Book Award.",
+  "traditions": [
+    "gnosticism"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/the-gospel-of-thomas.json
+++ b/data/resources/the-gospel-of-thomas.json
@@ -1,0 +1,14 @@
+{
+  "title": "The Gospel of Thomas: The Gnostic Wisdom of Jesus",
+  "slug": "the-gospel-of-thomas",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/the-gospel-of-thomas-the-gnostic-wisdom-of-jesus-jean-yves-leloup/dc537c454e97368a?aid=LINEAGE",
+  "author": "Jean-Yves Leloup",
+  "year": 2005,
+  "description": "A translation and commentary on the 114 logia of the Gospel of Thomas, revealing a Jesus with much in common with non-dualistic gnostic schools.",
+  "traditions": [
+    "gnosticism"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/the-heart-of-sufism.json
+++ b/data/resources/the-heart-of-sufism.json
@@ -1,0 +1,14 @@
+{
+  "title": "The Heart of Sufism",
+  "slug": "the-heart-of-sufism",
+  "type": "book",
+  "url": "https://bookshop.org/books/the-heart-of-sufism-essential-writings-of-hazrat-inayat-khan/9781570622106?aid=LINEAGE",
+  "author": "Hazrat Inayat Khan",
+  "year": 1999,
+  "description": "Essential writings of the great Sufi master who brought Sufism to the West, presenting the mystical heart of Islam's contemplative tradition.",
+  "traditions": [
+    "sufism"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/the-journal-of-george-fox.json
+++ b/data/resources/the-journal-of-george-fox.json
@@ -1,0 +1,14 @@
+{
+  "title": "The Journal of George Fox",
+  "slug": "the-journal-of-george-fox",
+  "type": "book",
+  "url": "https://bookshop.org/books/the-journal-of-george-fox/9780913408377?aid=LINEAGE",
+  "author": "George Fox",
+  "year": 1694,
+  "description": "The spiritual autobiography of Quakerism's founder, recording his discovery of the Inner Light and the birth of the Religious Society of Friends.",
+  "traditions": [
+    "quaker-inner-light"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/the-miracle-of-mindfulness.json
+++ b/data/resources/the-miracle-of-mindfulness.json
@@ -1,0 +1,17 @@
+{
+  "title": "The Miracle of Mindfulness",
+  "slug": "the-miracle-of-mindfulness",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/the-miracle-of-mindfulness-an-introduction-to-the-practice-of-meditation-thich-nhat-hanh/2333ddf24162fa0d?aid=LINEAGE",
+  "author": "Thich Nhat Hanh",
+  "year": 1975,
+  "description": "A gentle introduction to the practice of mindfulness meditation through anecdotes and practical exercises from the beloved Zen master.",
+  "traditions": [
+    "zen",
+    "mahayana"
+  ],
+  "teachers": [
+    "thich-nhat-hanh"
+  ],
+  "centers": []
+}

--- a/data/resources/the-philokalia-selections.json
+++ b/data/resources/the-philokalia-selections.json
@@ -1,0 +1,15 @@
+{
+  "title": "The Philokalia: The Eastern Christian Spiritual Texts",
+  "slug": "the-philokalia-selections",
+  "type": "book",
+  "url": "https://bookshop.org/books/the-philokalia-the-eastern-christian-spiritual-texts/9781594731037?aid=LINEAGE",
+  "author": "Allyne Smith",
+  "year": 2006,
+  "description": "Annotated selections from the Philokalia, the foundational anthology of hesychast writings on the prayer of the heart and contemplative stillness.",
+  "traditions": [
+    "hesychasm",
+    "christian-mysticism"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/the-places-that-scare-you.json
+++ b/data/resources/the-places-that-scare-you.json
@@ -1,0 +1,17 @@
+{
+  "title": "The Places That Scare You",
+  "slug": "the-places-that-scare-you",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/the-places-that-scare-you-a-guide-to-fearlessness-in-difficult-times-pema-chodron/9762315?aid=LINEAGE",
+  "author": "Pema Chödrön",
+  "year": 2001,
+  "description": "A guide to fearlessness in difficult times, drawing on Buddhist teachings to show how awakening basic human goodness can transform our relationship with fear.",
+  "traditions": [
+    "vajrayana",
+    "tibetan-buddhism-gelug"
+  ],
+  "teachers": [
+    "pema-chodron"
+  ],
+  "centers": []
+}

--- a/data/resources/the-platform-sutra-red-pine.json
+++ b/data/resources/the-platform-sutra-red-pine.json
@@ -1,0 +1,15 @@
+{
+  "title": "The Platform Sutra: The Zen Teaching of Hui-neng",
+  "slug": "the-platform-sutra-red-pine",
+  "type": "book",
+  "url": "https://bookshop.org/books/the-platform-sutra-the-zen-teaching-of-hui-neng/9781619024236?aid=LINEAGE",
+  "author": "Red Pine",
+  "year": 2006,
+  "description": "Red Pine's acclaimed translation of the Platform Sutra, the foundational Chan text recording Huineng's teachings on sudden awakening.",
+  "traditions": [
+    "chan-buddhism",
+    "zen"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/the-platform-sutra.json
+++ b/data/resources/the-platform-sutra.json
@@ -1,0 +1,15 @@
+{
+  "title": "The Platform Sutra of the Sixth Patriarch",
+  "slug": "the-platform-sutra",
+  "type": "book",
+  "url": "https://bookshop.org/books/the-platform-sutra-of-the-sixth-patriarch/9780231159579?aid=LINEAGE",
+  "author": "Huineng",
+  "year": 780,
+  "description": "A foundational text of Chan Buddhism recording the sermons and teachings of the Sixth Patriarch Huineng, revealing the early evolution of Chinese Chan.",
+  "traditions": [
+    "chan-buddhism",
+    "zen"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/the-tao-of-pooh.json
+++ b/data/resources/the-tao-of-pooh.json
@@ -1,0 +1,14 @@
+{
+  "title": "The Tao of Pooh",
+  "slug": "the-tao-of-pooh",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/the-tao-of-pooh-benjamin-hoff/16618380?aid=LINEAGE",
+  "author": "Benjamin Hoff",
+  "year": 1982,
+  "description": "An accessible and delightful introduction to Taoism through the characters of Winnie-the-Pooh, showing that the principles of Tao are not ancient and remote but practical and present.",
+  "traditions": [
+    "taoism"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/the-tibetan-yogas-of-dream-and-sleep.json
+++ b/data/resources/the-tibetan-yogas-of-dream-and-sleep.json
@@ -1,0 +1,18 @@
+{
+  "title": "The Tibetan Yogas of Dream and Sleep",
+  "slug": "the-tibetan-yogas-of-dream-and-sleep",
+  "type": "book",
+  "url": "https://bookshop.org/books/the-tibetan-yogas-of-dream-and-sleep/9781559391016?aid=LINEAGE",
+  "author": "Tenzin Wangyal Rinpoche",
+  "year": 1998,
+  "description": "A guide to dream yoga and sleep yoga from the Bön Dzogchen tradition, showing how to use the night for spiritual transformation.",
+  "traditions": [
+    "dzogchen",
+    "vajrayana",
+    "tantra"
+  ],
+  "teachers": [
+    "tenzin-wangyal-rinpoche"
+  ],
+  "centers": []
+}

--- a/data/resources/the-upanishads.json
+++ b/data/resources/the-upanishads.json
@@ -1,0 +1,15 @@
+{
+  "title": "The Upanishads",
+  "slug": "the-upanishads",
+  "type": "book",
+  "url": "https://bookshop.org/books/the-upanishads-2nd-revised-edition/9781586380212?aid=LINEAGE",
+  "author": "Eknath Easwaran",
+  "year": 1987,
+  "description": "Eknath Easwaran's accessible translation of the principal Upanishads, the foundational texts of Vedantic philosophy exploring the nature of consciousness and reality.",
+  "traditions": [
+    "vedanta",
+    "classical-yoga"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/the-way-of-a-pilgrim.json
+++ b/data/resources/the-way-of-a-pilgrim.json
@@ -1,0 +1,15 @@
+{
+  "title": "The Way of a Pilgrim",
+  "slug": "the-way-of-a-pilgrim",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/the-way-of-a-pilgrim-and-the-pilgrim-continues-on-his-way-collector-s-edition-anonymous-19th-century-russian-peasant/11434123?aid=LINEAGE",
+  "author": "Anonymous",
+  "year": 1884,
+  "description": "The account of a Russian pilgrim's journey to learn unceasing prayer, a foundational text of the hesychast tradition of the Jesus Prayer.",
+  "traditions": [
+    "hesychasm",
+    "christian-mysticism"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/the-way-of-qigong.json
+++ b/data/resources/the-way-of-qigong.json
@@ -1,0 +1,15 @@
+{
+  "title": "The Way of Qigong",
+  "slug": "the-way-of-qigong",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/the-way-of-qigong-the-art-and-science-of-chinese-energy-healing-kenneth-s-cohen/bd698c00955bbc4d?aid=LINEAGE",
+  "author": "Kenneth S. Cohen",
+  "year": 1997,
+  "description": "A comprehensive guide to the art and science of qigong, explaining this ancient Chinese energy healing method with practical exercises and scientific context.",
+  "traditions": [
+    "tai-chi-qigong",
+    "taoism"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/the-way-of-the-bodhisattva.json
+++ b/data/resources/the-way-of-the-bodhisattva.json
@@ -1,0 +1,15 @@
+{
+  "title": "The Way of the Bodhisattva",
+  "slug": "the-way-of-the-bodhisattva",
+  "type": "book",
+  "url": "https://bookshop.org/books/the-way-of-the-bodhisattva-revised/9781590306147?aid=LINEAGE",
+  "author": "Shantideva",
+  "year": 700,
+  "description": "A guide to cultivating the mind of enlightenment through love, compassion, generosity, and patience, studied in an unbroken tradition for centuries.",
+  "traditions": [
+    "mahayana",
+    "tibetan-buddhism-gelug"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/what-the-buddha-taught.json
+++ b/data/resources/what-the-buddha-taught.json
@@ -1,0 +1,15 @@
+{
+  "title": "What the Buddha Taught",
+  "slug": "what-the-buddha-taught",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/what-the-buddha-taught-revised-and-expanded-edition-with-texts-from-suttas-and-dhammapada-walpola-rahula/12473981?aid=LINEAGE",
+  "author": "Walpola Rahula",
+  "year": 1959,
+  "description": "An indispensable introduction to Buddhism, presenting the core teachings with clarity and authority using the Buddha's own words from the Suttas.",
+  "traditions": [
+    "early-buddhism",
+    "theravada"
+  ],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/when-things-fall-apart.json
+++ b/data/resources/when-things-fall-apart.json
@@ -1,0 +1,17 @@
+{
+  "title": "When Things Fall Apart",
+  "slug": "when-things-fall-apart",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/when-things-fall-apart-heart-advice-for-difficult-times-pema-chodron/9757480?aid=LINEAGE",
+  "author": "Pema Chödrön",
+  "year": 1997,
+  "description": "Heart advice for difficult times, showing how moving toward painful situations can open our hearts in ways we never imagined.",
+  "traditions": [
+    "vajrayana",
+    "tibetan-buddhism-gelug"
+  ],
+  "teachers": [
+    "pema-chodron"
+  ],
+  "centers": []
+}

--- a/data/resources/wherever-you-go-there-you-are.json
+++ b/data/resources/wherever-you-go-there-you-are.json
@@ -1,0 +1,16 @@
+{
+  "title": "Wherever You Go, There You Are",
+  "slug": "wherever-you-go-there-you-are",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/wherever-you-go-there-you-are-mindfulness-meditation-in-everyday-life-jon-kabat-zinn/19968905?aid=LINEAGE",
+  "author": "Jon Kabat-Zinn",
+  "year": 1994,
+  "description": "A foundational guide to mindfulness meditation in everyday life that helped catalyze the global mindfulness movement.",
+  "traditions": [
+    "secular-mindfulness"
+  ],
+  "teachers": [
+    "jon-kabat-zinn"
+  ],
+  "centers": []
+}

--- a/data/resources/zen-mind-beginners-mind.json
+++ b/data/resources/zen-mind-beginners-mind.json
@@ -1,0 +1,16 @@
+{
+  "title": "Zen Mind, Beginner's Mind",
+  "slug": "zen-mind-beginners-mind",
+  "type": "book",
+  "url": "https://bookshop.org/p/books/zen-mind-beginner-s-mind-50th-anniversary-edition-shunryu-suzuki/08164e1309629b8e?aid=LINEAGE",
+  "author": "Shunryu Suzuki",
+  "year": 1970,
+  "description": "One of the great modern spiritual classics, presenting the basics of Zen meditation with remarkable clarity and the joy of insight.",
+  "traditions": [
+    "zen"
+  ],
+  "teachers": [
+    "shunryu-suzuki"
+  ],
+  "centers": []
+}


### PR DESCRIPTION
## Summary
- Adds 44 new book resource JSON files to `data/resources/` to fill coverage gaps (closes #60)
- Every tradition now has at least 3 book resources linked
- Top published teachers (Kornfield, Salzberg, Pema Chödrön, Brach, Goldstein, Ram Dass, Thich Nhat Hanh, Adyashanti, Kabat-Zinn, Suzuki Roshi, Tenzin Wangyal Rinpoche) each have 1-2 books linked via `teachers[]` arrays
- All book URLs point to Bookshop.org with `?aid=LINEAGE` affiliate parameter
- No existing files were modified

## Teacher books added
| Teacher | Books |
|---------|-------|
| Jack Kornfield | A Path with Heart |
| Sharon Salzberg | Lovingkindness |
| Pema Chödrön | When Things Fall Apart, The Places That Scare You |
| Tara Brach | Radical Acceptance |
| Joseph Goldstein | Mindfulness: A Practical Guide to Awakening |
| Ram Dass | Be Here Now |
| Thich Nhat Hanh | The Miracle of Mindfulness |
| Adyashanti | The End of Your World |
| Jon Kabat-Zinn | Wherever You Go There You Are, Full Catastrophe Living |
| Shunryu Suzuki | Zen Mind, Beginner's Mind |
| Tenzin Wangyal Rinpoche | The Tibetan Yogas of Dream and Sleep |

## Tradition-gap books added
Gnosticism, Neoplatonism, Quaker Inner Light, Jainism, Tai Chi/Qigong, Tantra, Chan Buddhism, Hesychasm, Dzogchen, Sufism, Kabbalah, Kashmir Shaivism, Classical Yoga, Early Buddhism, Vedanta, Bhakti, Mahayana, Taoism

## Test plan
- [x] `npm run build` passes successfully
- [ ] Verify book resources appear on tradition and teacher detail pages
- [ ] Spot-check Bookshop.org URLs resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)