### PR TITLE
feat: add 8 teachers from Tantra Illuminated podcast

### DIFF
--- a/data/teachers/andrew-holecek.json
+++ b/data/teachers/andrew-holecek.json
@@ -1,0 +1,16 @@
+{
+  "name": "Andrew Holecek",
+  "slug": "andrew-holecek",
+  "bio": "Andrew Holecek is a meditation teacher and author specializing in dream yoga and the Tibetan yogas of sleep. He began studying Tibetan Buddhism in 1987, trained extensively in Nepal, India, Bhutan, and Tibet, and completed the traditional three-year Buddhist meditation retreat. He is the author of 'Dream Yoga' and hosts the Edge of Mind podcast. He is also a member of the American Academy of Sleep Medicine.",
+  "photo": null,
+  "website": "https://www.andrewholecek.com",
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "Colorado",
+  "country": "US",
+  "latitude": null,
+  "longitude": null,
+  "traditions": ["vajrayana", "tibetan-buddhism-gelug"],
+  "centers": []
+}

--- a/data/teachers/artur-appazov.json
+++ b/data/teachers/artur-appazov.json
@@ -1,0 +1,16 @@
+{
+  "name": "Artur Appazov",
+  "slug": "artur-appazov",
+  "bio": "Artur Appazov is a nondual teacher, Stanford Law graduate, and former international criminal lawyer who advised the United Nations. Over twenty years of practice, his exploration deepened through Indian and Tibetan wisdom traditions, leading to a profound shift and a year and a half of intensive integration. He now offers nondual inquiry coaching focused on direct pointing, the continuous recognition of truth, and the interconnection of psychological and spiritual work.",
+  "photo": null,
+  "website": "https://www.arturappazov.com",
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "US",
+  "latitude": null,
+  "longitude": null,
+  "traditions": ["modern-non-dual"],
+  "centers": []
+}

--- a/data/teachers/eshwar-segobind.json
+++ b/data/teachers/eshwar-segobind.json
@@ -1,0 +1,16 @@
+{
+  "name": "Eshwar Segobind",
+  "slug": "eshwar-segobind",
+  "bio": "Eshwar Segobind is a nondual teacher whose rapid and unexpected awakening unfolded over less than a year, without any prior spiritual or religious background. His realization began during a stay in an addiction recovery center and led to a profound, spontaneous recognition of nondual awareness. He offers satsang and speaks with sincere seekers freely, and has been recognized for the startling simplicity of his teaching.",
+  "photo": null,
+  "website": null,
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "US",
+  "latitude": null,
+  "longitude": null,
+  "traditions": ["modern-non-dual"],
+  "centers": []
+}

--- a/data/teachers/judith-blackstone.json
+++ b/data/teachers/judith-blackstone.json
@@ -1,0 +1,16 @@
+{
+  "name": "Judith Blackstone",
+  "slug": "judith-blackstone",
+  "bio": "Judith Blackstone, Ph.D., is a nondual teacher and the developer of the Realization Process, a direct path for realizing fundamental consciousness and its application to psychological, relational, and physical healing. She has studied with teachers in Advaita Vedanta, Bhakti, Kashmir Shaivism, Zen, and Tibetan Buddhism, including a year in residence at a Zen monastery and decades of Mahamudra and Dzogchen practice. She has taught the Realization Process for over forty years.",
+  "photo": null,
+  "website": "https://realizationprocess.org",
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "US",
+  "latitude": null,
+  "longitude": null,
+  "traditions": ["modern-non-dual", "advaita-vedanta", "kashmir-shaivism", "zen"],
+  "centers": []
+}

