### PR TITLE
Fix broken bookshop.org links with search URLs

### DIFF
--- a/data/resources/a-brief-introduction-to-jainism-and-sikhism.json
+++ b/data/resources/a-brief-introduction-to-jainism-and-sikhism.json
@@ -2,7 +2,7 @@
   "title": "A Brief Introduction to Jainism and Sikhism",
   "slug": "a-brief-introduction-to-jainism-and-sikhism",
   "type": "book",
-  "url": "https://bookshop.org/p/books/a-brief-introduction-to-jainism-and-sikhism-christopher-partridge/11572546?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=A%20Brief%20Introduction%20to%20Jainism%20and%20Sikhism%20Christopher%20Partridge&aid=LINEAGE",
   "author": "Christopher Partridge",
   "year": 2018,
   "description": "An accessible overview of Jainism covering its history, core doctrines of non-violence and liberation, and its continuing relevance in the modern world.",

--- a/data/resources/a-path-with-heart.json
+++ b/data/resources/a-path-with-heart.json
@@ -2,7 +2,7 @@
   "title": "A Path with Heart",
   "slug": "a-path-with-heart",
   "type": "book",
-  "url": "https://bookshop.org/p/books/a-path-with-heart-a-guide-through-the-perils-and-promises-of-spiritual-life-jack-kornfield/10788678?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=A%20Path%20with%20Heart%20Jack%20Kornfield&aid=LINEAGE",
   "author": "Jack Kornfield",
   "year": 1993,
   "description": "A guide through the perils and promises of spiritual life, offering practical wisdom on meditation and the integration of spiritual practice into daily life.",

--- a/data/resources/a-testament-of-devotion.json
+++ b/data/resources/a-testament-of-devotion.json
@@ -2,7 +2,7 @@
   "title": "A Testament of Devotion",
   "slug": "a-testament-of-devotion",
   "type": "book",
-  "url": "https://bookshop.org/p/books/a-testament-of-devotion-thomas-r-kelly/7944644?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=A%20Testament%20of%20Devotion%20Thomas%20R.%20Kelly&aid=LINEAGE",
   "author": "Thomas R. Kelly",
   "year": 1941,
   "description": "A Quaker spiritual classic of five essays urging readers to center their lives on God's presence and discover the peace of the inner spiritual journey.",

--- a/data/resources/awakening-buddha-within.json
+++ b/data/resources/awakening-buddha-within.json
@@ -2,7 +2,7 @@
   "title": "Awakening the Buddha Within",
   "slug": "awakening-buddha-within",
   "type": "book",
-  "url": "https://bookshop.org/p/books/awakening-the-buddha-within-tibetan-wisdom-for-the-western-world-lama-surya-das/6693556?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Awakening%20the%20Buddha%20Within%20Lama%20Surya%20Das&aid=LINEAGE",
   "author": "Lama Surya Das",
   "year": 1997,
   "description": "Accessible guide to Tibetan Buddhist practice by an American-born lama, integrating Dzogchen teachings with Western sensibilities.",

--- a/data/resources/awakening-of-the-heart.json
+++ b/data/resources/awakening-of-the-heart.json
@@ -2,7 +2,7 @@
   "title": "Awakening of the Heart",
   "slug": "awakening-of-the-heart",
   "type": "book",
-  "url": "https://bookshop.org/p/books/awakening-of-the-heart-essential-buddhist-sutras-and-commentaries-thich-nhat-hanh/6693559?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Awakening%20of%20the%20Heart%20Thich%20Nhat%20Hanh&aid=LINEAGE",
   "author": "Thich Nhat Hanh",
   "year": 2012,
   "description": "Collection of essential Buddhist sutras with commentary by Thich Nhat Hanh, presenting foundational Mahayana teachings in accessible language.",

--- a/data/resources/be-as-you-are.json
+++ b/data/resources/be-as-you-are.json
@@ -2,7 +2,7 @@
   "title": "Be As You Are: The Teachings of Sri Ramana Maharshi",
   "slug": "be-as-you-are",
   "type": "book",
-  "url": "https://bookshop.org/p/books/be-as-you-are-the-teachings-of-sri-ramana-maharshi-ramana-maharshi/6693488?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Be%20As%20You%20Are%3A%20The%20Teachings%20of%20Sri%20Ramana%20Maharshi%20David%20Godman&aid=LINEAGE",
   "author": "David Godman",
   "year": 1985,
   "description": "Thematically organized compilation of Ramana Maharshi's teachings on self-inquiry, edited by scholar David Godman.",

--- a/data/resources/be-here-now.json
+++ b/data/resources/be-here-now.json
@@ -2,7 +2,7 @@
   "title": "Be Here Now",
   "slug": "be-here-now",
   "type": "book",
-  "url": "https://bookshop.org/p/books/be-here-now-ram-dass/6556749?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Be%20Here%20Now%20Ram%20Dass&aid=LINEAGE",
   "author": "Ram Dass",
   "year": 1971,
   "description": "A countercultural classic that launched the mindfulness revolution, chronicling Richard Alpert's transformation into Ram Dass and introducing Eastern spirituality to the West.",

--- a/data/resources/bhagavad-gita.json
+++ b/data/resources/bhagavad-gita.json
@@ -2,7 +2,7 @@
   "title": "The Bhagavad Gita",
   "slug": "bhagavad-gita",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-bhagavad-gita-eknath-easwaran/6693574?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Bhagavad%20Gita%20Eknath%20Easwaran&aid=LINEAGE",
   "author": "Eknath Easwaran",
   "year": 1985,
   "description": "Easwaran's acclaimed translation of the Hindu scripture exploring karma yoga, bhakti yoga, and jnana yoga through the dialogue between Krishna and Arjuna.",

--- a/data/resources/bhakti-yoga.json
+++ b/data/resources/bhakti-yoga.json
@@ -2,7 +2,7 @@
   "title": "Bhakti Yoga: Tales and Teachings from the Bhagavata Purana",
   "slug": "bhakti-yoga",
   "type": "book",
