### PR TITLE
Rename Hindu tradition family to Vedic-Yogic

### DIFF
--- a/data/traditions/advaita-vedanta.mdx
+++ b/data/traditions/advaita-vedanta.mdx
@@ -1,7 +1,7 @@
 ---
 name: Advaita Vedanta
 slug: advaita-vedanta
-family: Hindu
+family: Vedic-Yogic
 origin_century: 8
 summary: The "non-dual" school of Hindu philosophy teaching that the individual self (Atman) and ultimate reality (Brahman) are one and the same.
 connections:

--- a/data/traditions/bhakti.mdx
+++ b/data/traditions/bhakti.mdx
@@ -1,7 +1,7 @@
 ---
 name: Bhakti
 slug: bhakti
-family: Hindu
+family: Vedic-Yogic
 origin_century: 6
 summary: The devotional path of Hinduism emphasizing love, surrender, and personal relationship with the divine as the primary means of spiritual realization.
 connections:

--- a/data/traditions/classical-yoga.mdx
+++ b/data/traditions/classical-yoga.mdx
@@ -1,7 +1,7 @@
 ---
 name: Classical Yoga (Patanjali)
 slug: classical-yoga
-family: Hindu
+family: Vedic-Yogic
 origin_century: -2
 summary: The systematic path of meditation and self-discipline codified by Patanjali in the Yoga Sutras, outlining eight limbs from ethical conduct to meditative absorption.
 connections:

--- a/data/traditions/kashmir-shaivism.mdx
+++ b/data/traditions/kashmir-shaivism.mdx
@@ -1,7 +1,7 @@
 ---
 name: Kashmir Shaivism
 slug: kashmir-shaivism
-family: Hindu
+family: Vedic-Yogic
 origin_century: 9
 summary: A non-dual tantric tradition from medieval Kashmir teaching that all of reality is the creative expression of a single divine consciousness (Shiva).
 connections:

--- a/data/traditions/tantra.mdx
+++ b/data/traditions/tantra.mdx
@@ -1,7 +1,7 @@
 ---
 name: Tantra
 slug: tantra
-family: Hindu
+family: Vedic-Yogic
 origin_century: 5
 summary: A broad family of esoteric traditions using ritual, embodiment, and the transformation of ordinary experience as paths to liberation.
 connections:

--- a/data/traditions/vedanta.mdx
+++ b/data/traditions/vedanta.mdx
@@ -1,7 +1,7 @@
 ---
 name: Vedanta
 slug: vedanta
-family: Hindu
+family: Vedic-Yogic
 summary: The philosophical tradition interpreting the Upanishads — exploring the nature of Brahman and the self.
 origin_century: -4
 connections:

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import { PageLayout } from "@/components/page-layout";
 import { SITE_URL } from "@/lib/seo";
 
 const description =
-  "An editorial guide to contemplative traditions, teachers, and meditation centers. Explore how Buddhist, Hindu, Christian, Sufi, and secular paths connect.";
+  "An editorial guide to contemplative traditions, teachers, and meditation centers. Explore how Buddhist, Vedic-Yogic, Christian, Sufi, and secular paths connect.";
 
 export const metadata: Metadata = {
   title: { absolute: "Lineage — A Map of Contemplative Traditions" },

--- a/src/app/traditions/__tests__/traditions.test.ts
+++ b/src/app/traditions/__tests__/traditions.test.ts
@@ -14,7 +14,7 @@ describe("Tradition pages data", () => {
     const tradition = getTradition("advaita-vedanta");
     expect(tradition).toBeDefined();
     expect(tradition!.name).toBe("Advaita Vedanta");
-    expect(tradition!.family).toBe("Hindu");
+    expect(tradition!.family).toBe("Vedic-Yogic");
     expect(tradition!.summary.length).toBeGreaterThan(0);
     expect(tradition!.content).toContain("# Advaita Vedanta");
   });
@@ -51,6 +51,6 @@ describe("Tradition pages data", () => {
     }
     expect(grouped.size).toBeGreaterThanOrEqual(2);
     expect(grouped.has("Buddhist")).toBe(true);
-    expect(grouped.has("Hindu")).toBe(true);
+    expect(grouped.has("Vedic-Yogic")).toBe(true);
   });
 });

