### PR TITLE
feat: teacher generator module for publishable JSON output

### DIFF
--- a/scripts/lib/__tests__/generate-teacher.test.ts
+++ b/scripts/lib/__tests__/generate-teacher.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect } from "vitest";
+import { generateTeacherJson } from "../generate-teacher";
+import type { AcceptedCandidate } from "../generate-teacher";
+
+function isTeacher(obj: unknown): obj is Record<string, unknown> {
+  const t = obj as Record<string, unknown>;
+  return (
+    typeof t.name === "string" &&
+    typeof t.slug === "string" &&
+    typeof t.bio === "string" &&
+    (t.birth_year === null || t.birth_year === undefined || typeof t.birth_year === "number") &&
+    (t.death_year === null || t.death_year === undefined || typeof t.death_year === "number") &&
+    typeof t.city === "string" &&
+    typeof t.state === "string" &&
+    typeof t.country === "string" &&
+    Array.isArray(t.traditions) &&
+    Array.isArray(t.centers)
+  );
+}
+
+const fullCandidate: AcceptedCandidate = {
+  name: "Ram Dass",
+  bio: "American spiritual teacher and author of Be Here Now.",
+  traditions: ["hinduism", "bhakti"],
+  location: { city: "Maui", state: "HI", country: "US" },
+  website: "https://ramdass.org",
+};
+
+describe("generateTeacherJson", () => {
+  it("generates a complete teacher with all fields", () => {
+    const teacher = generateTeacherJson(fullCandidate);
+    expect(teacher.name).toBe("Ram Dass");
+    expect(teacher.bio).toBe("American spiritual teacher and author of Be Here Now.");
+    expect(teacher.website).toBe("https://ramdass.org");
+    expect(teacher.city).toBe("Maui");
+    expect(teacher.state).toBe("HI");
+    expect(teacher.country).toBe("US");
+    expect(teacher.photo).toBeNull();
+    expect(teacher.birth_year).toBeNull();
+    expect(teacher.death_year).toBeNull();
+    expect(teacher.latitude).toBeNull();
+    expect(teacher.longitude).toBeNull();
+    expect(teacher.centers).toEqual([]);
+  });
+
+  it("generates slug: spaces to hyphens, lowercase", () => {
+    const teacher = generateTeacherJson(fullCandidate);
+    expect(teacher.slug).toBe("ram-dass");
+  });
+
+  it("generates slug: strips diacritics", () => {
+    const teacher = generateTeacherJson({
+      ...fullCandidate,
+      name: "Thích Nhất Hạnh",
+    });
+    expect(teacher.slug).toBe("thich-nhat-hanh");
+  });
+
+  it("generates slug: removes apostrophes", () => {
+    const teacher = generateTeacherJson({
+      ...fullCandidate,
+      name: "Christopher 'Hareesh' Wallis",
+    });
+    expect(teacher.slug).toBe("christopher-hareesh-wallis");
+  });
+
+  it("uses empty strings when location is null", () => {
+    const teacher = generateTeacherJson({
+      ...fullCandidate,
+      location: null,
+    });
+    expect(teacher.city).toBe("");
+    expect(teacher.state).toBe("");
+    expect(teacher.country).toBe("");
+  });
+
+  it("passes the isTeacher validator", () => {
+    const teacher = generateTeacherJson(fullCandidate);
+    expect(isTeacher(teacher)).toBe(true);
+  });
+
+  it("passes traditions array through correctly", () => {
+    const teacher = generateTeacherJson(fullCandidate);
+    expect(teacher.traditions).toEqual(["hinduism", "bhakti"]);
+  });
+});

--- a/scripts/lib/generate-teacher.ts
+++ b/scripts/lib/generate-teacher.ts
@@ -1,0 +1,39 @@
+import type { Teacher } from "../../src/lib/types";
+
+export interface AcceptedCandidate {
+  name: string;
+  bio: string;
+  traditions: string[];
+  location: { city: string; state: string; country: string } | null;
+  website: string | null;
+}
+
+function toSlug(name: string): string {
+  return name
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "") // strip diacritics
+    .toLowerCase()
+    .replace(/['']/g, "")           // remove apostrophes
+    .replace(/[^a-z0-9\s-]/g, "")   // remove other special chars
+    .trim()
+    .replace(/\s+/g, "-");          // spaces to hyphens
+}
+
+export function generateTeacherJson(candidate: AcceptedCandidate): Teacher {
+  return {
+    name: candidate.name,
+    slug: toSlug(candidate.name),
+    bio: candidate.bio,
+    photo: null,
+    website: candidate.website,
+    birth_year: null,
+    death_year: null,
+    city: candidate.location?.city ?? "",
+    state: candidate.location?.state ?? "",
+    country: candidate.location?.country ?? "",
+    latitude: null,
+    longitude: null,
+    traditions: candidate.traditions,
+    centers: [],
+  };
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -11,10 +11,11 @@ export default defineConfig({
     globals: true,
     environment: "jsdom",
     setupFiles: ["./src/test-setup.ts"],
-    include: ["src/**/*.test.{ts,tsx}"],
+    include: ["src/**/*.test.{ts,tsx}", "scripts/**/*.test.ts"],
     environmentMatchGlobs: [
       // Data tests don't need DOM
       ["src/lib/__tests__/*.test.ts", "node"],
+      ["scripts/**/*.test.ts", "node"],
     ],
   },
 });


### PR DESCRIPTION
## Summary
- Add `scripts/lib/generate-teacher.ts` — pure function that transforms an `AcceptedCandidate` into a publishable `Teacher` JSON object matching the existing schema
- Slug generation handles diacritics (Thích → thich), apostrophes, and special characters
- Sets appropriate null/empty defaults for fields not available at generation time (photo, birth/death year, lat/lng, centers)
- 7 vitest test cases covering all specified scenarios

## Test plan
- [x] All 7 new tests pass (`npx vitest run scripts/lib/__tests__/generate-teacher.test.ts`)
- [ ] Full test suite passes (pre-existing failures unrelated to this change)

Closes #106

🤖 Generated with [Claude Code](https://claude.com/claude-code)