-  "url": "https://bookshop.org/p/books/bhakti-yoga-tales-and-teachings-from-the-bhagavata-purana-edwin-f-bryant/8047746?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Bhakti%20Yoga%3A%20Tales%20and%20Teachings%20from%20the%20Bhagavata%20Purana%20Edwin%20F.%20Bryant&aid=LINEAGE",
   "author": "Edwin F. Bryant",
   "year": 2017,
   "description": "An accessible exploration of bhakti devotional practice through tales and teachings from the Bhagavata Purana, a foundational text of the bhakti tradition.",

--- a/data/resources/breath-by-breath.json
+++ b/data/resources/breath-by-breath.json
@@ -2,7 +2,7 @@
   "title": "Breath by Breath",
   "slug": "breath-by-breath",
   "type": "book",
-  "url": "https://bookshop.org/p/books/breath-by-breath-the-liberating-practice-of-insight-meditation-larry-rosenberg/6425012?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Breath%20by%20Breath%20Larry%20Rosenberg&aid=LINEAGE",
   "author": "Larry Rosenberg",
   "year": 1998,
   "description": "Detailed guide to anapanasati (mindfulness of breathing) practice in the Theravada tradition, written by a teacher at the Insight Meditation Center.",

--- a/data/resources/cloud-of-unknowing.json
+++ b/data/resources/cloud-of-unknowing.json
@@ -2,10 +2,10 @@
   "title": "The Cloud of Unknowing",
   "slug": "cloud-of-unknowing",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-cloud-of-unknowing-and-the-book-of-privy-counseling-anonymous/7101802?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Cloud%20of%20Unknowing&aid=LINEAGE",
   "author": null,
   "year": 1375,
-  "description": "Anonymous 14th-century mystical text guiding the contemplative toward direct experience of God through 'unknowing' \u2014 releasing conceptual thought.",
+  "description": "Anonymous 14th-century mystical text guiding the contemplative toward direct experience of God through 'unknowing' — releasing conceptual thought.",
   "traditions": [
     "christian-mysticism"
   ],

--- a/data/resources/cutting-through-spiritual-materialism.json
+++ b/data/resources/cutting-through-spiritual-materialism.json
@@ -2,7 +2,7 @@
   "title": "Cutting Through Spiritual Materialism",
   "slug": "cutting-through-spiritual-materialism",
   "type": "book",
-  "url": "https://bookshop.org/p/books/cutting-through-spiritual-materialism-chogyam-trungpa/6425064?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Cutting%20Through%20Spiritual%20Materialism%20Chogyam%20Trungpa&aid=LINEAGE",
   "author": "Chogyam Trungpa",
   "year": 1973,
   "description": "Classic warning against ego's tendency to co-opt the spiritual path, from one of the first Tibetan masters to teach extensively in the West.",

--- a/data/resources/essential-rumi.json
+++ b/data/resources/essential-rumi.json
@@ -2,7 +2,7 @@
   "title": "The Essential Rumi",
   "slug": "essential-rumi",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-essential-rumi-new-expanded-edition-jalal-al-din-rumi/6425038?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Essential%20Rumi%20Coleman%20Barks&aid=LINEAGE",
   "author": "Coleman Barks",
   "year": 1995,
   "description": "Popular English translations of the 13th-century Sufi mystic Rumi's poetry, exploring divine love, longing, and spiritual transformation.",

--- a/data/resources/full-catastrophe-living.json
+++ b/data/resources/full-catastrophe-living.json
@@ -2,7 +2,7 @@
   "title": "Full Catastrophe Living",
   "slug": "full-catastrophe-living",
   "type": "book",
-  "url": "https://bookshop.org/p/books/full-catastrophe-living-using-the-wisdom-of-your-body-and-mind-to-face-stress-pain-and-illness-jon-kabat-zinn/9119077?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Full%20Catastrophe%20Living%20Jon%20Kabat-Zinn&aid=LINEAGE",
   "author": "Jon Kabat-Zinn",
   "year": 1990,
   "description": "The definitive guide to mindfulness-based stress reduction (MBSR), showing how to use meditation and yoga to counteract stress, pain, and illness.",

--- a/data/resources/gnosticism-new-light.json
+++ b/data/resources/gnosticism-new-light.json
@@ -2,7 +2,7 @@
   "title": "Gnosticism: New Light on the Ancient Tradition of Inner Knowing",
   "slug": "gnosticism-new-light",
   "type": "book",
-  "url": "https://bookshop.org/books/gnosticism-new-light-on-the-ancient-tradition-of-inner-knowing/9780835608169?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Gnosticism%3A%20New%20Light%20on%20the%20Ancient%20Tradition%20of%20Inner%20Knowing%20Stephan%20A.%20Hoeller&aid=LINEAGE",
   "author": "Stephan A. Hoeller",
   "year": 2002,
   "description": "An accessible overview of Gnosticism from antiquity to the present, illuminating its core teaching that direct experiential knowledge of the divine is available to all.",

--- a/data/resources/heart-of-the-buddhas-teaching.json
+++ b/data/resources/heart-of-the-buddhas-teaching.json
@@ -2,7 +2,7 @@
   "title": "The Heart of the Buddha's Teaching",
   "slug": "heart-of-the-buddhas-teaching",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-heart-of-the-buddha-s-teaching-transforming-suffering-into-peace-joy-and-liberation-thich-nhat-hanh/6693941?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Heart%20of%20the%20Buddha's%20Teaching%20Thich%20Nhat%20Hanh&aid=LINEAGE",
   "author": "Thich Nhat Hanh",
   "year": 1998,
   "description": "Accessible introduction to the core teachings of Buddhism, covering the Four Noble Truths, the Eightfold Path, and key Mahayana concepts.",

--- a/data/resources/i-am-that.json
+++ b/data/resources/i-am-that.json
@@ -2,7 +2,7 @@
   "title": "I Am That",
   "slug": "i-am-that",
   "type": "book",
