### PR TITLE
Fix landing page link + add Hareesh Wallis

### DIFF
--- a/data/resources/tantra-illuminated.json
+++ b/data/resources/tantra-illuminated.json
@@ -10,6 +10,6 @@
     "tantra",
     "kashmir-shaivism"
   ],
-  "teachers": [],
+  "teachers": ["christopher-hareesh-wallis"],
   "centers": []
 }

--- a/data/teachers/christopher-hareesh-wallis.json
+++ b/data/teachers/christopher-hareesh-wallis.json
@@ -1,0 +1,16 @@
+{
+  "name": "Christopher 'Hareesh' Wallis",
+  "slug": "christopher-hareesh-wallis",
+  "bio": "Christopher Wallis, known as Hareesh, is a scholar-practitioner of Classical Tantra with over thirty years of experience. Initiated by a traditional Indian guru at age sixteen, he holds a B.A. in Religion and Classics from the University of Rochester, an M.A. in South Asian Studies from U.C. Berkeley, an M.Phil. in Classical Indian Religions from Oxford, and a Ph.D. in Sanskrit from U.C. Berkeley. He is the author of 'Tantra Illuminated,' the first comprehensive and accessible introduction to Classical Tantra, and 'Near Enemies of the Truth.' He teaches classical Tantric philosophy, meditation, Sanskrit, and mantra-science through his online learning community at Tantra Illuminated Online.",
+  "photo": null,
+  "website": "https://hareesh.org",
+  "birth_year": null,
+  "death_year": null,
+  "city": "San Francisco",
+  "state": "California",
+  "country": "US",
+  "latitude": null,
+  "longitude": null,
+  "traditions": ["tantra", "kashmir-shaivism"],
+  "centers": []
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -59,7 +59,7 @@ const sections = [
     title: "Explore Traditions",
     description:
       "How contemplative paths connect, diverge, and speak to one another.",
-    href: "/traditions",
+    href: "/map",
     icon: (
       <svg width="32" height="32" viewBox="0 0 32 32" fill="none" aria-hidden="true">
         <rect x="4" y="4" width="10" height="14" rx="1" stroke="currentColor" strokeWidth="1.5" />


### PR DESCRIPTION
## Summary
- "Explore Traditions" card on landing page now links to `/map` instead of `/traditions`
- Add Christopher 'Hareesh' Wallis as a teacher (tantra, kashmir-shaivism)
- Link existing `tantra-illuminated` resource to his teacher profile

## Test plan
- [ ] Landing page "Explore Traditions" card navigates to `/map`
- [ ] `/teachers/christopher-hareesh-wallis` renders with bio, traditions, and linked resource
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)