### PR TITLE
Create resource browse page with filters

### DIFF
--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -31,7 +31,14 @@ export default function LibraryPage() {
         <p className="text-lg text-muted-foreground leading-relaxed max-w-2xl">
           Curated reading paths through the contemplative traditions — each a
           sequence of 3–5 resources chosen to guide exploration of a tradition
-          or theme.
+          or theme. Looking for individual resources?{" "}
+          <a
+            href="/resources"
+            className="text-primary underline underline-offset-2 hover:text-primary/80 transition-colors"
+          >
+            Browse the full collection
+          </a>
+          .
         </p>
       </header>
 

--- a/src/app/resources/page.tsx
+++ b/src/app/resources/page.tsx
@@ -1,0 +1,53 @@
+import type { Metadata } from "next";
+import { PageLayout } from "@/components/page-layout";
+import { Breadcrumbs } from "@/components/breadcrumbs";
+import { getAllResources, getAllTraditions } from "@/lib/data";
+import { ResourcesClient } from "@/components/resources-client";
+import { SITE_URL } from "@/lib/seo";
+
+export const metadata: Metadata = {
+  title: "Resources",
+  description:
+    "Browse books, podcasts, videos, articles, and websites across contemplative traditions.",
+  openGraph: {
+    title: "Resources",
+    description:
+      "Browse books, podcasts, videos, articles, and websites across contemplative traditions.",
+    url: `${SITE_URL}/resources`,
+  },
+};
+
+export default function ResourcesPage() {
+  const resources = getAllResources().sort((a, b) =>
+    a.title.localeCompare(b.title)
+  );
+
+  const traditions = getAllTraditions();
+  const traditionNames: Record<string, string> = {};
+  for (const t of traditions) {
+    traditionNames[t.slug] = t.name;
+  }
+
+  return (
+    <PageLayout>
+      <Breadcrumbs items={[{ label: "Resources" }]} />
+
+      <header className="mb-10">
+        <h1 className="mb-3">Resources</h1>
+        <p className="text-lg text-muted-foreground leading-relaxed max-w-2xl">
+          Books, podcasts, videos, articles, and websites across contemplative
+          traditions. Want a guided journey? Try our{" "}
+          <a
+            href="/library"
+            className="text-primary underline underline-offset-2 hover:text-primary/80 transition-colors"
+          >
+            curated reading paths
+          </a>
+          .
+        </p>
+      </header>
+
+      <ResourcesClient resources={resources} traditionNames={traditionNames} />
+    </PageLayout>
+  );
+}

--- a/src/components/resources-client.tsx
+++ b/src/components/resources-client.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useState, useMemo, useCallback } from "react";
+import type { Resource } from "@/lib/types";
+import type { ResourceSearchFilters } from "@/lib/search";
+import { filterResources } from "@/lib/search";
+import { Input } from "@/components/ui/input";
+import { Select } from "@/components/ui/select";
+import { Badge } from "@/components/ui/badge";
+import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
+
+const RESOURCE_TYPES = ["book", "podcast", "video", "article", "website"] as const;
+
+function typeLabel(type: string): string {
+  return type.charAt(0).toUpperCase() + type.slice(1);
+}
+
+interface ResourcesClientProps {
+  resources: Resource[];
+  traditionNames: Record<string, string>;
+}
+
+export function ResourcesClient({ resources, traditionNames }: ResourcesClientProps) {
+  const [query, setQuery] = useState("");
+  const [selectedTraditions, setSelectedTraditions] = useState<string[]>([]);
+  const [selectedType, setSelectedType] = useState("");
+
+  const traditions = useMemo(() => {
+    const t = new Set<string>();
+    for (const r of resources) r.traditions.forEach((tr) => t.add(tr));
+    return Array.from(t).sort();
+  }, [resources]);
+
+  const filters: ResourceSearchFilters = useMemo(
+    () => ({ query, traditions: selectedTraditions, type: selectedType }),
+    [query, selectedTraditions, selectedType]
+  );
+
+  const results = useMemo(
+    () => filterResources(resources, filters),
+    [resources, filters]
+  );
+
+  const toggleTradition = useCallback((slug: string) => {
+    setSelectedTraditions((prev) =>
+      prev.includes(slug) ? prev.filter((t) => t !== slug) : [...prev, slug]
+    );
+  }, []);
+
+  const clearFilters = useCallback(() => {
+    setQuery("");
+    setSelectedTraditions([]);
+    setSelectedType("");
+  }, []);
+
+  const hasActiveFilters =
+    query !== "" || selectedTraditions.length > 0 || selectedType !== "";
+
+  return (
+    <div>
+      <div className="mb-8 space-y-4">
+        <Input
+          placeholder="Search by title or author..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          aria-label="Search resources by title or author"
+        />
+
+        <div className="flex flex-col gap-3 sm:flex-row sm:items-center">
+          <Select
+            value={selectedType}
+            onChange={(e) => setSelectedType(e.target.value)}
+            aria-label="Filter by type"
+            className="sm:max-w-xs"
+          >
+            <option value="">All types</option>
+            {RESOURCE_TYPES.map((type) => (
+              <option key={type} value={type}>
+                {typeLabel(type)}
+              </option>
+            ))}
+          </Select>
+
+          {hasActiveFilters && (
+            <button
+              onClick={clearFilters}
+              className="font-sans text-sm text-muted-foreground hover:text-foreground transition-colors underline underline-offset-2"
+            >
+              Clear filters
+            </button>
+          )}
+        </div>
+
+        <div className="flex flex-wrap gap-2" role="group" aria-label="Filter by tradition">
+          {traditions.map((slug) => {
+            const name = traditionNames[slug] ?? slug;
+            const isSelected = selectedTraditions.includes(slug);
+            return (
+              <button
+                key={slug}
+                onClick={() => toggleTradition(slug)}
+                aria-pressed={isSelected}
+                aria-label={`Filter by ${name}`}
+              >
+                <Badge variant={isSelected ? "family" : "tradition"}>
+                  {name}
+                </Badge>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <p className="font-sans text-sm text-muted-foreground mb-4">
+        {results.length} {results.length === 1 ? "resource" : "resources"}
+      </p>
+
+      {results.length === 0 ? (
+        <div className="text-center py-16">
+          <p className="text-lg text-muted-foreground mb-2">
+            No resources found.
+          </p>
+          <p className="text-sm text-muted-foreground">
+            Try adjusting your filters, or{" "}
+            <a
+              href="/library"
+              className="text-primary underline underline-offset-2 hover:text-primary/80 transition-colors"
+            >
+              explore our curated reading paths
+            </a>
+            .
+          </p>
+        </div>
+      ) : (
+        <div className="grid gap-4 sm:grid-cols-2">
+          {results.map((resource) => (
+            <a
+              key={resource.slug}
+              href={resource.url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="group"
+            >
+              <Card accent="terracotta" className="h-full group-hover:shadow-md">
+                <CardHeader>
+                  <div className="flex items-start justify-between gap-2">
+                    <CardTitle className="group-hover:text-primary transition-colors">
+                      {resource.title}
+                    </CardTitle>
+                    <Badge variant="outline" className="shrink-0">
+                      {typeLabel(resource.type)}
+                    </Badge>
+                  </div>
+                  <CardDescription>
+                    {resource.author && <span>{resource.author}</span>}
+                    {resource.author && resource.year && <span> · </span>}
+                    {resource.year && <span>{resource.year}</span>}
+                  </CardDescription>
+                </CardHeader>
+                <div className="px-5 pb-3">
+                  <p className="font-sans text-sm text-muted-foreground line-clamp-2">
+                    {resource.description}
+                  </p>
+                </div>
+                <div className="flex flex-wrap gap-1.5 px-5 pb-5">
+                  {resource.traditions.map((slug) => (
+                    <Badge key={slug} variant="tradition">
+                      {traditionNames[slug] ?? slug}
+                    </Badge>
+                  ))}
+                </div>
+              </Card>
+            </a>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -7,6 +7,7 @@ import { cn } from "@/lib/utils";
 const navLinks = [
   { href: "/map", label: "Map" },
   { href: "/library", label: "Library" },
+  { href: "/resources", label: "Resources" },
   { href: "/teachers", label: "Teachers" },
   { href: "/masters", label: "Masters" },
   { href: "/centers", label: "Centers" },

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,4 +1,4 @@
-import type { Teacher, Center } from "./types";
+import type { Teacher, Center, Resource } from "./types";
 
 export interface SearchFilters {
   query: string;
@@ -75,6 +75,32 @@ export function searchAll(
     (item) => ({ type: "center", item })
   );
   return [...teacherResults, ...centerResults];
+}
+
+// -- Resource filtering --
+
+export interface ResourceSearchFilters {
+  query: string;
+  traditions: string[];
+  type: string; // empty string = all types
+}
+
+/**
+ * Filter resources by title/author query, tradition, and type.
+ */
+export function filterResources(
+  resources: Resource[],
+  filters: ResourceSearchFilters
+): Resource[] {
+  return resources.filter((r) => {
+    if (!matchesQuery(r.title, filters.query) &&
+        !(r.author && matchesQuery(r.author, filters.query))) {
+      return false;
+    }
+    if (!matchesTraditions(r.traditions, filters.traditions)) return false;
+    if (filters.type && r.type !== filters.type) return false;
+    return true;
+  });
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `/resources` page with filterable grid of all resources
- Filter by type (book/video/podcast/article/website), tradition, and search
- Cross-link between library and resources pages
- Add Resources to site navigation

Closes #120

## Test plan
- [ ] `/resources` page renders all resources
- [ ] Type filter works (selecting "book" shows only books)
- [ ] Tradition filter works
- [ ] Search filters by title and author
- [ ] Empty state shows when no results match
- [ ] Resource links open in new tab
- [ ] Cross-links work in both directions
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)