-  "url": "https://bookshop.org/p/books/i-am-that-talks-with-sri-nisargadatta-maharaj-nisargadatta-maharaj/11710637?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=I%20Am%20That%20Nisargadatta%20Maharaj&aid=LINEAGE",
   "author": "Nisargadatta Maharaj",
   "year": 1973,
   "description": "Transcribed dialogues with the Advaita Vedanta master Nisargadatta Maharaj, exploring the nature of consciousness and self-inquiry.",

--- a/data/resources/interior-castle.json
+++ b/data/resources/interior-castle.json
@@ -2,7 +2,7 @@
   "title": "The Interior Castle",
   "slug": "interior-castle",
   "type": "book",
-  "url": "https://bookshop.org/p/books/interior-castle-teresa-of-avila/11380218?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Interior%20Castle%20Teresa%20of%20Avila&aid=LINEAGE",
   "author": "Teresa of Avila",
   "year": 1577,
   "description": "Teresa of Avila's masterwork mapping seven stages of spiritual development as mansions within a crystal castle, a landmark of Christian mystical literature.",

--- a/data/resources/jainism-at-a-glance.json
+++ b/data/resources/jainism-at-a-glance.json
@@ -2,7 +2,7 @@
   "title": "Jainism at a Glance",
   "slug": "jainism-at-a-glance",
   "type": "book",
-  "url": "https://bookshop.org/books/jainism-at-a-glance-a-religion-of-non-violence/9781452841854?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Jainism%20at%20a%20Glance%20Subhash%20C.%20Jain&aid=LINEAGE",
   "author": "Subhash C. Jain",
   "year": 2013,
   "description": "Traces the antiquity of Jainism and delineates its basic principles including the nature of the soul, doctrine of karma, and the path of salvation.",

--- a/data/resources/joy-of-living.json
+++ b/data/resources/joy-of-living.json
@@ -2,7 +2,7 @@
   "title": "The Joy of Living",
   "slug": "joy-of-living",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-joy-of-living-unlocking-the-secret-and-science-of-happiness-yongey-mingyur-rinpoche/6693832?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Joy%20of%20Living%20Yongey%20Mingyur%20Rinpoche&aid=LINEAGE",
   "author": "Yongey Mingyur Rinpoche",
   "year": 2007,
   "description": "Tibetan Buddhist master bridges meditation practice and modern neuroscience, offering practical tools for transforming anxiety into contentment.",

--- a/data/resources/kabbalah-very-short-introduction.json
+++ b/data/resources/kabbalah-very-short-introduction.json
@@ -2,7 +2,7 @@
   "title": "Kabbalah: A Very Short Introduction",
   "slug": "kabbalah-very-short-introduction",
   "type": "book",
-  "url": "https://bookshop.org/books/kabbalah-a-very-short-introduction/9780195327052?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Kabbalah%3A%20A%20Very%20Short%20Introduction%20Joseph%20Dan&aid=LINEAGE",
   "author": "Joseph Dan",
   "year": 2006,
   "description": "A concise and authoritative introduction to the history, major ideas, and key figures of the Kabbalistic tradition of Jewish mysticism.",

--- a/data/resources/kashmir-shaivism-secret-supreme.json
+++ b/data/resources/kashmir-shaivism-secret-supreme.json
@@ -2,7 +2,7 @@
   "title": "Kashmir Shaivism: The Secret Supreme",
   "slug": "kashmir-shaivism-secret-supreme",
   "type": "book",
-  "url": "https://bookshop.org/books/kashmir-shaivism-the-secret-supreme/9781587611568?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Kashmir%20Shaivism%3A%20The%20Secret%20Supreme%20Swami%20Lakshmanjoo&aid=LINEAGE",
   "author": "Swami Lakshmanjoo",
   "year": 1988,
   "description": "Teachings from the last living master of an unbroken oral lineage of Kashmir Shaivism, revealing the philosophical heart of this non-dual tantric tradition.",

--- a/data/resources/light-on-yoga.json
+++ b/data/resources/light-on-yoga.json
@@ -2,7 +2,7 @@
   "title": "Light on Yoga",
   "slug": "light-on-yoga",
   "type": "book",
-  "url": "https://bookshop.org/p/books/light-on-yoga/18792550?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Light%20on%20Yoga%20B.K.S.%20Iyengar&aid=LINEAGE",
   "author": "B.K.S. Iyengar",
   "year": 1966,
   "description": "The definitive guide to yoga practice, widely called the bible of yoga, with complete descriptions and illustrations of asanas and pranayama.",

--- a/data/resources/lovingkindness.json
+++ b/data/resources/lovingkindness.json
@@ -2,7 +2,7 @@
   "title": "Lovingkindness: The Revolutionary Art of Happiness",
   "slug": "lovingkindness",
   "type": "book",
-  "url": "https://bookshop.org/p/books/lovingkindness-the-revolutionary-art-of-happiness-sharon-salzberg/2812982772c48a3c?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Lovingkindness%3A%20The%20Revolutionary%20Art%20of%20Happiness%20Sharon%20Salzberg&aid=LINEAGE",
   "author": "Sharon Salzberg",
   "year": 1995,
   "description": "Draws on Buddhist teachings and guided meditation exercises to show how the practice of lovingkindness can cultivate love, compassion, and joy.",

--- a/data/resources/mindfulness-a-practical-guide-to-awakening.json
+++ b/data/resources/mindfulness-a-practical-guide-to-awakening.json
@@ -2,7 +2,7 @@
   "title": "Mindfulness: A Practical Guide to Awakening",
   "slug": "mindfulness-a-practical-guide-to-awakening",
   "type": "book",
-  "url": "https://bookshop.org/p/books/mindfulness-a-practical-guide-to-awakening-joseph-goldstein/9259626?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Mindfulness%3A%20A%20Practical%20Guide%20to%20Awakening%20Joseph%20Goldstein&aid=LINEAGE",
   "author": "Joseph Goldstein",
   "year": 2013,
   "description": "A comprehensive guide to mindfulness meditation rooted in the Satipatthana Sutta, distilling four decades of teaching and practice.",