--- a/src/app/traditions/page.tsx
+++ b/src/app/traditions/page.tsx
@@ -11,16 +11,16 @@ import { SITE_URL } from "@/lib/seo";
 export const metadata: Metadata = {
   title: "Traditions",
   description:
-    "Explore contemplative traditions — Buddhist, Hindu, Taoist, Christian, Islamic, and more.",
+    "Explore contemplative traditions — Buddhist, Vedic-Yogic, Taoist, Christian, Islamic, and more.",
   openGraph: {
     title: "Traditions",
     description:
-      "Explore contemplative traditions — Buddhist, Hindu, Taoist, Christian, Islamic, and more.",
+      "Explore contemplative traditions — Buddhist, Vedic-Yogic, Taoist, Christian, Islamic, and more.",
     url: `${SITE_URL}/traditions`,
   },
 };
 
-const familyOrder = ["Buddhist", "Hindu", "Taoist", "Christian Contemplative", "Islamic Contemplative", "Modern Secular", "Other"];
+const familyOrder = ["Buddhist", "Vedic-Yogic", "Taoist", "Christian Contemplative", "Islamic Contemplative", "Modern Secular", "Other"];
 
 function groupByFamily(traditions: ParsedTradition[]) {
   const grouped = new Map<string, ParsedTradition[]>();

--- a/src/components/tradition-map/__tests__/family-filter.test.tsx
+++ b/src/components/tradition-map/__tests__/family-filter.test.tsx
@@ -5,7 +5,7 @@ import type { TraditionFamily } from "@/lib/types";
 
 const ALL_FAMILIES: TraditionFamily[] = [
   "Buddhist",
-  "Hindu",
+  "Vedic-Yogic",
   "Taoist",
   "Christian Contemplative",
   "Islamic Contemplative",
@@ -28,7 +28,7 @@ describe("FamilyFilter", () => {
   });
 
   it("marks active families with aria-pressed=true", () => {
-    const active = new Set<TraditionFamily>(["Buddhist", "Hindu"]);
+    const active = new Set<TraditionFamily>(["Buddhist", "Vedic-Yogic"]);
     render(
       <FamilyFilter families={ALL_FAMILIES} activeFamilies={active} onToggle={() => {}} />
     );

--- a/src/components/tradition-map/__tests__/tradition-map.test.tsx
+++ b/src/components/tradition-map/__tests__/tradition-map.test.tsx
@@ -70,8 +70,8 @@ const sampleTraditions: TraditionInput[] = [
   {
     name: "Advaita Vedanta",
     slug: "advaita-vedanta",
-    family: "Hindu",
-    summary: "Non-dual Hindu philosophy",
+    family: "Vedic-Yogic",
+    summary: "Non-dual Vedic-Yogic philosophy",
     origin_century: 8,
     connections: [],
   },
@@ -94,7 +94,7 @@ describe("TraditionMap", () => {
     const buttons = filterGroup.querySelectorAll("button");
     expect(buttons).toHaveLength(2);
     expect(buttons[0]).toHaveTextContent("Buddhist");
-    expect(buttons[1]).toHaveTextContent("Hindu");
+    expect(buttons[1]).toHaveTextContent("Vedic-Yogic");
   });
 
   it("renders connection legend", () => {
@@ -109,10 +109,10 @@ describe("TraditionMap", () => {
     const filterGroup = screen.getByRole("group", {
       name: /filter by tradition family/i,
     });
-    const hinduButton = filterGroup.querySelector("button:last-child")!;
-    expect(hinduButton).toHaveAttribute("aria-pressed", "true");
-    fireEvent.click(hinduButton);
-    expect(hinduButton).toHaveAttribute("aria-pressed", "false");
+    const vedicYogicButton = filterGroup.querySelector("button:last-child")!;
+    expect(vedicYogicButton).toHaveAttribute("aria-pressed", "true");
+    fireEvent.click(vedicYogicButton);
+    expect(vedicYogicButton).toHaveAttribute("aria-pressed", "false");
   });
 
   it("has accessible SVG label", () => {

--- a/src/components/tradition-map/__tests__/use-map-interaction.test.ts
+++ b/src/components/tradition-map/__tests__/use-map-interaction.test.ts
@@ -13,7 +13,7 @@ const testGraph: TraditionGraph = {
   nodes: [
     { slug: "zen", name: "Zen", family: "Buddhist", summary: "Zen Buddhism", originCentury: 6 },
     { slug: "theravada", name: "Theravada", family: "Buddhist", summary: "Way of the Elders", originCentury: -3 },
-    { slug: "advaita", name: "Advaita", family: "Hindu", summary: "Non-dual", originCentury: 8 },
+    { slug: "advaita", name: "Advaita", family: "Vedic-Yogic", summary: "Non-dual", originCentury: 8 },
   ],
   edges: [
     { source: "zen", target: "theravada", connectionType: "related_to", description: "Both meditate", strength: 1 },
@@ -24,8 +24,8 @@ const mixedEdgeGraph: TraditionGraph = {
   nodes: [
     { slug: "zen", name: "Zen", family: "Buddhist", summary: "Zen Buddhism", originCentury: 6 },
     { slug: "theravada", name: "Theravada", family: "Buddhist", summary: "Way of the Elders", originCentury: -3 },
-    { slug: "advaita", name: "Advaita", family: "Hindu", summary: "Non-dual", originCentury: 8 },
-    { slug: "yoga", name: "Yoga", family: "Hindu", summary: "Yoga tradition", originCentury: -5 },
+    { slug: "advaita", name: "Advaita", family: "Vedic-Yogic", summary: "Non-dual", originCentury: 8 },
+    { slug: "yoga", name: "Yoga", family: "Vedic-Yogic", summary: "Yoga tradition", originCentury: -5 },
   ],
   edges: [
     { source: "zen", target: "theravada", connectionType: "branch_of", description: "Branch", strength: 2 },

--- a/src/lib/__tests__/compute-layout.test.ts
+++ b/src/lib/__tests__/compute-layout.test.ts
@@ -127,7 +127,7 @@ describe("computeLayout", () => {
   });
 
   it("separates different-family clusters on X axis", () => {
-    // Buddhist cluster (connected) and Hindu cluster (connected), no cross-family edges
+    // Buddhist cluster (connected) and Vedic-Yogic cluster (connected), no cross-family edges
     const traditions: ParsedTradition[] = [
       makeTradition({
         slug: "b1",
@@ -144,13 +144,13 @@ describe("computeLayout", () => {
       makeTradition({
         slug: "h1",
         origin_century: 5,
-        family: "Hindu",
+        family: "Vedic-Yogic",
         connections: [{ tradition_slug: "h2", connection_type: "branch_of", strength: 3, description: "" }],
       }),
       makeTradition({
         slug: "h2",
         origin_century: 5,
-        family: "Hindu",
+        family: "Vedic-Yogic",
         connections: [{ tradition_slug: "h1", connection_type: "branch_of", strength: 3, description: "" }],
       }),
     ];
@@ -158,9 +158,9 @@ describe("computeLayout", () => {
 
     // Within-family distance should be smaller than between-family distance
     const buddhistCenterX = (layout["b1"].x + layout["b2"].x) / 2;
-    const hinduCenterX = (layout["h1"].x + layout["h2"].x) / 2;
+    const vedicYogicCenterX = (layout["h1"].x + layout["h2"].x) / 2;
     const withinBuddhist = Math.abs(layout["b1"].x - layout["b2"].x);
-    const betweenClusters = Math.abs(buddhistCenterX - hinduCenterX);
+    const betweenClusters = Math.abs(buddhistCenterX - vedicYogicCenterX);
 
     // The between-cluster distance should exceed within-cluster distance
     expect(betweenClusters).toBeGreaterThan(withinBuddhist);
@@ -197,7 +197,7 @@ describe("computeLayout", () => {
       makeTradition({
         slug: "advaita-vedanta",
         origin_century: 8,
-        family: "Hindu",
+        family: "Vedic-Yogic",
         connections: [
           { tradition_slug: "kashmir-shaivism", connection_type: "related_to", strength: 3, description: "" },
         ],
@@ -205,7 +205,7 @@ describe("computeLayout", () => {
       makeTradition({
         slug: "kashmir-shaivism",
         origin_century: 9,
-        family: "Hindu",
+        family: "Vedic-Yogic",
         connections: [
           { tradition_slug: "advaita-vedanta", connection_type: "diverged_from", strength: 3, description: "" },
         ],

--- a/src/lib/__tests__/data.test.ts
+++ b/src/lib/__tests__/data.test.ts
@@ -86,7 +86,7 @@ describe("getTradition", () => {
     const tradition = getTradition("advaita-vedanta");
     expect(tradition).toBeDefined();
     expect(tradition!.name).toBe("Advaita Vedanta");
-    expect(tradition!.family).toBe("Hindu");
+    expect(tradition!.family).toBe("Vedic-Yogic");
     expect(tradition!.content).toContain("# Advaita Vedanta");
     expect(tradition!.connections.length).toBeGreaterThan(0);
   });

--- a/src/lib/__tests__/seed-data.test.ts
+++ b/src/lib/__tests__/seed-data.test.ts
@@ -7,7 +7,7 @@ import type { Teacher, Center, TraditionFamily, ConnectionType } from "../types"
 const DATA_DIR = join(process.cwd(), "data");
 const VALID_FAMILIES: TraditionFamily[] = [
   "Buddhist",
-  "Hindu",
+  "Vedic-Yogic",
   "Taoist",
   "Christian Contemplative",
   "Islamic Contemplative",

--- a/src/lib/__tests__/tradition-graph.test.ts
+++ b/src/lib/__tests__/tradition-graph.test.ts
@@ -43,26 +43,26 @@ const sampleTraditions: TraditionInput[] = [
   {
     name: "Advaita Vedanta",
     slug: "advaita-vedanta",
-    family: "Hindu",
-    summary: "Non-dual Hindu philosophy",
+    family: "Vedic-Yogic",
+    summary: "Non-dual Vedic-Yogic philosophy",
     connections: [
       {
         tradition_slug: "kashmir-shaivism",
         connection_type: "related_to",
-        description: "Both non-dual Hindu traditions",
+        description: "Both non-dual Vedic-Yogic traditions",
       },
     ],
   },
   {
     name: "Kashmir Shaivism",
     slug: "kashmir-shaivism",
-    family: "Hindu",
+    family: "Vedic-Yogic",
     summary: "Non-dual tantric tradition",
     connections: [
       {
         tradition_slug: "advaita-vedanta",
         connection_type: "related_to",
-        description: "Both non-dual Hindu traditions",
+        description: "Both non-dual Vedic-Yogic traditions",
       },
     ],
   },
@@ -126,7 +126,7 @@ describe("buildTraditionGraph", () => {
     const zen = graph.nodes.find((n) => n.slug === "zen");
     expect(zen?.family).toBe("Buddhist");
     const advaita = graph.nodes.find((n) => n.slug === "advaita-vedanta");
-    expect(advaita?.family).toBe("Hindu");
+    expect(advaita?.family).toBe("Vedic-Yogic");
   });
 });
 
@@ -134,7 +134,7 @@ describe("getFamilies", () => {
   it("returns unique families", () => {
     const graph = buildTraditionGraph(sampleTraditions);
     const families = getFamilies(graph);
-    expect(families.sort()).toEqual(["Buddhist", "Hindu"]);
+    expect(families.sort()).toEqual(["Buddhist", "Vedic-Yogic"]);
   });
 });
 

--- a/src/lib/tradition-graph.ts
+++ b/src/lib/tradition-graph.ts
@@ -38,7 +38,7 @@ export const FAMILY_COLORS: Record<TraditionFamily, { fill: string; stroke: stri
     text: "#6b4c2a",
     bg: "#f5ead8",
   },
-  Hindu: {
+  "Vedic-Yogic": {
     fill: "#9e4a3a",     // terracotta
     stroke: "#7d3a2e",
     text: "#5a2a20",

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,6 +1,6 @@
 export type TraditionFamily =
   | "Buddhist"
-  | "Hindu"
+  | "Vedic-Yogic"
   | "Taoist"
   | "Christian Contemplative"
   | "Islamic Contemplative"


### PR DESCRIPTION
## Summary
- Renames the `TraditionFamily` type value from "Hindu" to "Vedic-Yogic"
- Updates all 6 tradition MDX files (Vedanta, Advaita Vedanta, Classical Yoga, Kashmir Shaivism, Tantra, Bhakti)
- Updates graph colors, tests, and metadata descriptions
- Regenerates map layout
- Editorial prose in MDX content still uses "Hindu/Hinduism" where historically accurate

## Why
"Hindu" is a colonial-era umbrella term. "Vedic-Yogic" captures both the scriptural (Vedic) and practice (Yogic) dimensions of these traditions without being reductive.

## Test plan
- [ ] Map page shows "VEDIC-YOGIC" filter pill instead of "HINDU"
- [ ] Masters page family dropdown shows "Vedic-Yogic"
- [ ] All 6 traditions still grouped correctly
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)