### PR TITLE
feat: podcast scraper and teacher expansion pipeline

### DIFF
--- a/data/teachers/ah-almaas.json
+++ b/data/teachers/ah-almaas.json
@@ -1,0 +1,20 @@
+{
+  "name": "A.H. Almaas",
+  "slug": "ah-almaas",
+  "bio": "A.H. Almaas is the pen name of Hameed Ali, founder of the Diamond Approach to Self-Realization. His teaching integrates depth psychology with contemplative practices, drawing on Sufism and non-dual wisdom traditions.",
+  "photo": null,
+  "website": null,
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "advaita-vedanta",
+    "modern-non-dual",
+    "sufism"
+  ],
+  "centers": []
+}

--- a/data/teachers/anam-thubten.json
+++ b/data/teachers/anam-thubten.json
@@ -1,0 +1,20 @@
+{
+  "name": "Anam Thubten",
+  "slug": "anam-thubten",
+  "bio": "Anam Thubten is a Tibetan Buddhist teacher in the Nyingma tradition who leads the Dharmata Foundation. He teaches Dzogchen meditation and emphasizes direct experience of the nature of mind in the Vajrayana tradition.",
+  "photo": null,
+  "website": null,
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "dzogchen",
+    "tibetan-buddhism-gelug",
+    "vajrayana"
+  ],
+  "centers": []
+}

--- a/data/teachers/anna-douglas.json
+++ b/data/teachers/anna-douglas.json
@@ -1,0 +1,20 @@
+{
+  "name": "Anna Douglas",
+  "slug": "anna-douglas",
+  "bio": "Anna Douglas is a founding teacher of Spirit Rock Meditation Center. She teaches insight meditation and vipassana in the Theravada Buddhist tradition and has been practicing Buddhist meditation for over four decades.",
+  "photo": null,
+  "website": null,
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "early-buddhism",
+    "theravada",
+    "vipassana-movement"
+  ],
+  "centers": []
+}

--- a/data/teachers/brother-david-steindl-rast.json
+++ b/data/teachers/brother-david-steindl-rast.json
@@ -1,0 +1,18 @@
+{
+  "name": "Brother David Steindl-Rast",
+  "slug": "brother-david-steindl-rast",
+  "bio": "Brother David Steindl-Rast is a Benedictine monk known for his work in interfaith dialogue and contemplative prayer. He has been a bridge between Christian mysticism and Buddhist meditation, emphasizing gratefulness as a spiritual practice.",
+  "photo": null,
+  "website": null,
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "christian-mysticism"
+  ],
+  "centers": []
+}

--- a/data/teachers/diane-musho-hamilton.json
+++ b/data/teachers/diane-musho-hamilton.json
@@ -1,0 +1,18 @@
+{
+  "name": "Diane Musho Hamilton",
+  "slug": "diane-musho-hamilton",
+  "bio": "Diane Musho Hamilton is a Zen teacher who received dharma transmission in the Soto Zen lineage. She is known for integrating Zen practice with Integral theory and dialogue facilitation.",
+  "photo": null,
+  "website": null,
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "zen"
+  ],
+  "centers": []
+}

--- a/data/teachers/eckhart-tolle.json
+++ b/data/teachers/eckhart-tolle.json
@@ -1,0 +1,18 @@
+{
+  "name": "Eckhart Tolle",
+  "slug": "eckhart-tolle",
+  "bio": "Eckhart Tolle is a spiritual teacher and author of The Power of Now and A New Earth. His teachings emphasize non-dual awareness, present-moment consciousness, and transcending the ego through direct realization.",
+  "photo": null,
+  "website": null,
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "modern-non-dual"
+  ],
+  "centers": []
+}

--- a/data/teachers/fleet-maull.json
+++ b/data/teachers/fleet-maull.json
@@ -1,0 +1,18 @@
+{
+  "name": "Fleet Maull",
+  "slug": "fleet-maull",
+  "bio": "Fleet Maull is a Zen teacher and social activist who founded Prison Dharma Network. He received dharma transmission from Roshi Bernie Glassman and teaches Zen meditation and socially engaged Buddhism.",
+  "photo": null,
+  "website": null,
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "zen"
+  ],
+  "centers": []
+}

--- a/data/teachers/lama-tsultrim-allione.json
+++ b/data/teachers/lama-tsultrim-allione.json
@@ -1,0 +1,19 @@
+{
+  "name": "Lama Tsultrim Allione",
+  "slug": "lama-tsultrim-allione",
+  "bio": "Lama Tsultrim Allione is a teacher in the Tibetan Buddhist tradition and founder of Tara Mandala retreat center. She is known for reviving the practice of Chöd, a Vajrayana practice, and was one of the first American women ordained as a Tibetan Buddhist nun.",
+  "photo": null,
+  "website": null,
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "tibetan-buddhism-gelug",
+    "vajrayana"
+  ],
+  "centers": []
+}