--- a/data/resources/mindfulness-in-plain-english.json
+++ b/data/resources/mindfulness-in-plain-english.json
@@ -2,7 +2,7 @@
   "title": "Mindfulness in Plain English",
   "slug": "mindfulness-in-plain-english",
   "type": "book",
-  "url": "https://bookshop.org/p/books/mindfulness-in-plain-english-bhante-henepola-gunaratana/6693860?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Mindfulness%20in%20Plain%20English%20Bhante%20Gunaratana&aid=LINEAGE",
   "author": "Bhante Gunaratana",
   "year": 1991,
   "description": "Clear, practical guide to Vipassana meditation from a Sri Lankan Theravada monk, widely regarded as one of the best introductions to meditation.",

--- a/data/resources/nature-of-consciousness.json
+++ b/data/resources/nature-of-consciousness.json
@@ -2,7 +2,7 @@
   "title": "The Nature of Consciousness",
   "slug": "nature-of-consciousness",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-nature-of-consciousness-essays-on-the-unity-of-mind-and-matter-rupert-spira/9494962?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Nature%20of%20Consciousness%20Rupert%20Spira&aid=LINEAGE",
   "author": "Rupert Spira",
   "year": 2017,
   "description": "Essays exploring the non-dual nature of experience, arguing that consciousness is the fundamental reality underlying all perception.",

--- a/data/resources/neoplatonism.json
+++ b/data/resources/neoplatonism.json
@@ -2,7 +2,7 @@
   "title": "Neoplatonism",
   "slug": "neoplatonism",
   "type": "book",
-  "url": "https://bookshop.org/books/neoplatonism/9780520254985?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Neoplatonism%20Pauliina%20Remes&aid=LINEAGE",
   "author": "Pauliina Remes",
   "year": 2008,
   "description": "An accessible introduction to Neoplatonic philosophy covering Plotinus, Porphyry, Iamblichus, and Proclus, and their enduring influence on Western thought.",

--- a/data/resources/philokalia.json
+++ b/data/resources/philokalia.json
@@ -2,7 +2,7 @@
   "title": "The Philokalia",
   "slug": "philokalia",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-philokalia-volume-1-the-complete-text-g-e-h-palmer/15914905?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Philokalia&aid=LINEAGE",
   "author": null,
   "year": 1782,
   "description": "Collection of texts on contemplative prayer by Eastern Orthodox monks spanning the 4th to 15th centuries, central to the Hesychast tradition.",

--- a/data/resources/plotinus-introduction-to-the-enneads.json
+++ b/data/resources/plotinus-introduction-to-the-enneads.json
@@ -2,7 +2,7 @@
   "title": "Plotinus: An Introduction to the Enneads",
   "slug": "plotinus-introduction-to-the-enneads",
   "type": "book",
-  "url": "https://bookshop.org/p/books/plotinus-an-introduction-to-the-enneads-dominic-j-o-meara/9760754?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Plotinus%3A%20An%20Introduction%20to%20the%20Enneads%20Dominic%20J.%20O'Meara&aid=LINEAGE",
   "author": "Dominic J. O'Meara",
   "year": 1993,
   "description": "An accessible introduction to the philosophy of Plotinus, the founder of Neoplatonism, placing his thinking within its intellectual context.",

--- a/data/resources/quaker-spirituality.json
+++ b/data/resources/quaker-spirituality.json
@@ -2,7 +2,7 @@
   "title": "Quaker Spirituality: Selected Writings",
   "slug": "quaker-spirituality",
   "type": "book",
-  "url": "https://bookshop.org/books/quaker-spirituality-selected-writings/9780809135059?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Quaker%20Spirituality%3A%20Selected%20Writings%20Douglas%20V.%20Steere&aid=LINEAGE",
   "author": "Douglas V. Steere",
   "year": 1984,
   "description": "A collection of essential Quaker writings spanning four centuries, exploring the tradition of silent worship and the experience of the Inner Light.",

--- a/data/resources/radical-acceptance.json
+++ b/data/resources/radical-acceptance.json
@@ -2,7 +2,7 @@
   "title": "Radical Acceptance",
   "slug": "radical-acceptance",
   "type": "book",
-  "url": "https://bookshop.org/p/books/radical-acceptance-embracing-your-life-with-the-heart-of-a-buddha-tara-brach/73f251c91e30fe7a?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Radical%20Acceptance%20Tara%20Brach&aid=LINEAGE",
   "author": "Tara Brach",
   "year": 2003,
   "description": "Combines Buddhist teachings with Western psychology to offer a path to emotional healing through embracing our lives with the heart of a Buddha.",

--- a/data/resources/shiva-sutras.json
+++ b/data/resources/shiva-sutras.json
@@ -2,7 +2,7 @@
   "title": "Shiva Sutras: The Supreme Awakening",
   "slug": "shiva-sutras",
   "type": "book",
-  "url": "https://bookshop.org/p/books/siva-sutras-the-supreme-awakening-swami-lakshmanjoo/9920064?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Shiva%20Sutras%3A%20The%20Supreme%20Awakening%20Swami%20Lakshmanjoo&aid=LINEAGE",
   "author": "Swami Lakshmanjoo",
   "year": 2007,
   "description": "Commentary on the foundational text of Kashmir Shaivism by the last living master of the tradition, revealing the nature of consciousness and liberation.",

--- a/data/resources/tai-chi-classics.json
+++ b/data/resources/tai-chi-classics.json
@@ -2,7 +2,7 @@
   "title": "Tai Chi Classics",
   "slug": "tai-chi-classics",
   "type": "book",
-  "url": "https://bookshop.org/books/tai-chi-classics/9781590302613?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Tai%20Chi%20Classics%20Waysun%20Liao&aid=LINEAGE",
   "author": "Waysun Liao",
   "year": 1977,
   "description": "Translations and commentary on the original tai chi texts, revealing the philosophical and practical foundations of this ancient internal art.",

