### PR TITLE
Lighten edge tooltips and add source count badge

### DIFF
--- a/src/components/tradition-map/map-edge-tooltip.tsx
+++ b/src/components/tradition-map/map-edge-tooltip.tsx
@@ -44,16 +44,16 @@ export function MapEdgeTooltip({
         onMouseEnter={onTooltipEnter}
         onMouseLeave={onTooltipLeave}
         style={{
-          background: "#f5f0eb",
-          border: "1px solid #d4cdc4",
-          borderRadius: 6,
-          padding: "8px 12px",
-          fontSize: 11,
+          background: "rgba(245, 240, 235, 0.92)",
+          border: "1px solid #e0dad3",
+          borderRadius: 4,
+          padding: "5px 9px",
+          fontSize: 10,
           fontFamily: "system-ui, sans-serif",
-          color: "#6a6560",
-          lineHeight: 1.5,
-          boxShadow: "0 1px 4px rgba(0,0,0,0.08)",
-          maxWidth: 320,
+          color: "#8a8580",
+          lineHeight: 1.4,
+          boxShadow: "0 1px 3px rgba(0,0,0,0.05)",
+          maxWidth: 280,
         }}
       >
         <div>{edge.description}</div>
@@ -63,7 +63,7 @@ export function MapEdgeTooltip({
               marginTop: 4,
               paddingTop: 4,
               borderTop: "1px solid #d4cdc4",
-              fontSize: 10,
+              fontSize: 9,
               color: "#8a8580",
             }}
           >

--- a/src/components/tradition-map/tradition-map.tsx
+++ b/src/components/tradition-map/tradition-map.tsx
@@ -264,12 +264,17 @@ export function TraditionMap({ traditions, resourceMap = {} }: TraditionMapProps
         {mapResources.length > 0 && (
           <aside className="w-full lg:w-[320px] lg:shrink-0">
             <div className="lg:sticky lg:top-20 overflow-y-auto max-h-[800px]">
-              {/* Header with optional filter label */}
+              {/* Header with optional filter label and count */}
               <div className="flex items-baseline justify-between mb-2">
                 <h2 className="font-serif text-xl font-normal">
                   {selectedTraditionName
                     ? `Sources for ${selectedTraditionName}`
                     : "Sources"}
+                  {filteredResources.length !== mapResources.length && (
+                    <span className="text-sm font-sans font-normal text-[#999] ml-2">
+                      ({filteredResources.length} of {mapResources.length})
+                    </span>
+                  )}
                 </h2>
                 {selectedSlug && (
                   <button


### PR DESCRIPTION
## Summary
- **#90**: Edge tooltips now visually subordinate to node popovers — smaller font (10px→10px, sources 9px), less padding (5px 9px), semi-transparent background, lighter shadow
- **#91**: Source count badge "(N of M)" appears in sidebar header when filtered by tradition or family pills; hidden when showing all sources

Closes #90
Closes #91

## Test plan
- [ ] Hover an edge → tooltip is noticeably lighter/smaller than node popovers
- [ ] Click a tradition → sidebar shows "Sources for X (N of M)"
- [ ] Toggle a family pill off → count updates, badge shows filtered count
- [ ] Show all sources → no count badge
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)