--- a/data/teachers/llewellyn-vaughan-lee.json
+++ b/data/teachers/llewellyn-vaughan-lee.json
@@ -1,0 +1,18 @@
+{
+  "name": "Llewellyn Vaughan-Lee",
+  "slug": "llewellyn-vaughan-lee",
+  "bio": "Llewellyn Vaughan-Lee is a Sufi teacher and author in the Naqshbandiyya-Mujaddidiyya Sufi Order. He has written extensively on Sufi mysticism, dreamwork, and the spiritual significance of ecology from a contemplative Islamic perspective.",
+  "photo": null,
+  "website": null,
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "sufism"
+  ],
+  "centers": []
+}

--- a/data/teachers/matthew-fox.json
+++ b/data/teachers/matthew-fox.json
@@ -1,0 +1,18 @@
+{
+  "name": "Matthew Fox",
+  "slug": "matthew-fox",
+  "bio": "Matthew Fox is an American priest and theologian known for Creation Spirituality, a movement drawing on Christian mysticism, the teachings of Meister Eckhart and Hildegard of Bingen, and contemplative prayer traditions.",
+  "photo": null,
+  "website": null,
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "christian-mysticism"
+  ],
+  "centers": []
+}

--- a/data/teachers/mirabai-starr.json
+++ b/data/teachers/mirabai-starr.json
@@ -1,0 +1,19 @@
+{
+  "name": "Mirabai Starr",
+  "slug": "mirabai-starr",
+  "bio": "Mirabai Starr is a writer, translator, and teacher of the interspiritual path who draws on Christian mysticism, Sufism, and other contemplative traditions. She has translated works by Teresa of Ávila, John of the Cross, and other Christian contemplatives.",
+  "photo": null,
+  "website": null,
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "christian-mysticism",
+    "sufism"
+  ],
+  "centers": []
+}

--- a/data/teachers/ponlop-rinpoche.json
+++ b/data/teachers/ponlop-rinpoche.json
@@ -1,0 +1,20 @@
+{
+  "name": "Ponlop Rinpoche",
+  "slug": "ponlop-rinpoche",
+  "bio": "Dzogchen Ponlop Rinpoche is a Tibetan Buddhist master in the Karma Kagyu and Nyingma lineages. He teaches Mahamudra and Vajrayana meditation and founded Nalandabodhi, a network of Buddhist study and meditation centers.",
+  "photo": null,
+  "website": null,
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "dzogchen",
+    "tibetan-buddhism-gelug",
+    "vajrayana"
+  ],
+  "centers": []
+}

--- a/data/teachers/ravi-shankar.json
+++ b/data/teachers/ravi-shankar.json
@@ -1,0 +1,19 @@
+{
+  "name": "Ravi Shankar",
+  "slug": "ravi-shankar",
+  "bio": "Sri Sri Ravi Shankar is a spiritual teacher and humanitarian who founded the Art of Living Foundation. He teaches pranayama, meditation, and yoga philosophy rooted in Vedantic and classical yoga traditions.",
+  "photo": null,
+  "website": null,
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "classical-yoga",
+    "vedanta"
+  ],
+  "centers": []
+}

--- a/data/teachers/roshi-bernie-glassman.json
+++ b/data/teachers/roshi-bernie-glassman.json
@@ -1,0 +1,18 @@
+{
+  "name": "Roshi Bernie Glassman",
+  "slug": "roshi-bernie-glassman",
+  "bio": "Roshi Bernie Glassman was a Zen teacher and founder of the Zen Peacemakers. He received dharma transmission from Taizan Maezumi Roshi and was known for his street retreats and socially engaged Zen practice.",
+  "photo": null,
+  "website": null,
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "zen"
+  ],
+  "centers": []
+}

--- a/data/teachers/thomas-hubl.json
+++ b/data/teachers/thomas-hubl.json
@@ -1,0 +1,18 @@
+{
+  "name": "Thomas Hubl",
+  "slug": "thomas-hubl",
+  "bio": "Thomas Hubl is a spiritual teacher and author who works with contemplative practice and collective trauma integration. His approach incorporates mindfulness, mystical traditions, and awareness practices for healing ancestral and cultural trauma.",
+  "photo": null,
+  "website": null,
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "secular-mindfulness"
+  ],
+  "centers": []
+}

--- a/data/teachers/tsoknyi-rinpoche.json
+++ b/data/teachers/tsoknyi-rinpoche.json
@@ -1,0 +1,20 @@
+{
+  "name": "Tsoknyi Rinpoche",
+  "slug": "tsoknyi-rinpoche",
+  "bio": "Tsoknyi Rinpoche is a Tibetan Buddhist teacher in the Drukpa Kagyu and Nyingma lineages who teaches Dzogchen and Mahamudra. He is the son of Tulku Urgyen Rinpoche and leads retreats combining Vajrayana practice with embodied awareness.",
+  "photo": null,
+  "website": null,
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "dzogchen",
+    "tibetan-buddhism-gelug",
+    "vajrayana"
+  ],
+  "centers": []
+}