--- a/data/resources/tantra-illuminated.json
+++ b/data/resources/tantra-illuminated.json
@@ -2,7 +2,7 @@
   "title": "Tantra Illuminated",
   "slug": "tantra-illuminated",
   "type": "book",
-  "url": "https://bookshop.org/p/books/tantra-illuminated-the-philosophy-history-and-practice-of-a-timeless-tradition-christopher-d-wallis/0037e20101308c70?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Tantra%20Illuminated%20Christopher%20D.%20Wallis&aid=LINEAGE",
   "author": "Christopher D. Wallis",
   "year": 2012,
   "description": "An accessible introduction to the philosophy, history, and practice of Tantra, drawing on primary Sanskrit sources to reveal its rich teachings.",

--- a/data/resources/tao-te-ching.json
+++ b/data/resources/tao-te-ching.json
@@ -2,7 +2,7 @@
   "title": "Tao Te Ching",
   "slug": "tao-te-ching",
   "type": "book",
-  "url": "https://bookshop.org/p/books/tao-te-ching-laozi/18692155?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Tao%20Te%20Ching%20Laozi&aid=LINEAGE",
   "author": "Laozi",
   "year": null,
   "description": "Foundational text of Taoism, offering 81 brief chapters on the nature of the Tao, non-action (wu wei), and the art of living in harmony with reality.",

--- a/data/resources/that-which-is.json
+++ b/data/resources/that-which-is.json
@@ -2,7 +2,7 @@
   "title": "That Which Is: Tattvartha Sutra",
   "slug": "that-which-is",
   "type": "book",
-  "url": "https://bookshop.org/books/that-which-is-tattvartha-sutra/9780300165227?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=That%20Which%20Is%3A%20Tattvartha%20Sutra%20Umasvati&aid=LINEAGE",
   "author": "Umasvati",
   "year": 200,
   "description": "The only Jain text accepted as authoritative by all sects, presenting the foundational doctrines of Jainism including karma, the soul, and liberation.",

--- a/data/resources/the-complete-book-of-tai-chi-chuan.json
+++ b/data/resources/the-complete-book-of-tai-chi-chuan.json
@@ -2,7 +2,7 @@
   "title": "The Complete Book of Tai Chi Chuan",
   "slug": "the-complete-book-of-tai-chi-chuan",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-complete-book-of-tai-chi-chuan-a-comprehensive-guide-to-the-principles-and-practice-wong-kiew-kit/11027389?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Complete%20Book%20of%20Tai%20Chi%20Chuan%20Wong%20Kiew%20Kit&aid=LINEAGE",
   "author": "Wong Kiew Kit",
   "year": 1996,
   "description": "A comprehensive guide to the principles and practice of Tai Chi Chuan, covering its benefits for physical, mental, spiritual, and emotional development.",

--- a/data/resources/the-conference-of-the-birds.json
+++ b/data/resources/the-conference-of-the-birds.json
@@ -2,7 +2,7 @@
   "title": "The Conference of the Birds",
   "slug": "the-conference-of-the-birds",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-conference-of-the-birds-the-selected-sufi-poetry-of-farid-ud-din-attar-farid-ud-din-attar/3eb4f199a7e7159b?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Conference%20of%20the%20Birds%20Farid%20ud-Din%20Attar&aid=LINEAGE",
   "author": "Farid ud-Din Attar",
   "year": 1177,
   "description": "A masterwork of Sufi poetry in which the birds of the world undertake a perilous journey through seven valleys to find their king, allegorizing the soul's search for God.",

--- a/data/resources/the-crystal-and-the-way-of-light.json
+++ b/data/resources/the-crystal-and-the-way-of-light.json
@@ -2,7 +2,7 @@
   "title": "The Crystal and the Way of Light",
   "slug": "the-crystal-and-the-way-of-light",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-crystal-and-the-way-of-light-sutra-tantra-and-dzogchen-chogyal-namkhai-norbu/f288c91749ae0172?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Crystal%20and%20the%20Way%20of%20Light%20Chogyal%20Namkhai%20Norbu&aid=LINEAGE",
   "author": "Chogyal Namkhai Norbu",
   "year": 1986,
   "description": "An accessible introduction to Dzogchen by a revered Tibetan master, interweaving his life story with teachings on the base, path, and fruit of practice.",

--- a/data/resources/the-end-of-your-world.json
+++ b/data/resources/the-end-of-your-world.json
@@ -2,7 +2,7 @@
   "title": "The End of Your World",
   "slug": "the-end-of-your-world",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-end-of-your-world-uncensored-straight-talk-on-the-nature-of-enlightenment-adyashanti/10792613?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20End%20of%20Your%20World%20Adyashanti&aid=LINEAGE",
   "author": "Adyashanti",
   "year": 2008,
   "description": "Uncensored straight talk on what happens after spiritual awakening, addressing common pitfalls and the journey from nonabiding to abiding realization.",

--- a/data/resources/the-essential-kabbalah.json
+++ b/data/resources/the-essential-kabbalah.json
@@ -2,7 +2,7 @@
   "title": "The Essential Kabbalah",
   "slug": "the-essential-kabbalah",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-essential-kabbalah-the-heart-of-jewish-mysticism-revised-daniel-c-matt/6438429?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Essential%20Kabbalah%20Daniel%20C.%20Matt&aid=LINEAGE",
   "author": "Daniel C. Matt",
   "year": 1995,
   "description": "The perfect introduction to Kabbalism, presenting its most essential teachings with expert translations and clear explanations of the Ten Sefirot and the Zohar.",

--- a/data/resources/the-gnostic-gospels.json
+++ b/data/resources/the-gnostic-gospels.json
@@ -2,7 +2,7 @@
   "title": "The Gnostic Gospels",
   "slug": "the-gnostic-gospels",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-gnostic-gospels-elaine-pagels/6719485?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Gnostic%20Gospels%20Elaine%20Pagels&aid=LINEAGE",
   "author": "Elaine Pagels",
   "year": 1979,
   "description": "A landmark exploration of the Nag Hammadi texts that reveals a radically different view of early Christianity. Winner of the National Book Award.",