--- a/data/teachers/kavitha-chinnaiyan.json
+++ b/data/teachers/kavitha-chinnaiyan.json
@@ -1,0 +1,16 @@
+{
+  "name": "Kavitha Chinnaiyan",
+  "slug": "kavitha-chinnaiyan",
+  "bio": "Dr. Kavitha Chinnaiyan is a cardiologist, Professor of Medicine, and a Tantric initiate and practitioner of Sri Vidya. She is a disciple of Sri Chaitanyananda Natha Saraswati and has studied yoga, Vedanta, and tantra through Chinmaya Mission and the teachings of Sally Kempton and Paul Muller-Ortega. She is the author of 'Shakti Rising,' 'The Heart of Wellness,' and 'Glorious Alchemy,' and founded the Svatantra Institute for contemplative study.",
+  "photo": null,
+  "website": "https://svatantra.institute",
+  "birth_year": null,
+  "death_year": null,
+  "city": "Rochester",
+  "state": "Michigan",
+  "country": "US",
+  "latitude": null,
+  "longitude": null,
+  "traditions": ["tantra", "kashmir-shaivism", "vedanta"],
+  "centers": []
+}

--- a/data/teachers/kiran-trace.json
+++ b/data/teachers/kiran-trace.json
@@ -1,0 +1,16 @@
+{
+  "name": "Kiran Trace",
+  "slug": "kiran-trace",
+  "bio": "Kiran Trace is a nondual teacher who experienced a spontaneous awakening in 2005 with no prior spiritual background. Encouraged by Adyashanti and others, she began teaching eight years later. She has mentored thousands of people across 17 countries, combining 15 years of clinical practice with direct applications of nondual realization. She is known for her frank, practical approach to post-awakening integration and the human dimensions of spiritual life.",
+  "photo": null,
+  "website": "https://kirantrace.com",
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "US",
+  "latitude": null,
+  "longitude": null,
+  "traditions": ["modern-non-dual"],
+  "centers": []
+}

--- a/data/teachers/michael-taft.json
+++ b/data/teachers/michael-taft.json
@@ -1,0 +1,16 @@
+{
+  "name": "Michael Taft",
+  "slug": "michael-taft",
+  "bio": "Michael Taft is a meditation teacher, author, and host of the Deconstructing Yourself podcast. He has practiced nondual meditation for over 35 years, with extensive experience in both Buddhist and Hindu Tantric traditions — from Zen temples in Japan to yogi caves in India. He is the author of 'The Mindful Geek' and 'Nondualism: A Brief History of a Timeless Concept,' and co-founded the Alembic center in Berkeley.",
+  "photo": null,
+  "website": "https://deconstructingyourself.com",
+  "birth_year": null,
+  "death_year": null,
+  "city": "Berkeley",
+  "state": "California",
+  "country": "US",
+  "latitude": null,
+  "longitude": null,
+  "traditions": ["modern-non-dual", "zen", "tantra"],
+  "centers": []
+}

--- a/data/teachers/tina-rasmussen.json
+++ b/data/teachers/tina-rasmussen.json
@@ -1,0 +1,16 @@
+{
+  "name": "Tina Rasmussen",
+  "slug": "tina-rasmussen",
+  "bio": "Tina Rasmussen, Ph.D., has been meditating for over 30 years. She was taught personally by the Venerable Pa Auk Sayadaw and was the first Western woman he authorized to teach, after completing the entire Samatha path in his lineage during an intensive year-long solo retreat. She also took refuge with Tsoknyi Rinpoche and was initiated into the Nyingma lineage. She teaches samatha, vipassana, the brahmaviharas, and Dzogchen practices, and is the co-author of 'Practicing the Jhanas.'",
+  "photo": null,
+  "website": "https://www.jhanasadvice.com",
+  "birth_year": null,
+  "death_year": null,
+  "city": "",
+  "state": "",
+  "country": "US",
+  "latitude": null,
+  "longitude": null,
+  "traditions": ["theravada", "vipassana-movement", "dzogchen"],
+  "centers": ["spirit-rock"]
+}


### PR DESCRIPTION
## Summary
8 new contemplative teachers sourced from the Tantra Illuminated podcast with Dr. Christopher Wallis (Hareesh). Each has a researched bio with tradition mappings.

Excluded from the guest list: Alexis Sanderson (academic, not practitioner), Josh Schrei (myth teller), Ben Joffe & Katherine Bennett (not practitioners), Ashton Szabo (uncertain), and non-contemplative guests (neuroscientists, interviewers).

## Test plan
- [ ] `npm run build` passes
- [ ] Spot-check teacher pages render

🤖 Generated with [Claude Code](https://claude.com/claude-code)