--- a/data/teachers/tsultrim-gyamtso-rinpoche.json
+++ b/data/teachers/tsultrim-gyamtso-rinpoche.json
@@ -1,0 +1,19 @@
+{
+  "name": "Tsultrim Gyamtso Rinpoche",
+  "slug": "tsultrim-gyamtso-rinpoche",
+  "bio": "Khenpo Tsultrim Gyamtso Rinpoche is a Tibetan Buddhist master known for his mastery of Mahamudra and Vajrayana philosophy. He trained in the Kagyu tradition and is celebrated for teaching through songs of realization.",
+  "photo": null,
+  "website": null,
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "tibetan-buddhism-gelug",
+    "vajrayana"
+  ],
+  "centers": []
+}

--- a/data/teachers/wes-nisker.json
+++ b/data/teachers/wes-nisker.json
@@ -1,0 +1,20 @@
+{
+  "name": "Wes Nisker",
+  "slug": "wes-nisker",
+  "bio": "Wes Nisker is a Buddhist teacher, author, and co-founder of the journal Inquiring Mind. He teaches vipassana meditation in the Theravada tradition and explores the intersection of Buddhism and evolutionary biology.",
+  "photo": null,
+  "website": null,
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "early-buddhism",
+    "theravada",
+    "vipassana-movement"
+  ],
+  "centers": []
+}

--- a/data/teachers/zenju-earthlyn-manuel.json
+++ b/data/teachers/zenju-earthlyn-manuel.json
@@ -1,0 +1,18 @@
+{
+  "name": "Zenju Earthlyn Manuel",
+  "slug": "zenju-earthlyn-manuel",
+  "bio": "Zenju Earthlyn Manuel is a Zen Buddhist priest who received dharma transmission in the Soto Zen lineage. She explores the intersection of Zen practice with race, identity, and social transformation.",
+  "photo": null,
+  "website": null,
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "zen"
+  ],
+  "centers": []
+}