--- a/data/resources/the-gospel-of-thomas.json
+++ b/data/resources/the-gospel-of-thomas.json
@@ -2,7 +2,7 @@
   "title": "The Gospel of Thomas: The Gnostic Wisdom of Jesus",
   "slug": "the-gospel-of-thomas",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-gospel-of-thomas-the-gnostic-wisdom-of-jesus-jean-yves-leloup/dc537c454e97368a?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Gospel%20of%20Thomas%3A%20The%20Gnostic%20Wisdom%20of%20Jesus%20Jean-Yves%20Leloup&aid=LINEAGE",
   "author": "Jean-Yves Leloup",
   "year": 2005,
   "description": "A translation and commentary on the 114 logia of the Gospel of Thomas, revealing a Jesus with much in common with non-dualistic gnostic schools.",

--- a/data/resources/the-heart-of-sufism.json
+++ b/data/resources/the-heart-of-sufism.json
@@ -2,7 +2,7 @@
   "title": "The Heart of Sufism",
   "slug": "the-heart-of-sufism",
   "type": "book",
-  "url": "https://bookshop.org/books/the-heart-of-sufism-essential-writings-of-hazrat-inayat-khan/9781570622106?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Heart%20of%20Sufism%20Hazrat%20Inayat%20Khan&aid=LINEAGE",
   "author": "Hazrat Inayat Khan",
   "year": 1999,
   "description": "Essential writings of the great Sufi master who brought Sufism to the West, presenting the mystical heart of Islam's contemplative tradition.",

--- a/data/resources/the-journal-of-george-fox.json
+++ b/data/resources/the-journal-of-george-fox.json
@@ -2,7 +2,7 @@
   "title": "The Journal of George Fox",
   "slug": "the-journal-of-george-fox",
   "type": "book",
-  "url": "https://bookshop.org/books/the-journal-of-george-fox/9780913408377?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Journal%20of%20George%20Fox%20George%20Fox&aid=LINEAGE",
   "author": "George Fox",
   "year": 1694,
   "description": "The spiritual autobiography of Quakerism's founder, recording his discovery of the Inner Light and the birth of the Religious Society of Friends.",

--- a/data/resources/the-miracle-of-mindfulness.json
+++ b/data/resources/the-miracle-of-mindfulness.json
@@ -2,7 +2,7 @@
   "title": "The Miracle of Mindfulness",
   "slug": "the-miracle-of-mindfulness",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-miracle-of-mindfulness-an-introduction-to-the-practice-of-meditation-thich-nhat-hanh/2333ddf24162fa0d?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Miracle%20of%20Mindfulness%20Thich%20Nhat%20Hanh&aid=LINEAGE",
   "author": "Thich Nhat Hanh",
   "year": 1975,
   "description": "A gentle introduction to the practice of mindfulness meditation through anecdotes and practical exercises from the beloved Zen master.",

--- a/data/resources/the-philokalia-selections.json
+++ b/data/resources/the-philokalia-selections.json
@@ -2,7 +2,7 @@
   "title": "The Philokalia: The Eastern Christian Spiritual Texts",
   "slug": "the-philokalia-selections",
   "type": "book",
-  "url": "https://bookshop.org/books/the-philokalia-the-eastern-christian-spiritual-texts/9781594731037?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Philokalia%3A%20The%20Eastern%20Christian%20Spiritual%20Texts%20Allyne%20Smith&aid=LINEAGE",
   "author": "Allyne Smith",
   "year": 2006,
   "description": "Annotated selections from the Philokalia, the foundational anthology of hesychast writings on the prayer of the heart and contemplative stillness.",

--- a/data/resources/the-places-that-scare-you.json
+++ b/data/resources/the-places-that-scare-you.json
@@ -2,7 +2,7 @@
   "title": "The Places That Scare You",
   "slug": "the-places-that-scare-you",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-places-that-scare-you-a-guide-to-fearlessness-in-difficult-times-pema-chodron/9762315?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Places%20That%20Scare%20You%20Pema%20Ch%C3%B6dr%C3%B6n&aid=LINEAGE",
   "author": "Pema Chödrön",
   "year": 2001,
   "description": "A guide to fearlessness in difficult times, drawing on Buddhist teachings to show how awakening basic human goodness can transform our relationship with fear.",

--- a/data/resources/the-platform-sutra-red-pine.json
+++ b/data/resources/the-platform-sutra-red-pine.json
@@ -2,7 +2,7 @@
   "title": "The Platform Sutra: The Zen Teaching of Hui-neng",
   "slug": "the-platform-sutra-red-pine",
   "type": "book",
-  "url": "https://bookshop.org/books/the-platform-sutra-the-zen-teaching-of-hui-neng/9781619024236?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Platform%20Sutra%3A%20The%20Zen%20Teaching%20of%20Hui-neng%20Red%20Pine&aid=LINEAGE",
   "author": "Red Pine",
   "year": 2006,
   "description": "Red Pine's acclaimed translation of the Platform Sutra, the foundational Chan text recording Huineng's teachings on sudden awakening.",

--- a/data/resources/the-platform-sutra.json
+++ b/data/resources/the-platform-sutra.json
@@ -2,7 +2,7 @@
   "title": "The Platform Sutra of the Sixth Patriarch",
   "slug": "the-platform-sutra",
   "type": "book",
-  "url": "https://bookshop.org/books/the-platform-sutra-of-the-sixth-patriarch/9780231159579?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Platform%20Sutra%20of%20the%20Sixth%20Patriarch%20Huineng&aid=LINEAGE",
   "author": "Huineng",
   "year": 780,
   "description": "A foundational text of Chan Buddhism recording the sermons and teachings of the Sixth Patriarch Huineng, revealing the early evolution of Chinese Chan.",

