### PR TITLE
Show node popovers on hover instead of only on click

### DIFF
--- a/src/components/tradition-map/map-canvas.tsx
+++ b/src/components/tradition-map/map-canvas.tsx
@@ -26,7 +26,7 @@ interface MapCanvasProps {
   isEdgeDimmed: (source: string, target: string) => boolean;
   isEdgeHidden: (source: string, target: string, connectionType: ConnectionType) => boolean;
   resourceMap?: ResourceMap;
-  selectedSlug: string | null;
+  activeSlug: string | null;
   onNodeDeselect: () => void;
 }
 
@@ -47,7 +47,7 @@ export function MapCanvas({
   isEdgeDimmed,
   isEdgeHidden,
   resourceMap = {},
-  selectedSlug,
+  activeSlug,
   onNodeDeselect,
 }: MapCanvasProps) {
   // Entrance animation delays based on Y position
@@ -171,9 +171,9 @@ export function MapCanvas({
         );
       })()}
 
-      {/* Layer 5: Node popover (topmost) */}
-      {selectedSlug && (() => {
-        const node = graph.nodes.find((n) => n.slug === selectedSlug);
+      {/* Layer 5: Node popover (topmost) — shows on hover or selection */}
+      {activeSlug && (() => {
+        const node = graph.nodes.find((n) => n.slug === activeSlug);
         const pos = node ? layout[node.slug] : null;
         if (!node || !pos) return null;
         return (

--- a/src/components/tradition-map/tradition-map.tsx
+++ b/src/components/tradition-map/tradition-map.tsx
@@ -250,7 +250,7 @@ export function TraditionMap({ traditions, resourceMap = {} }: TraditionMapProps
                   isEdgeHighlighted={interaction.isEdgeHighlighted}
                   isEdgeDimmed={interaction.isEdgeDimmed}
                   isEdgeHidden={interaction.isEdgeHidden}
-                  selectedSlug={selectedSlug}
+                  activeSlug={interaction.activeSlug}
                   onNodeDeselect={handleBackgroundTap}
                 />
               </g>


### PR DESCRIPTION
## Summary
- Popover now appears on mouseover (not just click) for easier discovery
- Uses `activeSlug` (hoveredSlug ?? selectedSlug) instead of just `selectedSlug`
- Click still selects for sidebar filtering — popover persists after hover ends

## Test plan
- [ ] Hover a tradition node → popover appears immediately
- [ ] Move mouse away → popover disappears
- [ ] Click a node → popover stays, sidebar filters
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)