--- a/scripts/data/iate-episodes.json
+++ b/scripts/data/iate-episodes.json
@@ -1,0 +1,250 @@
+[
+  {
+    "guest": "Tara Brach",
+    "description": "Tara Brach is a meditation teacher, psychologist, and author of Radical Acceptance and True Refuge. She leads the Insight Meditation Community of Washington and teaches vipassana and mindfulness meditation rooted in Buddhist psychology."
+  },
+  {
+    "guest": "Jack Kornfield",
+    "description": "Jack Kornfield is a Buddhist teacher, author, and co-founder of Spirit Rock Meditation Center. Trained as a Buddhist monk in Thailand, Burma, and India, he has been a key figure in bringing vipassana and Theravada Buddhist practice to the West."
+  },
+  {
+    "guest": "Pema Chödrön",
+    "description": "Pema Chödrön is an American Tibetan Buddhist nun and author. She is a teacher in the Shambhala tradition of Chögyam Trungpa and has written bestselling books on Vajrayana and Mahayana Buddhist teachings including When Things Fall Apart."
+  },
+  {
+    "guest": "Adyashanti",
+    "description": "Adyashanti is a spiritual teacher from the San Francisco Bay Area who draws on Zen Buddhism and Advaita Vedanta. His teachings emphasize direct experience and non-dual awakening, pointing to the nature of true self beyond thought."
+  },
+  {
+    "guest": "Sharon Salzberg",
+    "description": "Sharon Salzberg is a central figure in the field of meditation and co-founder of the Insight Meditation Society in Barre, Massachusetts. She has played a crucial role in bringing vipassana and loving-kindness (metta) meditation practices to the West."
+  },
+  {
+    "guest": "Roshi Joan Halifax",
+    "description": "Roshi Joan Halifax is a Zen Buddhist teacher, author, and founder of the Upaya Zen Center in Santa Fe. She received dharma transmission in the Rinzai and Soto lineages and is known for her work on death and dying and socially engaged Buddhism."
+  },
+  {
+    "guest": "Gangaji",
+    "description": "Gangaji is a teacher in the Advaita Vedanta tradition who received her spiritual name from H.W.L. Poonja (Papaji), a disciple of Ramana Maharshi. Her teachings focus on self-inquiry and the direct recognition of one's true nature."
+  },
+  {
+    "guest": "Lama Surya Das",
+    "description": "Lama Surya Das is one of the foremost Western Buddhist teachers trained in the Tibetan Buddhist Dzogchen tradition. He founded the Dzogchen Center and has studied under many great masters including Kalu Rinpoche and Nyoshul Khenpo."
+  },
+  {
+    "guest": "Krishna Das",
+    "description": "Krishna Das is a world-renowned devotional chanting artist and practitioner of bhakti yoga. A student of Neem Karoli Baba, he leads kirtan gatherings worldwide and has brought the bhakti tradition of devotional singing to Western audiences."
+  },
+  {
+    "guest": "Trudy Goodman",
+    "description": "Trudy Goodman is the founding teacher of InsightLA, a vipassana meditation community in Los Angeles. She has practiced Zen and vipassana for over 40 years and trained with Joseph Goldstein, Jack Kornfield, and several Zen masters."
+  },
+  {
+    "guest": "Reggie Ray",
+    "description": "Reggie Ray is a Buddhist teacher in the Vajrayana and Tibetan Buddhist tradition. He studied extensively with Chögyam Trungpa Rinpoche and founded Dharma Ocean Foundation, which focuses on somatic meditation and embodied awakening practices."
+  },
+  {
+    "guest": "Robert Thurman",
+    "description": "Robert Thurman is a scholar of Tibetan Buddhism, professor at Columbia University, and the first American to be ordained as a Tibetan Buddhist monk by the Dalai Lama. He is a leading interpreter of the Gelug tradition and Mahayana philosophy."
+  },
+  {
+    "guest": "Mirabai Starr",
+    "description": "Mirabai Starr is a writer, translator, and teacher of the interspiritual path who draws on Christian mysticism, Sufism, and other contemplative traditions. She has translated works by Teresa of Ávila, John of the Cross, and other Christian contemplatives."
+  },
+  {
+    "guest": "Ravi Shankar",
+    "description": "Sri Sri Ravi Shankar is a spiritual teacher and humanitarian who founded the Art of Living Foundation. He teaches pranayama, meditation, and yoga philosophy rooted in Vedantic and classical yoga traditions."
+  },
+  {
+    "guest": "A.H. Almaas",
+    "description": "A.H. Almaas is the pen name of Hameed Ali, founder of the Diamond Approach to Self-Realization. His teaching integrates depth psychology with contemplative practices, drawing on Sufism and non-dual wisdom traditions."
+  },
+  {
+    "guest": "Shinzen Young",
+    "description": "Shinzen Young is a mindfulness teacher known for his systematic approach to meditation. Trained in Zen Buddhism, vipassana, and Shingon Buddhism, he developed a system called Unified Mindfulness that bridges contemplative practice and neuroscience."
+  },
+  {
+    "guest": "Sylvia Boorstein",
+    "description": "Sylvia Boorstein is a psychotherapist and Buddhist teacher who co-founded Spirit Rock Meditation Center. She teaches vipassana and mindfulness meditation and is the author of several books including It's Easier Than You Think."
+  },
+  {
+    "guest": "Llewellyn Vaughan-Lee",
+    "description": "Llewellyn Vaughan-Lee is a Sufi teacher and author in the Naqshbandiyya-Mujaddidiyya Sufi Order. He has written extensively on Sufi mysticism, dreamwork, and the spiritual significance of ecology from a contemplative Islamic perspective."
+  },
+  {
+    "guest": "Thomas Hubl",
+    "description": "Thomas Hubl is a spiritual teacher and author who works with contemplative practice and collective trauma integration. His approach incorporates mindfulness, mystical traditions, and awareness practices for healing ancestral and cultural trauma."
+  },
+  {
+    "guest": "Diane Musho Hamilton",
+    "description": "Diane Musho Hamilton is a Zen teacher who received dharma transmission in the Soto Zen lineage. She is known for integrating Zen practice with Integral theory and dialogue facilitation."
+  },
+  {
+    "guest": "Father Thomas Keating",
+    "description": "Father Thomas Keating was a Trappist monk and priest who developed the practice of Centering Prayer. He was a founder of the Centering Prayer movement in Christian mysticism and the Contemplative Outreach organization."
+  },
+  {
+    "guest": "Jon Kabat-Zinn",
+    "description": "Jon Kabat-Zinn is the founder of Mindfulness-Based Stress Reduction (MBSR) and a pioneer in secular mindfulness. He has brought mindfulness meditation into mainstream medicine and society through scientific research at the UMass Medical Center."
+  },
+  {
+    "guest": "Ram Dass",
+    "description": "Ram Dass, born Richard Alpert, was a spiritual teacher, psychologist, and author of Be Here Now. A student of Neem Karoli Baba, he taught bhakti yoga, devotional practices, and explored the intersection of Eastern contemplative traditions and Western psychology."
+  },
+  {
+    "guest": "Lama Tsultrim Allione",
+    "description": "Lama Tsultrim Allione is a teacher in the Tibetan Buddhist tradition and founder of Tara Mandala retreat center. She is known for reviving the practice of Chöd, a Vajrayana practice, and was one of the first American women ordained as a Tibetan Buddhist nun."
+  },
+  {
+    "guest": "Matthew Fox",
+    "description": "Matthew Fox is an American priest and theologian known for Creation Spirituality, a movement drawing on Christian mysticism, the teachings of Meister Eckhart and Hildegard of Bingen, and contemplative prayer traditions."
+  },
+  {
+    "guest": "Roshi Bernie Glassman",
+    "description": "Roshi Bernie Glassman was a Zen teacher and founder of the Zen Peacemakers. He received dharma transmission from Taizan Maezumi Roshi and was known for his street retreats and socially engaged Zen practice."
+  },
+  {
+    "guest": "Joseph Goldstein",
+    "description": "Joseph Goldstein is a Buddhist teacher and co-founder of the Insight Meditation Society. He has been instrumental in bringing vipassana and Theravada Buddhist meditation practices to the West and is the author of Mindfulness: A Practical Guide."
+  },
+  {
+    "guest": "Eckhart Tolle",
+    "description": "Eckhart Tolle is a spiritual teacher and author of The Power of Now and A New Earth. His teachings emphasize non-dual awareness, present-moment consciousness, and transcending the ego through direct realization."
+  },
+  {
+    "guest": "Mingyur Rinpoche",
+    "description": "Yongey Mingyur Rinpoche is a Tibetan Buddhist master in the Karma Kagyu and Nyingma lineages. He teaches Vajrayana meditation, Dzogchen, and Mahamudra practices and is known for bridging Buddhist practice with neuroscience."
+  },
+  {
+    "guest": "Tsoknyi Rinpoche",
+    "description": "Tsoknyi Rinpoche is a Tibetan Buddhist teacher in the Drukpa Kagyu and Nyingma lineages who teaches Dzogchen and Mahamudra. He is the son of Tulku Urgyen Rinpoche and leads retreats combining Vajrayana practice with embodied awareness."
+  },
+  {
+    "guest": "Tsultrim Gyamtso Rinpoche",
+    "description": "Khenpo Tsultrim Gyamtso Rinpoche is a Tibetan Buddhist master known for his mastery of Mahamudra and Vajrayana philosophy. He trained in the Kagyu tradition and is celebrated for teaching through songs of realization."
+  },
+  {
+    "guest": "Brother David Steindl-Rast",
+    "description": "Brother David Steindl-Rast is a Benedictine monk known for his work in interfaith dialogue and contemplative prayer. He has been a bridge between Christian mysticism and Buddhist meditation, emphasizing gratefulness as a spiritual practice."
+  },
+  {
+    "guest": "Brené Brown",
+    "description": "Brené Brown is a research professor, author, and motivational speaker known for her work on vulnerability, courage, and empathy. She is a bestselling self-help author and leadership coach."
+  },
+  {
+    "guest": "Dan Siegel",
+    "description": "Dan Siegel is a clinical professor of psychiatry and psychotherapist known for interpersonal neurobiology. He developed the concept of mindsight and works with mindful awareness in psychotherapy contexts."
+  },
+  {
+    "guest": "Gabor Maté",
+    "description": "Gabor Maté is a physician and author known for his work on addiction and trauma. He is a psychotherapist who integrates somatic experiencing and compassionate inquiry approaches to healing."
+  },
+  {
+    "guest": "Peter Levine",
+    "description": "Peter Levine is the developer of Somatic Experiencing, a body-awareness approach to healing trauma. He is a psychotherapist and author of Waking the Tiger."
+  },
+  {
+    "guest": "Caroline Myss",
+    "description": "Caroline Myss is a medical intuitive and author who works with energy anatomy, psychic healing, and channeling spiritual guidance. She has written about archetypes, mysticism and energy medicine."
+  },
+  {
+    "guest": "Marianne Williamson",
+    "description": "Marianne Williamson is a self-help author, motivational speaker, and spiritual teacher known for her work with A Course in Miracles. She focuses on personal development and transformational thinking."
+  },
+  {
+    "guest": "Rupert Spira",
+    "description": "Rupert Spira is a teacher of the direct path of non-dual awareness. Influenced by Francis Lucille and the Advaita Vedanta tradition, he explores the nature of consciousness through contemplative self-inquiry and meditation."
+  },
+  {
+    "guest": "Cynthia Bourgeault",
+    "description": "Cynthia Bourgeault is an Episcopal priest, writer, and retreat leader rooted in Christian mysticism and centering prayer. She draws on the wisdom of the Desert Fathers, Thomas Merton, and the contemplative prayer tradition."
+  },
+  {
+    "guest": "Daniel Goleman",
+    "description": "Daniel Goleman is a psychologist and author of Emotional Intelligence who has explored the intersection of mindfulness meditation and neuroscience. He has studied with vipassana teachers and helped bring secular mindfulness into education and leadership."
+  },
+  {
+    "guest": "Spring Washam",
+    "description": "Spring Washam is a meditation teacher and founder of East Bay Meditation Center. She teaches vipassana and insight meditation in the Theravada Buddhist tradition and studied with Jack Kornfield."
+  },
+  {
+    "guest": "Zenju Earthlyn Manuel",
+    "description": "Zenju Earthlyn Manuel is a Zen Buddhist priest who received dharma transmission in the Soto Zen lineage. She explores the intersection of Zen practice with race, identity, and social transformation."
+  },
+  {
+    "guest": "Mark Epstein",
+    "description": "Mark Epstein is a psychiatrist and author who integrates Buddhist philosophy with psychotherapy. He has studied vipassana and Theravada Buddhist meditation and written about the intersection of dharma and psychological healing."
+  },
+  {
+    "guest": "Loch Kelly",
+    "description": "Loch Kelly is a meditation teacher and psychotherapist who teaches non-dual awareness and effortless mindfulness. His approach draws on Dzogchen, Mahamudra, and Advaita Vedanta traditions."
+  },
+  {
+    "guest": "David Whyte",
+    "description": "David Whyte is a poet and author who brings poetry into organizational and personal development settings. He is known as a motivational speaker and author of self-help oriented works on courage and conversation."
+  },
+  {
+    "guest": "Michael Singer",
+    "description": "Michael Singer is the author of The Untethered Soul and a teacher of meditation and yoga philosophy. His teachings draw on classical yoga, Vedanta, and contemplative self-inquiry practices."
+  },
+  {
+    "guest": "Tenzin Wangyal Rinpoche",
+    "description": "Tenzin Wangyal Rinpoche is a teacher of the Bön Dzogchen tradition of Tibet. He founded Ligmincha International and teaches Dzogchen meditation, dream yoga, and other contemplative practices from the ancient Bön tradition."
+  },
+  {
+    "guest": "Fleet Maull",
+    "description": "Fleet Maull is a Zen teacher and social activist who founded Prison Dharma Network. He received dharma transmission from Roshi Bernie Glassman and teaches Zen meditation and socially engaged Buddhism."
+  },
+  {
+    "guest": "Ponlop Rinpoche",
+    "description": "Dzogchen Ponlop Rinpoche is a Tibetan Buddhist master in the Karma Kagyu and Nyingma lineages. He teaches Mahamudra and Vajrayana meditation and founded Nalandabodhi, a network of Buddhist study and meditation centers."
+  },
+  {
+    "guest": "Norman Fischer",
+    "description": "Norman Fischer is a Zen teacher, poet, and former abbot of the San Francisco Zen Center. He founded the Everyday Zen Foundation and teaches Soto Zen meditation, emphasizing the integration of zazen with daily life."
+  },
+  {
+    "guest": "Roshi Pat Enkyo O'Hara",
+    "description": "Roshi Pat Enkyo O'Hara is the abbot of the Village Zendo in New York City. She received dharma transmission in the Soto Zen lineage from Maezumi Roshi's lineage and teaches Zen practice with a focus on social engagement."
+  },
+  {
+    "guest": "Shiva Rea",
+    "description": "Shiva Rea is a yoga teacher known for her Prana Vinyasa flow approach. She teaches vinyasa yoga, movement arts, and yoga as embodied practice focused on creative physical expression."
+  },
+  {
+    "guest": "Seane Corn",
+    "description": "Seane Corn is a yoga instructor known for her vinyasa yoga teaching and activism. She co-founded Off the Mat, Into the World and is known as a yoga teacher and community organizer."
+  },
+  {
+    "guest": "Lama Rod Owens",
+    "description": "Lama Rod Owens is a Buddhist teacher and activist authorized in the Kagyu lineage of Tibetan Buddhism. He studied under Lama Norlha Rinpoche and teaches Vajrayana meditation and dharma through the lens of radical love and social justice."
+  },
+  {
+    "guest": "Anam Thubten",
+    "description": "Anam Thubten is a Tibetan Buddhist teacher in the Nyingma tradition who leads the Dharmata Foundation. He teaches Dzogchen meditation and emphasizes direct experience of the nature of mind in the Vajrayana tradition."
+  },
+  {
+    "guest": "Sandra Ingerman",
+    "description": "Sandra Ingerman is a licensed therapist and teacher of shamanic journeying, soul retrieval, and psychic healing practices. She works with energy medicine and animistic spiritual traditions."
+  },
+  {
+    "guest": "James Finley",
+    "description": "James Finley is a clinical psychologist, author, and contemplative teacher who was a monk at the Abbey of Gethsemani under Thomas Merton. He teaches Christian mysticism and contemplative prayer rooted in the monastic tradition."
+  },
+  {
+    "guest": "Richard Rohr",
+    "description": "Richard Rohr is a Franciscan friar and founder of the Center for Action and Contemplation. He is a teacher of Christian mysticism, contemplative prayer, and the perennial tradition, drawing on the Desert Fathers, Meister Eckhart, and Thomas Merton."
+  },
+  {
+    "guest": "Tami Simon",
+    "description": "Tami Simon is the founder and publisher of Sounds True, a multimedia publisher of spiritual teachings. She is the host of Insights at the Edge and a practitioner of meditation and contemplative inquiry."
+  },
+  {
+    "guest": "Wes Nisker",
+    "description": "Wes Nisker is a Buddhist teacher, author, and co-founder of the journal Inquiring Mind. He teaches vipassana meditation in the Theravada tradition and explores the intersection of Buddhism and evolutionary biology."
+  },
+  {
+    "guest": "Anna Douglas",
+    "description": "Anna Douglas is a founding teacher of Spirit Rock Meditation Center. She teaches insight meditation and vipassana in the Theravada Buddhist tradition and has been practicing Buddhist meditation for over four decades."
+  }
+]

