### PR TITLE
Fix popover z-ordering on tradition map

### DIFF
--- a/src/components/tradition-map/map-canvas.tsx
+++ b/src/components/tradition-map/map-canvas.tsx
@@ -3,6 +3,7 @@ import type { TraditionGraph } from "@/lib/tradition-graph";
 import type { ConnectionType } from "@/lib/types";
 import { yearToY, type LayoutMap } from "@/lib/compute-layout";
 import { MapEdge } from "./map-edge";
+import { MapEdgeTooltip } from "./map-edge-tooltip";
 import { MapNode } from "./map-node";
 import { MapTimeAxis } from "./map-time-axis";
 import type { ResourceMap } from "./tradition-map";
@@ -90,9 +91,14 @@ export function MapCanvas({
   const xMin = Math.min(...xValues);
   const xMax = Math.max(...xValues);
 
+  // Find the hovered edge for tooltip rendering
+  const hoveredEdge = hoveredEdgeKey
+    ? graph.edges.find((e) => `${e.source}--${e.target}` === hoveredEdgeKey)
+    : null;
+
   return (
     <>
-      {/* Time axis with era labels and grid lines — rendered first (behind everything) */}
+      {/* Layer 1: Time axis (behind everything) */}
       <MapTimeAxis
         x={xMin - 110}
         yMin={yMin - 20}
@@ -102,7 +108,7 @@ export function MapCanvas({
         xMax={xMax + 60}
       />
 
-      {/* Edges */}
+      {/* Layer 2: Edge paths */}
       {graph.edges.map((edge) => {
         const sourcePos = layout[edge.source];
         const targetPos = layout[edge.target];
@@ -117,17 +123,13 @@ export function MapCanvas({
             highlighted={isEdgeHighlighted(edge.source, edge.target)}
             dimmed={isEdgeDimmed(edge.source, edge.target)}
             hidden={isEdgeHidden(edge.source, edge.target, edge.connectionType)}
-            showTooltip={hoveredEdgeKey === edgeKey}
             onEdgeHover={onEdgeHover}
-            onTooltipEnter={onTooltipEnter}
-            onTooltipLeave={onTooltipLeave}
             entranceDelay={edgeDelays.get(edgeKey) ?? 0}
-            resourceMap={resourceMap}
           />
         );
       })}
 
-      {/* Nodes */}
+      {/* Layer 3: Nodes */}
       {graph.nodes.map((node) => {
         const pos = layout[node.slug];
         if (!pos) return null;
@@ -146,6 +148,23 @@ export function MapCanvas({
           />
         );
       })}
+
+      {/* Layer 4: Tooltips/popovers (topmost) */}
+      {hoveredEdge && (() => {
+        const sourcePos = layout[hoveredEdge.source];
+        const targetPos = layout[hoveredEdge.target];
+        if (!sourcePos || !targetPos) return null;
+        return (
+          <MapEdgeTooltip
+            edge={hoveredEdge}
+            sourcePos={sourcePos}
+            targetPos={targetPos}
+            onTooltipEnter={onTooltipEnter}
+            onTooltipLeave={onTooltipLeave}
+            resourceMap={resourceMap}
+          />
+        );
+      })()}
     </>
   );
 }

--- a/src/components/tradition-map/map-edge-tooltip.tsx
+++ b/src/components/tradition-map/map-edge-tooltip.tsx
@@ -1,0 +1,94 @@
+import type { GraphEdge } from "@/lib/tradition-graph";
+import type { ResourceMap } from "./tradition-map";
+
+interface MapEdgeTooltipProps {
+  edge: GraphEdge;
+  sourcePos: { x: number; y: number };
+  targetPos: { x: number; y: number };
+  onTooltipEnter: () => void;
+  onTooltipLeave: () => void;
+  resourceMap: ResourceMap;
+}
+
+/**
+ * Edge tooltip — rendered in a separate SVG layer above nodes
+ * for correct z-ordering.
+ */
+export function MapEdgeTooltip({
+  edge,
+  sourcePos,
+  targetPos,
+  onTooltipEnter,
+  onTooltipLeave,
+  resourceMap,
+}: MapEdgeTooltipProps) {
+  if (!edge.description) return null;
+
+  const midX = (sourcePos.x + targetPos.x) / 2;
+  const midY = (sourcePos.y + targetPos.y) / 2;
+
+  const resolvedSources = (edge.sources ?? [])
+    .map((slug) => resourceMap[slug])
+    .filter(Boolean);
+  const hasSource = resolvedSources.length > 0;
+
+  return (
+    <foreignObject
+      x={midX - 160}
+      y={midY - 80}
+      width={320}
+      height={hasSource ? 140 : 100}
+      style={{ overflow: "visible" }}
+    >
+      <div
+        onMouseEnter={onTooltipEnter}
+        onMouseLeave={onTooltipLeave}
+        style={{
+          background: "#f5f0eb",
+          border: "1px solid #d4cdc4",
+          borderRadius: 6,
+          padding: "8px 12px",
+          fontSize: 11,
+          fontFamily: "system-ui, sans-serif",
+          color: "#6a6560",
+          lineHeight: 1.5,
+          boxShadow: "0 1px 4px rgba(0,0,0,0.08)",
+          maxWidth: 320,
+        }}
+      >
+        <div>{edge.description}</div>
+        {hasSource && (
+          <div
+            style={{
+              marginTop: 4,
+              paddingTop: 4,
+              borderTop: "1px solid #d4cdc4",
+              fontSize: 10,
+              color: "#8a8580",
+            }}
+          >
+            <span style={{ fontStyle: "italic" }}>Source: </span>
+            {resolvedSources.map((r, i) => (
+              <span key={i}>
+                {i > 0 && ", "}
+                <a
+                  href={r.url}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  style={{
+                    color: "#9e4a3a",
+                    textDecoration: "underline",
+                    textDecorationStyle: "dotted",
+                    textUnderlineOffset: "2px",
+                  }}
+                >
+                  {r.title}
+                </a>
+              </span>
+            ))}
+          </div>
+        )}
+      </div>
+    </foreignObject>
+  );
+}

--- a/src/components/tradition-map/map-edge.tsx
+++ b/src/components/tradition-map/map-edge.tsx
@@ -1,5 +1,4 @@
 import type { GraphEdge } from "@/lib/tradition-graph";
-import type { ResourceMap } from "./tradition-map";
 
 interface MapEdgeProps {
   edge: GraphEdge;
@@ -8,22 +7,15 @@ interface MapEdgeProps {
   highlighted: boolean;
   dimmed: boolean;
   hidden: boolean;
-  showTooltip: boolean;
   onEdgeHover: (source: string | null, target: string | null) => void;
-  onTooltipEnter: () => void;
-  onTooltipLeave: () => void;
   entranceDelay?: number;
-  resourceMap?: ResourceMap;
 }
 
 /**
  * MapEdge — bezier curve connection between traditions.
  *
- * Matches Figma's TimelineMap: vertical S-curves using cubic bezier
- * with control points at the vertical midpoint.
- * - branch_of: solid line, rgba(180, 140, 100)
- * - influenced_by: dashed (6 4), rgba(140, 140, 160)
- * - related_to / diverged_from: dotted, warm gray
+ * Renders only the path and hit area. Tooltips are rendered separately
+ * in MapCanvas as a top-level layer for correct z-ordering.
  */
 export function MapEdge({
   edge,
@@ -32,12 +24,8 @@ export function MapEdge({
   highlighted,
   dimmed,
   hidden,
-  showTooltip,
   onEdgeHover,
-  onTooltipEnter,
-  onTooltipLeave,
   entranceDelay = 0,
-  resourceMap = {},
 }: MapEdgeProps) {
   if (hidden) return null;
 
@@ -46,13 +34,10 @@ export function MapEdge({
   const strokeWidth = highlighted ? 2.5 : 1.5;
   const dashArray = isBranch ? undefined : "6 4";
 
-  // Figma-style vertical bezier: control points at midY
   const midY = (sourcePos.y + targetPos.y) / 2;
   const pathD = `M ${sourcePos.x} ${sourcePos.y} C ${sourcePos.x} ${midY}, ${targetPos.x} ${midY}, ${targetPos.x} ${targetPos.y}`;
 
   const opacity = dimmed ? 0.12 : highlighted ? 1 : 0.5;
-
-  const midX = (sourcePos.x + targetPos.x) / 2;
 
   return (
     <g
@@ -63,7 +48,6 @@ export function MapEdge({
       }}
       className="map-edge-entrance"
     >
-      {/* Invisible wider hit area for hover */}
       <path
         d={pathD}
         fill="none"
@@ -83,73 +67,6 @@ export function MapEdge({
         strokeLinecap="round"
         style={{ transition: "stroke-width 0.2s ease", pointerEvents: "none" }}
       />
-
-      {/* Edge tooltip */}
-      {showTooltip && edge.description && (() => {
-        const resolvedSources = (edge.sources ?? [])
-          .map((slug) => resourceMap[slug])
-          .filter(Boolean);
-        const hasSource = resolvedSources.length > 0;
-        return (
-          <foreignObject
-            x={midX - 160}
-            y={midY - 80}
-            width={320}
-            height={hasSource ? 140 : 100}
-            style={{ overflow: "visible" }}
-          >
-            <div
-              onMouseEnter={onTooltipEnter}
-              onMouseLeave={onTooltipLeave}
-              style={{
-                background: "#f5f0eb",
-                border: "1px solid #d4cdc4",
-                borderRadius: 6,
-                padding: "10px 14px",
-                fontSize: 12,
-                fontFamily: "Georgia, serif",
-                color: "#4a4540",
-                lineHeight: 1.5,
-                boxShadow: "0 2px 8px rgba(0,0,0,0.12)",
-                maxWidth: 320,
-              }}
-            >
-              <div>{edge.description}</div>
-              {hasSource && (
-                <div
-                  style={{
-                    marginTop: 6,
-                    paddingTop: 6,
-                    borderTop: "1px solid #d4cdc4",
-                    fontSize: 11,
-                    color: "#7a7570",
-                  }}
-                >
-                  <span style={{ fontStyle: "italic" }}>Source: </span>
-                  {resolvedSources.map((r, i) => (
-                    <span key={i}>
-                      {i > 0 && ", "}
-                      <a
-                        href={r.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        style={{
-                          color: "#9e4a3a",
-                          textDecoration: "underline",
-                          textDecorationStyle: "dotted",
-                          textUnderlineOffset: "2px",
-                        }}
-                      >
-                        {r.title}
-                      </a>
-                    </span>
-                  ))}
-                </div>
-              )}
-            </div>
-          </foreignObject>
-        );
-      })()}
     </g>
   );
 }


### PR DESCRIPTION
Closes #82

## Summary
- Extract tooltip from `MapEdge` into new `MapEdgeTooltip` component
- Render tooltips as Layer 4 (topmost) in `MapCanvas`, after: time axis → edges → nodes
- Edge tooltips are now visually lighter (11px font, less padding, subtler shadow) to be subordinate to future node popovers

## Test plan
- [ ] Hover an edge → tooltip renders above node labels and edge lines
- [ ] Tooltip hover interaction still works (mouse can enter tooltip without it disappearing)
- [ ] No visual regression when no tooltip is shown
- [ ] Edge hover hit areas still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)