--- a/data/resources/the-tao-of-pooh.json
+++ b/data/resources/the-tao-of-pooh.json
@@ -2,7 +2,7 @@
   "title": "The Tao of Pooh",
   "slug": "the-tao-of-pooh",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-tao-of-pooh-benjamin-hoff/16618380?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Tao%20of%20Pooh%20Benjamin%20Hoff&aid=LINEAGE",
   "author": "Benjamin Hoff",
   "year": 1982,
   "description": "An accessible and delightful introduction to Taoism through the characters of Winnie-the-Pooh, showing that the principles of Tao are not ancient and remote but practical and present.",

--- a/data/resources/the-tibetan-yogas-of-dream-and-sleep.json
+++ b/data/resources/the-tibetan-yogas-of-dream-and-sleep.json
@@ -2,7 +2,7 @@
   "title": "The Tibetan Yogas of Dream and Sleep",
   "slug": "the-tibetan-yogas-of-dream-and-sleep",
   "type": "book",
-  "url": "https://bookshop.org/books/the-tibetan-yogas-of-dream-and-sleep/9781559391016?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Tibetan%20Yogas%20of%20Dream%20and%20Sleep%20Tenzin%20Wangyal%20Rinpoche&aid=LINEAGE",
   "author": "Tenzin Wangyal Rinpoche",
   "year": 1998,
   "description": "A guide to dream yoga and sleep yoga from the Bön Dzogchen tradition, showing how to use the night for spiritual transformation.",

--- a/data/resources/the-upanishads.json
+++ b/data/resources/the-upanishads.json
@@ -2,7 +2,7 @@
   "title": "The Upanishads",
   "slug": "the-upanishads",
   "type": "book",
-  "url": "https://bookshop.org/books/the-upanishads-2nd-revised-edition/9781586380212?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Upanishads%20Eknath%20Easwaran&aid=LINEAGE",
   "author": "Eknath Easwaran",
   "year": 1987,
   "description": "Eknath Easwaran's accessible translation of the principal Upanishads, the foundational texts of Vedantic philosophy exploring the nature of consciousness and reality.",

--- a/data/resources/the-way-of-a-pilgrim.json
+++ b/data/resources/the-way-of-a-pilgrim.json
@@ -2,7 +2,7 @@
   "title": "The Way of a Pilgrim",
   "slug": "the-way-of-a-pilgrim",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-way-of-a-pilgrim-and-the-pilgrim-continues-on-his-way-collector-s-edition-anonymous-19th-century-russian-peasant/11434123?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Way%20of%20a%20Pilgrim%20Anonymous&aid=LINEAGE",
   "author": "Anonymous",
   "year": 1884,
   "description": "The account of a Russian pilgrim's journey to learn unceasing prayer, a foundational text of the hesychast tradition of the Jesus Prayer.",

--- a/data/resources/the-way-of-qigong.json
+++ b/data/resources/the-way-of-qigong.json
@@ -2,7 +2,7 @@
   "title": "The Way of Qigong",
   "slug": "the-way-of-qigong",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-way-of-qigong-the-art-and-science-of-chinese-energy-healing-kenneth-s-cohen/bd698c00955bbc4d?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Way%20of%20Qigong%20Kenneth%20S.%20Cohen&aid=LINEAGE",
   "author": "Kenneth S. Cohen",
   "year": 1997,
   "description": "A comprehensive guide to the art and science of qigong, explaining this ancient Chinese energy healing method with practical exercises and scientific context.",

--- a/data/resources/the-way-of-the-bodhisattva.json
+++ b/data/resources/the-way-of-the-bodhisattva.json
@@ -2,7 +2,7 @@
   "title": "The Way of the Bodhisattva",
   "slug": "the-way-of-the-bodhisattva",
   "type": "book",
-  "url": "https://bookshop.org/books/the-way-of-the-bodhisattva-revised/9781590306147?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Way%20of%20the%20Bodhisattva%20Shantideva&aid=LINEAGE",
   "author": "Shantideva",
   "year": 700,
   "description": "A guide to cultivating the mind of enlightenment through love, compassion, generosity, and patience, studied in an unbroken tradition for centuries.",

--- a/data/resources/tibetan-book-of-living-and-dying.json
+++ b/data/resources/tibetan-book-of-living-and-dying.json
@@ -2,7 +2,7 @@
   "title": "The Tibetan Book of Living and Dying",
   "slug": "tibetan-book-of-living-and-dying",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-tibetan-book-of-living-and-dying-sogyal-rinpoche/6425008?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Tibetan%20Book%20of%20Living%20and%20Dying%20Sogyal%20Rinpoche&aid=LINEAGE",
   "author": "Sogyal Rinpoche",
   "year": 1992,
   "description": "Modern presentation of Tibetan Buddhist teachings on death, dying, and the nature of mind, drawing on the Bardo Thodol tradition.",

--- a/data/resources/way-of-zen.json
+++ b/data/resources/way-of-zen.json
@@ -2,7 +2,7 @@
   "title": "The Way of Zen",
   "slug": "way-of-zen",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-way-of-zen-alan-watts/6693942?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Way%20of%20Zen%20Alan%20Watts&aid=LINEAGE",
   "author": "Alan Watts",
   "year": 1957,
   "description": "Influential introduction to Zen Buddhism for Western audiences, tracing its roots from Indian Buddhism through Chinese Chan to Japanese Zen.",

--- a/data/resources/what-the-buddha-taught.json
+++ b/data/resources/what-the-buddha-taught.json
@@ -2,7 +2,7 @@
   "title": "What the Buddha Taught",
   "slug": "what-the-buddha-taught",
   "type": "book",
-  "url": "https://bookshop.org/p/books/what-the-buddha-taught-revised-and-expanded-edition-with-texts-from-suttas-and-dhammapada-walpola-rahula/12473981?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=What%20the%20Buddha%20Taught%20Walpola%20Rahula&aid=LINEAGE",
   "author": "Walpola Rahula",
   "year": 1959,
   "description": "An indispensable introduction to Buddhism, presenting the core teachings with clarity and authority using the Buddha's own words from the Suttas.",