--- a/scripts/expand-teachers.ts
+++ b/scripts/expand-teachers.ts
@@ -1,0 +1,215 @@
+/**
+ * Teacher expansion pipeline — CLI entry point.
+ *
+ * Usage:
+ *   npx tsx scripts/expand-teachers.ts --source podcast
+ *   npx tsx scripts/expand-teachers.ts --source all
+ */
+
+import { readFileSync, writeFileSync, existsSync, mkdirSync, readdirSync } from "fs";
+import { join } from "path";
+import { classifyCandidate, type RawCandidate, type Classification } from "./lib/classify";
+import { generateTeacherJson, type AcceptedCandidate } from "./lib/generate-teacher";
+import { scrapePodcast } from "./scrape-podcast";
+
+// ---------------------------------------------------------------------------
+// CLI arg parsing
+// ---------------------------------------------------------------------------
+
+const args = process.argv.slice(2);
+const sourceIdx = args.indexOf("--source");
+const source = sourceIdx !== -1 ? args[sourceIdx + 1] : "all";
+
+if (!["podcast", "centers", "all"].includes(source)) {
+  console.error(`Unknown source: ${source}. Use --source podcast|centers|all`);
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+const ROOT = join(__dirname, "..");
+const TEACHERS_DIR = join(ROOT, "data", "teachers");
+const LLM_DIR = join(ROOT, ".llm");
+
+// ---------------------------------------------------------------------------
+// Load existing teacher names
+// ---------------------------------------------------------------------------
+
+function loadExistingTeacherNames(): string[] {
+  const files = readdirSync(TEACHERS_DIR).filter((f) => f.endsWith(".json"));
+  return files.map((f) => {
+    const data = JSON.parse(readFileSync(join(TEACHERS_DIR, f), "utf-8"));
+    return data.name as string;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Gather candidates from sources
+// ---------------------------------------------------------------------------
+
+function gatherCandidates(src: string): RawCandidate[] {
+  const candidates: RawCandidate[] = [];
+
+  if (src === "podcast" || src === "all") {
+    candidates.push(...scrapePodcast());
+  }
+
+  if (src === "centers") {
+    console.log("⚠  Centers source not yet implemented (see #108)");
+  }
+
+  return candidates;
+}
+
+// ---------------------------------------------------------------------------
+// Pipeline result types
+// ---------------------------------------------------------------------------
+
+interface PipelineRow {
+  index: number;
+  name: string;
+  status: "accepted" | "rejected" | "duplicate";
+  traditions: string[];
+  reason: string;
+  source: string;
+}
+
+// ---------------------------------------------------------------------------
+// Main pipeline
+// ---------------------------------------------------------------------------
+
+function run() {
+  console.log(`\nTeacher expansion pipeline — source: ${source}\n`);
+
+  const existingNames = loadExistingTeacherNames();
+  console.log(`Loaded ${existingNames.length} existing teachers for dedup.\n`);
+
+  const candidates = gatherCandidates(source);
+  console.log(`Found ${candidates.length} candidates from source(s).\n`);
+
+  const rows: PipelineRow[] = [];
+  const acceptedCandidates: { candidate: AcceptedCandidate; source: string }[] = [];
+  const centerLeads: { name: string; source: string }[] = [];
+
+  // Track names within this batch for intra-batch dedup
+  const batchNames: string[] = [...existingNames];
+
+  for (let i = 0; i < candidates.length; i++) {
+    const c = candidates[i];
+    const classification: Classification = classifyCandidate(c, batchNames);
+
+    const row: PipelineRow = {
+      index: i + 1,
+      name: c.name,
+      status: classification.status,
+      traditions: classification.traditions,
+      reason: classification.reject_reason ?? "—",
+      source: c.source,
+    };
+
+    if (classification.status === "accepted") {
+      // Add to batch names for intra-batch dedup
+      batchNames.push(c.name);
+
+      acceptedCandidates.push({
+        candidate: {
+          name: c.name,
+          bio: c.bio,
+          traditions: classification.traditions,
+          location: null,
+          website: null,
+        },
+        source: c.source,
+      });
+
+      // Track as potential center lead
+      centerLeads.push({ name: c.name, source: c.source });
+    }
+
+    if (classification.reject_reason === "duplicate") {
+      row.status = "duplicate";
+    }
+
+    rows.push(row);
+  }
+
+  // -------------------------------------------------------------------------
+  // Write accepted teacher JSON files
+  // -------------------------------------------------------------------------
+
+  let written = 0;
+  let skipped = 0;
+
+  for (const { candidate } of acceptedCandidates) {
+    const teacher = generateTeacherJson(candidate);
+    const filePath = join(TEACHERS_DIR, `${teacher.slug}.json`);
+
+    if (existsSync(filePath)) {
+      skipped++;
+      continue;
+    }
+
+    writeFileSync(filePath, JSON.stringify(teacher, null, 2) + "\n");
+    written++;
+  }
+
+  // -------------------------------------------------------------------------
+  // Summary table
+  // -------------------------------------------------------------------------
+
+  const accepted = rows.filter((r) => r.status === "accepted").length;
+  const rejected = rows.filter((r) => r.status === "rejected").length;
+  const duplicates = rows.filter((r) => r.status === "duplicate").length;
+
+  const tableHeader = "| # | Name | Status | Traditions | Reason | Source |";
+  const tableSep = "|---|------|--------|------------|--------|--------|";
+  const tableRows = rows.map(
+    (r) =>
+      `| ${r.index} | ${r.name} | ${r.status} | ${r.traditions.join(", ") || "—"} | ${r.reason} | ${r.source} |`,
+  );
+
+  const summaryLine = `\nAccepted: ${accepted} | Rejected: ${rejected} | Duplicates: ${duplicates}`;
+  const writeLine = `Written: ${written} new files | Skipped: ${skipped} (already exist)`;
+
+  const fullTable = [tableHeader, tableSep, ...tableRows, "", summaryLine, writeLine].join("\n");
+
+  console.log(fullTable);
+
+  // -------------------------------------------------------------------------
+  // Write pipeline results to .llm/
+  // -------------------------------------------------------------------------
+
+  if (!existsSync(LLM_DIR)) {
+    mkdirSync(LLM_DIR, { recursive: true });
+  }
+
+  writeFileSync(
+    join(LLM_DIR, "pipeline-results.md"),
+    `# Pipeline Results — ${new Date().toISOString().slice(0, 10)}\n\nSource: ${source}\n\n${fullTable}\n`,
+  );
+
+  // -------------------------------------------------------------------------
+  // Write center leads
+  // -------------------------------------------------------------------------
+
+  if (centerLeads.length > 0) {
+    const leadsContent = [
+      `# Center Leads — ${new Date().toISOString().slice(0, 10)}`,
+      "",
+      "Teachers accepted by the pipeline who may be associated with centers.",
+      "Use these as starting points for center discovery (see #108).",
+      "",
+      ...centerLeads.map((l) => `- ${l.name} (source: ${l.source})`),
+      "",
+    ].join("\n");
+
+    writeFileSync(join(LLM_DIR, "center-leads.md"), leadsContent);
+  }
+
+  console.log(`\nResults saved to .llm/pipeline-results.md`);
+  console.log(`Center leads saved to .llm/center-leads.md`);
+}
+
+run();

--- a/scripts/scrape-podcast.ts
+++ b/scripts/scrape-podcast.ts
@@ -1,0 +1,30 @@
+/**
+ * Insights at the Edge podcast scraper.
+ *
+ * Loads guest data from a curated seed file (scripts/data/iate-episodes.json)
+ * and returns RawCandidate objects for the classification pipeline.
+ *
+ * The seed approach was chosen because the Sounds True website is JS-rendered
+ * and difficult to scrape reliably. The seed file can be expanded over time.
+ */
+
+import { readFileSync } from "fs";
+import { join } from "path";
+import type { RawCandidate } from "./lib/classify";
+
+interface IATEEpisode {
+  guest: string;
+  description: string;
+}
+
+export function scrapePodcast(): RawCandidate[] {
+  const seedPath = join(__dirname, "data", "iate-episodes.json");
+  const raw = readFileSync(seedPath, "utf-8");
+  const episodes: IATEEpisode[] = JSON.parse(raw);
+
+  return episodes.map((ep) => ({
+    name: ep.guest,
+    bio: ep.description,
+    source: "iate",
+  }));
+}


### PR DESCRIPTION
## Summary

- Adds `scripts/expand-teachers.ts` — CLI pipeline runner (`--source podcast|centers|all`) that loads existing teachers, classifies candidates, deduplicates, generates JSON, and prints a summary table
- Adds `scripts/scrape-podcast.ts` — loads Insights at the Edge guest data from a curated seed file (`scripts/data/iate-episodes.json`, 62 guests)
- Adds 19 new teacher JSON files from the pipeline run

## Pipeline results

```
Accepted: 21 | Rejected: 12 | Duplicates: 29
Written: 19 new files | Skipped: 2 (already exist)
```

Rejections look correct: Brene Brown (self-help), Dan Siegel (therapist), Caroline Myss (new-age), Shiva Rea (yoga-non-contemplative), etc.

## Review checklist

- [ ] Review the summary table in `.llm/pipeline-results.md` (not committed — run the pipeline to generate)
- [ ] Spot-check a few generated teacher JSON files
- [ ] Verify no `npm run build` breakage (deferred per issue instructions)

## Test plan

- [x] Pipeline runs: `npx tsx scripts/expand-teachers.ts --source podcast`
- [x] Idempotent: second run writes 0 new files
- [x] Classifier correctly rejects non-contemplative guests
- [x] Duplicates detected against existing 110 teachers

Closes #107

🤖 Generated with [Claude Code](https://claude.com/claude-code)