### PR TITLE
fix: keep node popover visible when mousing from node to popover

### DIFF
--- a/src/components/tradition-map/__tests__/map-node-popover.test.tsx
+++ b/src/components/tradition-map/__tests__/map-node-popover.test.tsx
@@ -19,6 +19,8 @@ const defaultProps = {
   node: mockNode,
   position: { x: 200, y: 300 },
   onClose: vi.fn(),
+  onPopoverEnter: vi.fn(),
+  onPopoverLeave: vi.fn(),
 };
 
 describe("MapNodePopover", () => {

--- a/src/components/tradition-map/map-canvas.tsx
+++ b/src/components/tradition-map/map-canvas.tsx
@@ -28,6 +28,8 @@ interface MapCanvasProps {
   resourceMap?: ResourceMap;
   activeSlug: string | null;
   onNodeDeselect: () => void;
+  onPopoverEnter: () => void;
+  onPopoverLeave: () => void;
 }
 
 export function MapCanvas({
@@ -49,6 +51,8 @@ export function MapCanvas({
   resourceMap = {},
   activeSlug,
   onNodeDeselect,
+  onPopoverEnter,
+  onPopoverLeave,
 }: MapCanvasProps) {
   // Entrance animation delays based on Y position
   const nodeDelays = useMemo(() => {
@@ -181,6 +185,8 @@ export function MapCanvas({
             node={node}
             position={pos}
             onClose={onNodeDeselect}
+            onPopoverEnter={onPopoverEnter}
+            onPopoverLeave={onPopoverLeave}
           />
         );
       })()}

--- a/src/components/tradition-map/map-node-popover.tsx
+++ b/src/components/tradition-map/map-node-popover.tsx
@@ -5,6 +5,8 @@ interface MapNodePopoverProps {
   node: GraphNode;
   position: { x: number; y: number };
   onClose: () => void;
+  onPopoverEnter: () => void;
+  onPopoverLeave: () => void;
 }
 
 const MAX_SUMMARY_LENGTH = 140;
@@ -24,13 +26,15 @@ export function MapNodePopover({
   node,
   position,
   onClose,
+  onPopoverEnter,
+  onPopoverLeave,
 }: MapNodePopoverProps) {
   const containerRef = useRef<HTMLDivElement>(null);
   const width = 260;
   const height = 180;
   // Position above the node, centered horizontally
   const x = position.x - width / 2;
-  const y = position.y - height - 18;
+  const y = position.y - height - 10;
 
   // Auto-focus for keyboard dismiss
   useEffect(() => {
@@ -48,6 +52,8 @@ export function MapNodePopover({
       <div
         ref={containerRef}
         tabIndex={-1}
+        onMouseEnter={onPopoverEnter}
+        onMouseLeave={onPopoverLeave}
         role="dialog"
         aria-label={`${node.name} details`}
         onKeyDown={(e) => {

--- a/src/components/tradition-map/tradition-map.tsx
+++ b/src/components/tradition-map/tradition-map.tsx
@@ -252,6 +252,8 @@ export function TraditionMap({ traditions, resourceMap = {} }: TraditionMapProps
                   isEdgeHidden={interaction.isEdgeHidden}
                   activeSlug={interaction.activeSlug}
                   onNodeDeselect={handleBackgroundTap}
+                  onPopoverEnter={interaction.handlePopoverEnter}
+                  onPopoverLeave={interaction.handlePopoverLeave}
                 />
               </g>
             </svg>

--- a/src/components/tradition-map/use-map-interaction.ts
+++ b/src/components/tradition-map/use-map-interaction.ts
@@ -41,8 +41,35 @@ export function useMapInteraction(graph: TraditionGraph) {
     return keys;
   }, [graph, activeSlug]);
 
+  // Delayed node unhover — gives user time to move mouse to the popover
+  const nodeHideTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
   const handleNodeHover = useCallback((slug: string | null) => {
-    setHoveredSlug(slug);
+    if (nodeHideTimer.current) {
+      clearTimeout(nodeHideTimer.current);
+      nodeHideTimer.current = null;
+    }
+    if (slug) {
+      setHoveredSlug(slug);
+    } else {
+      nodeHideTimer.current = setTimeout(() => {
+        setHoveredSlug(null);
+      }, 300);
+    }
+  }, []);
+
+  // Allow popover itself to keep the node hovered
+  const handlePopoverEnter = useCallback(() => {
+    if (nodeHideTimer.current) {
+      clearTimeout(nodeHideTimer.current);
+      nodeHideTimer.current = null;
+    }
+  }, []);
+
+  const handlePopoverLeave = useCallback(() => {
+    nodeHideTimer.current = setTimeout(() => {
+      setHoveredSlug(null);
+    }, 200);
   }, []);
 
   const handleNodeClick = useCallback(
@@ -181,6 +208,8 @@ export function useMapInteraction(graph: TraditionGraph) {
     handleEdgeHover,
     handleTooltipEnter,
     handleTooltipLeave,
+    handlePopoverEnter,
+    handlePopoverLeave,
     highlightedSourceSlug,
     setHighlightedSourceSlug,
     isNodeHighlighted,


### PR DESCRIPTION
## Summary
- Add 300ms hide delay when leaving a node, so the popover stays visible while moving the mouse toward it
- Add `onMouseEnter`/`onMouseLeave` handlers on the popover itself to keep it alive during hover
- Reduce node-to-popover gap from 18px to 10px for tighter visual feel

Mirrors the existing edge tooltip hover pattern from `use-map-interaction.ts`.

## Test plan
- [ ] Hover a node on the map — popover appears
- [ ] Move mouse from node up to popover — popover stays visible
- [ ] Click links inside popover — they work
- [ ] Move mouse away from popover — it disappears after short delay
- [ ] Verify popover sits closer to node than before (10px vs 18px gap)

🤖 Generated with [Claude Code](https://claude.com/claude-code)