--- a/data/resources/when-things-fall-apart.json
+++ b/data/resources/when-things-fall-apart.json
@@ -2,7 +2,7 @@
   "title": "When Things Fall Apart",
   "slug": "when-things-fall-apart",
   "type": "book",
-  "url": "https://bookshop.org/p/books/when-things-fall-apart-heart-advice-for-difficult-times-pema-chodron/9757480?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=When%20Things%20Fall%20Apart%20Pema%20Ch%C3%B6dr%C3%B6n&aid=LINEAGE",
   "author": "Pema Chödrön",
   "year": 1997,
   "description": "Heart advice for difficult times, showing how moving toward painful situations can open our hearts in ways we never imagined.",

--- a/data/resources/wherever-you-go-there-you-are.json
+++ b/data/resources/wherever-you-go-there-you-are.json
@@ -2,7 +2,7 @@
   "title": "Wherever You Go, There You Are",
   "slug": "wherever-you-go-there-you-are",
   "type": "book",
-  "url": "https://bookshop.org/p/books/wherever-you-go-there-you-are-mindfulness-meditation-in-everyday-life-jon-kabat-zinn/19968905?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Wherever%20You%20Go%2C%20There%20You%20Are%20Jon%20Kabat-Zinn&aid=LINEAGE",
   "author": "Jon Kabat-Zinn",
   "year": 1994,
   "description": "A foundational guide to mindfulness meditation in everyday life that helped catalyze the global mindfulness movement.",

--- a/data/resources/yoga-sutras-of-patanjali.json
+++ b/data/resources/yoga-sutras-of-patanjali.json
@@ -2,7 +2,7 @@
   "title": "The Yoga Sutras of Patanjali",
   "slug": "yoga-sutras-of-patanjali",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-yoga-sutras-of-patanjali-sri-swami-satchidananda/6425182?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Yoga%20Sutras%20of%20Patanjali%20Patanjali&aid=LINEAGE",
   "author": "Patanjali",
   "year": null,
   "description": "Foundational text of Classical Yoga, systematizing the philosophy and practice of yoga into 196 concise aphorisms.",

--- a/data/resources/zen-mind-beginners-mind.json
+++ b/data/resources/zen-mind-beginners-mind.json
@@ -2,7 +2,7 @@
   "title": "Zen Mind, Beginner's Mind",
   "slug": "zen-mind-beginners-mind",
   "type": "book",
-  "url": "https://bookshop.org/p/books/zen-mind-beginner-s-mind-50th-anniversary-edition-shunryu-suzuki/08164e1309629b8e?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=Zen%20Mind%2C%20Beginner's%20Mind%20Shunryu%20Suzuki&aid=LINEAGE",
   "author": "Shunryu Suzuki",
   "year": 1970,
   "description": "One of the great modern spiritual classics, presenting the basics of Zen meditation with remarkable clarity and the joy of insight.",

--- a/data/resources/zohar.json
+++ b/data/resources/zohar.json
@@ -2,7 +2,7 @@
   "title": "The Zohar: Pritzker Edition",
   "slug": "zohar",
   "type": "book",
-  "url": "https://bookshop.org/p/books/the-zohar-pritzker-edition-volume-one-daniel-c-matt/8211563?aid=LINEAGE",
+  "url": "https://bookshop.org/beta-search?keywords=The%20Zohar%3A%20Pritzker%20Edition%20Daniel%20C.%20Matt&aid=LINEAGE",
   "author": "Daniel C. Matt",
   "year": 2003,
   "description": "Definitive English translation of the central text of Kabbalah, a 13th-century mystical commentary on the Torah exploring the hidden dimensions of reality.",

--- a/scripts/fix-bookshop-urls.ts
+++ b/scripts/fix-bookshop-urls.ts
@@ -1,0 +1,39 @@
+/**
+ * One-shot script: Replace broken bookshop.org product URLs with search URLs.
+ *
+ * Usage: npx tsx scripts/fix-bookshop-urls.ts
+ */
+import { readFileSync, writeFileSync, readdirSync } from "fs";
+import { join } from "path";
+
+const RESOURCES_DIR = join(__dirname, "..", "data", "resources");
+const AFFILIATE_ID = "LINEAGE";
+
+const files = readdirSync(RESOURCES_DIR).filter((f) => f.endsWith(".json"));
+
+let updated = 0;
+let skipped = 0;
+
+for (const file of files) {
+  const path = join(RESOURCES_DIR, file);
+  const data = JSON.parse(readFileSync(path, "utf-8"));
+
+  if (!data.url?.includes("bookshop.org")) {
+    skipped++;
+    continue;
+  }
+
+  const keywords = [data.title, data.author].filter(Boolean).join(" ");
+  const searchUrl = `https://bookshop.org/beta-search?keywords=${encodeURIComponent(keywords)}&aid=${AFFILIATE_ID}`;
+
+  const oldUrl = data.url;
+  data.url = searchUrl;
+
+  writeFileSync(path, JSON.stringify(data, null, 2) + "\n");
+  console.log(`✓ ${file}`);
+  console.log(`  OLD: ${oldUrl}`);
+  console.log(`  NEW: ${searchUrl}\n`);
+  updated++;
+}
+
+console.log(`\nDone. Updated: ${updated}, Skipped: ${skipped}`);


### PR DESCRIPTION
## Summary
All 65 bookshop.org product URLs were redirecting to wrong books (product IDs recycled by bookshop.org). Replaced with search URLs that land users on a bookshop.org search page with the book's title + author as keywords.

Format: `bookshop.org/beta-search?keywords={title}+{author}&aid=LINEAGE`

This approach is resilient — even if bookshop.org changes their catalog, the search will still help users find the book.

## Test plan
- [ ] Click a book link on the map sidebar → lands on bookshop.org search showing the correct book
- [ ] Try 3-4 different books to verify search quality
- [ ] Affiliate ID (`aid=LINEAGE`) is preserved in all URLs
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)