### PR TITLE
Add geocoding script for teachers and centers

### DIFF
--- a/data/centers/abbey-of-gethsemani.json
+++ b/data/centers/abbey-of-gethsemani.json
@@ -7,8 +7,12 @@
   "city": "Trappist",
   "state": "Kentucky",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["christian-mysticism"],
-  "teachers": ["james-finley"]
+  "latitude": 37.652506,
+  "longitude": -85.569232,
+  "traditions": [
+    "christian-mysticism"
+  ],
+  "teachers": [
+    "james-finley"
+  ]
 }

--- a/data/centers/abhayagiri-buddhist-monastery.json
+++ b/data/centers/abhayagiri-buddhist-monastery.json
@@ -7,8 +7,13 @@
   "city": "Redwood Valley",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada"],
-  "teachers": ["ajahn-pasanno", "ajahn-sumedho"]
+  "latitude": 39.2683315,
+  "longitude": -123.1993752,
+  "traditions": [
+    "theravada"
+  ],
+  "teachers": [
+    "ajahn-pasanno",
+    "ajahn-sumedho"
+  ]
 }

--- a/data/centers/atlanta-soto-zen-center.json
+++ b/data/centers/atlanta-soto-zen-center.json
@@ -7,8 +7,10 @@
   "city": "Atlanta",
   "state": "Georgia",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
+  "latitude": 33.7544657,
+  "longitude": -84.3898151,
+  "traditions": [
+    "zen"
+  ],
   "teachers": []
 }

--- a/data/centers/barre-center-for-buddhist-studies.json
+++ b/data/centers/barre-center-for-buddhist-studies.json
@@ -7,8 +7,13 @@
   "city": "Barre",
   "state": "Massachusetts",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada", "early-buddhism"],
-  "teachers": ["stephen-batchelor"]
+  "latitude": 42.4228006,
+  "longitude": -72.1051592,
+  "traditions": [
+    "theravada",
+    "early-buddhism"
+  ],
+  "teachers": [
+    "stephen-batchelor"
+  ]
 }

--- a/data/centers/bhavana-society.json
+++ b/data/centers/bhavana-society.json
@@ -7,8 +7,10 @@
   "city": "High View",
   "state": "West Virginia",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada"],
+  "latitude": 39.2306585,
+  "longitude": -78.4083399,
+  "traditions": [
+    "theravada"
+  ],
   "teachers": []
 }

--- a/data/centers/blue-cliff-monastery.json
+++ b/data/centers/blue-cliff-monastery.json
@@ -7,8 +7,13 @@
   "city": "Pine Bush",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen", "mahayana"],
-  "teachers": ["thich-nhat-hanh"]
+  "latitude": 41.61329,
+  "longitude": -74.2939101,
+  "traditions": [
+    "zen",
+    "mahayana"
+  ],
+  "teachers": [
+    "thich-nhat-hanh"
+  ]
 }

--- a/data/centers/boundless-way-zen.json
+++ b/data/centers/boundless-way-zen.json
@@ -7,8 +7,10 @@
   "city": "Worcester",
   "state": "Massachusetts",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
+  "latitude": 42.2625621,
+  "longitude": -71.8018877,
+  "traditions": [
+    "zen"
+  ],
   "teachers": []
 }

--- a/data/centers/california-vipassana-center.json
+++ b/data/centers/california-vipassana-center.json
@@ -7,8 +7,10 @@
   "city": "North Fork",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vipassana-movement"],
+  "latitude": 37.2295677,
+  "longitude": -119.5096126,
+  "traditions": [
+    "vipassana-movement"
+  ],
   "teachers": []
 }

--- a/data/centers/cambridge-insight-meditation-center.json
+++ b/data/centers/cambridge-insight-meditation-center.json
@@ -7,8 +7,13 @@
   "city": "Cambridge",
   "state": "Massachusetts",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada", "vipassana-movement"],
-  "teachers": ["larry-rosenberg"]
+  "latitude": 42.3656347,
+  "longitude": -71.1040018,
+  "traditions": [
+    "theravada",
+    "vipassana-movement"
+  ],
+  "teachers": [
+    "larry-rosenberg"
+  ]
 }

--- a/data/centers/center-for-action-and-contemplation.json
+++ b/data/centers/center-for-action-and-contemplation.json
@@ -7,8 +7,14 @@
   "city": "Albuquerque",
   "state": "New Mexico",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["christian-mysticism"],
-  "teachers": ["richard-rohr", "cynthia-bourgeault", "james-finley"]
+  "latitude": 35.0841034,
+  "longitude": -106.650985,
+  "traditions": [
+    "christian-mysticism"
+  ],
+  "teachers": [
+    "richard-rohr",
+    "cynthia-bourgeault",
+    "james-finley"
+  ]
 }

--- a/data/centers/chan-meditation-center.json
+++ b/data/centers/chan-meditation-center.json
@@ -7,8 +7,11 @@
   "city": "Elmhurst",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["chan-buddhism", "mahayana"],
+  "latitude": 40.7365804,
+  "longitude": -73.8783932,
+  "traditions": [
+    "chan-buddhism",
+    "mahayana"
+  ],
   "teachers": []
 }

--- a/data/centers/chuang-yen-monastery.json
+++ b/data/centers/chuang-yen-monastery.json
@@ -7,8 +7,12 @@
   "city": "Carmel",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["mahayana"],
-  "teachers": ["bhikkhu-bodhi"]
+  "latitude": 41.4266361,
+  "longitude": -73.6788272,
+  "traditions": [
+    "mahayana"
+  ],
+  "teachers": [
+    "bhikkhu-bodhi"
+  ]
 }

--- a/data/centers/city-of-ten-thousand-buddhas.json
+++ b/data/centers/city-of-ten-thousand-buddhas.json
@@ -7,8 +7,11 @@
   "city": "Talmage",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["chan-buddhism", "mahayana"],
+  "latitude": 39.1332266,
+  "longitude": -123.167782,
+  "traditions": [
+    "chan-buddhism",
+    "mahayana"
+  ],
   "teachers": []
 }

--- a/data/centers/cloud-mountain-retreat-center.json
+++ b/data/centers/cloud-mountain-retreat-center.json
@@ -7,8 +7,11 @@
   "city": "Castle Rock",
   "state": "Washington",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vipassana-movement", "zen"],
+  "latitude": 46.2739907,
+  "longitude": -122.904918,
+  "traditions": [
+    "vipassana-movement",
+    "zen"
+  ],
   "teachers": []
 }

--- a/data/centers/dai-bosatsu-zendo.json
+++ b/data/centers/dai-bosatsu-zendo.json
@@ -7,8 +7,10 @@
   "city": "Livingston Manor",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
+  "latitude": 41.89321,
+  "longitude": -74.8268287,
+  "traditions": [
+    "zen"
+  ],
   "teachers": []
 }

--- a/data/centers/deer-park-monastery.json
+++ b/data/centers/deer-park-monastery.json
@@ -7,8 +7,13 @@
   "city": "Escondido",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen", "mahayana"],
-  "teachers": ["thich-nhat-hanh"]
+  "latitude": 33.1216751,
+  "longitude": -117.0814849,
+  "traditions": [
+    "zen",
+    "mahayana"
+  ],
+  "teachers": [
+    "thich-nhat-hanh"
+  ]
 }

--- a/data/centers/dhamma-dhara.json
+++ b/data/centers/dhamma-dhara.json
@@ -7,8 +7,10 @@
   "city": "Shelburne Falls",
   "state": "Massachusetts",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vipassana-movement"],
+  "latitude": 42.6035589,
+  "longitude": -72.7394623,
+  "traditions": [
+    "vipassana-movement"
+  ],
   "teachers": []
 }

--- a/data/centers/dhamma-patapa.json
+++ b/data/centers/dhamma-patapa.json
@@ -7,8 +7,10 @@
   "city": "Kaufman",
   "state": "Texas",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vipassana-movement"],
+  "latitude": 32.601641,
+  "longitude": -96.3375126,
+  "traditions": [
+    "vipassana-movement"
+  ],
   "teachers": []
 }

--- a/data/centers/dharma-ocean-foundation.json
+++ b/data/centers/dharma-ocean-foundation.json
@@ -7,8 +7,12 @@
   "city": "Crestone",
   "state": "Colorado",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vajrayana"],
-  "teachers": ["reggie-ray"]
+  "latitude": 37.995443,
+  "longitude": -105.6991929,
+  "traditions": [
+    "vajrayana"
+  ],
+  "teachers": [
+    "reggie-ray"
+  ]
 }

--- a/data/centers/east-bay-meditation-center.json
+++ b/data/centers/east-bay-meditation-center.json
@@ -7,8 +7,13 @@
   "city": "Oakland",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada", "vipassana-movement"],
-  "teachers": ["spring-washam"]
+  "latitude": 37.8044557,
+  "longitude": -122.271356,
+  "traditions": [
+    "theravada",
+    "vipassana-movement"
+  ],
+  "teachers": [
+    "spring-washam"
+  ]
 }

--- a/data/centers/esalen-institute.json
+++ b/data/centers/esalen-institute.json
@@ -7,8 +7,11 @@
   "city": "Big Sur",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["classical-yoga", "secular-mindfulness"],
+  "latitude": 36.1437044,
+  "longitude": -121.564593,
+  "traditions": [
+    "classical-yoga",
+    "secular-mindfulness"
+  ],
   "teachers": []
 }

--- a/data/centers/gampo-abbey.json
+++ b/data/centers/gampo-abbey.json
@@ -7,8 +7,12 @@
   "city": "Pleasant Bay",
   "state": "Nova Scotia",
   "country": "CA",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vajrayana"],
-  "teachers": ["pema-chodron"]
+  "latitude": 46.8230805,
+  "longitude": -60.7998526,
+  "traditions": [
+    "vajrayana"
+  ],
+  "teachers": [
+    "pema-chodron"
+  ]
 }

--- a/data/centers/garrison-institute.json
+++ b/data/centers/garrison-institute.json
@@ -7,8 +7,11 @@
   "city": "Garrison",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vipassana-movement", "secular-mindfulness"],
+  "latitude": 41.3839827,
+  "longitude": -73.945694,
+  "traditions": [
+    "vipassana-movement",
+    "secular-mindfulness"
+  ],
   "teachers": []
 }

--- a/data/centers/great-vow-zen-monastery.json
+++ b/data/centers/great-vow-zen-monastery.json
@@ -7,8 +7,12 @@
   "city": "Clatskanie",
   "state": "Oregon",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
-  "teachers": ["jan-chozen-bays"]
+  "latitude": 46.1036879,
+  "longitude": -123.2048168,
+  "traditions": [
+    "zen"
+  ],
+  "teachers": [
+    "jan-chozen-bays"
+  ]
 }

--- a/data/centers/green-gulch-farm.json
+++ b/data/centers/green-gulch-farm.json
@@ -7,8 +7,12 @@
   "city": "Muir Beach",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
-  "teachers": ["norman-fischer"]
+  "latitude": 37.8661174,
+  "longitude": -122.5898587,
+  "traditions": [
+    "zen"
+  ],
+  "teachers": [
+    "norman-fischer"
+  ]
 }

--- a/data/centers/holy-cross-monastery.json
+++ b/data/centers/holy-cross-monastery.json
@@ -7,8 +7,10 @@
   "city": "West Park",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["christian-mysticism"],
+  "latitude": 41.7945375,
+  "longitude": -73.9595823,
+  "traditions": [
+    "christian-mysticism"
+  ],
   "teachers": []
 }

--- a/data/centers/hsi-lai-temple.json
+++ b/data/centers/hsi-lai-temple.json
@@ -7,8 +7,11 @@
   "city": "Hacienda Heights",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["mahayana", "chan-buddhism"],
+  "latitude": 34.0004225,
+  "longitude": -117.9752615,
+  "traditions": [
+    "mahayana",
+    "chan-buddhism"
+  ],
   "teachers": []
 }

--- a/data/centers/insight-meditation-community-of-washington.json
+++ b/data/centers/insight-meditation-community-of-washington.json
@@ -7,8 +7,13 @@
   "city": "Bethesda",
   "state": "Maryland",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada", "vipassana-movement"],
-  "teachers": ["tara-brach"]
+  "latitude": 38.9812726,
+  "longitude": -77.1233587,
+  "traditions": [
+    "theravada",
+    "vipassana-movement"
+  ],
+  "teachers": [
+    "tara-brach"
+  ]
 }

--- a/data/centers/insight-meditation-society.json
+++ b/data/centers/insight-meditation-society.json
@@ -7,8 +7,19 @@
   "city": "Barre",
   "state": "Massachusetts",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada", "vipassana-movement"],
-  "teachers": ["joseph-goldstein", "sharon-salzberg", "jack-kornfield", "sylvia-boorstein", "larry-rosenberg", "jack-engler", "rob-burbea"]
+  "latitude": 42.4228006,
+  "longitude": -72.1051592,
+  "traditions": [
+    "theravada",
+    "vipassana-movement"
+  ],
+  "teachers": [
+    "joseph-goldstein",
+    "sharon-salzberg",
+    "jack-kornfield",
+    "sylvia-boorstein",
+    "larry-rosenberg",
+    "jack-engler",
+    "rob-burbea"
+  ]
 }

--- a/data/centers/insightla.json
+++ b/data/centers/insightla.json
@@ -7,8 +7,13 @@
   "city": "Los Angeles",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada", "vipassana-movement"],
-  "teachers": ["trudy-goodman"]
+  "latitude": 34.0536909,
+  "longitude": -118.242766,
+  "traditions": [
+    "theravada",
+    "vipassana-movement"
+  ],
+  "teachers": [
+    "trudy-goodman"
+  ]
 }

--- a/data/centers/integral-yoga-institute-new-york.json
+++ b/data/centers/integral-yoga-institute-new-york.json
@@ -7,8 +7,11 @@
   "city": "New York",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["classical-yoga", "bhakti"],
+  "latitude": 40.7127281,
+  "longitude": -74.0060152,
+  "traditions": [
+    "classical-yoga",
+    "bhakti"
+  ],
   "teachers": []
 }

--- a/data/centers/kadampa-center-raleigh.json
+++ b/data/centers/kadampa-center-raleigh.json
@@ -7,8 +7,10 @@
   "city": "Raleigh",
   "state": "North Carolina",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["tibetan-buddhism-gelug"],
+  "latitude": 35.7803977,
+  "longitude": -78.6390989,
+  "traditions": [
+    "tibetan-buddhism-gelug"
+  ],
   "teachers": []
 }

--- a/data/centers/kadampa-meditation-center-new-york.json
+++ b/data/centers/kadampa-meditation-center-new-york.json
@@ -7,8 +7,10 @@
   "city": "Glen Spey",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["tibetan-buddhism-gelug"],
+  "latitude": 41.4787025,
+  "longitude": -74.8134978,
+  "traditions": [
+    "tibetan-buddhism-gelug"
+  ],
   "teachers": []
 }

--- a/data/centers/karme-choling.json
+++ b/data/centers/karme-choling.json
@@ -7,8 +7,10 @@
   "city": "Barnet",
   "state": "Vermont",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vajrayana"],
+  "latitude": 44.2966923,
+  "longitude": -72.0495301,
+  "traditions": [
+    "vajrayana"
+  ],
   "teachers": []
 }

--- a/data/centers/kripalu-center.json
+++ b/data/centers/kripalu-center.json
@@ -7,8 +7,12 @@
   "city": "Stockbridge",
   "state": "Massachusetts",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["classical-yoga"],
-  "teachers": ["rolf-gates"]
+  "latitude": 42.282398,
+  "longitude": -73.3123684,
+  "traditions": [
+    "classical-yoga"
+  ],
+  "teachers": [
+    "rolf-gates"
+  ]
 }

--- a/data/centers/land-of-medicine-buddha.json
+++ b/data/centers/land-of-medicine-buddha.json
@@ -7,8 +7,10 @@
   "city": "Soquel",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["tibetan-buddhism-gelug"],
+  "latitude": 36.992568,
+  "longitude": -121.9428597,
+  "traditions": [
+    "tibetan-buddhism-gelug"
+  ],
   "teachers": []
 }

--- a/data/centers/ligmincha-international.json
+++ b/data/centers/ligmincha-international.json
@@ -7,8 +7,13 @@
   "city": "Charlottesville",
   "state": "Virginia",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["dzogchen", "vajrayana"],
-  "teachers": ["tenzin-wangyal-rinpoche"]
+  "latitude": 38.029306,
+  "longitude": -78.4766781,
+  "traditions": [
+    "dzogchen",
+    "vajrayana"
+  ],
+  "teachers": [
+    "tenzin-wangyal-rinpoche"
+  ]
 }

--- a/data/centers/magnolia-grove-monastery.json
+++ b/data/centers/magnolia-grove-monastery.json
@@ -7,8 +7,13 @@
   "city": "Batesville",
   "state": "Mississippi",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen", "mahayana"],
-  "teachers": ["thich-nhat-hanh"]
+  "latitude": 34.316488,
+  "longitude": -89.9527108,
+  "traditions": [
+    "zen",
+    "mahayana"
+  ],
+  "teachers": [
+    "thich-nhat-hanh"
+  ]
 }

--- a/data/centers/metta-forest-monastery.json
+++ b/data/centers/metta-forest-monastery.json
@@ -7,8 +7,10 @@
   "city": "Valley Center",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada"],
+  "latitude": 33.2183701,
+  "longitude": -117.0341967,
+  "traditions": [
+    "theravada"
+  ],
   "teachers": []
 }

--- a/data/centers/minnesota-zen-meditation-center.json
+++ b/data/centers/minnesota-zen-meditation-center.json
@@ -7,8 +7,10 @@
   "city": "Minneapolis",
   "state": "Minnesota",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
+  "latitude": 44.9772995,
+  "longitude": -93.2654692,
+  "traditions": [
+    "zen"
+  ],
   "teachers": []
 }

--- a/data/centers/monastery-of-the-holy-spirit.json
+++ b/data/centers/monastery-of-the-holy-spirit.json
@@ -7,8 +7,10 @@
   "city": "Conyers",
   "state": "Georgia",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["christian-mysticism"],
+  "latitude": 33.6676103,
+  "longitude": -84.0176904,
+  "traditions": [
+    "christian-mysticism"
+  ],
   "teachers": []
 }

--- a/data/centers/mount-baldy-zen-center.json
+++ b/data/centers/mount-baldy-zen-center.json
@@ -7,8 +7,10 @@
   "city": "Mt. Baldy",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
+  "latitude": 34.2364191,
+  "longitude": -117.6591731,
+  "traditions": [
+    "zen"
+  ],
   "teachers": []
 }

--- a/data/centers/mount-madonna-center.json
+++ b/data/centers/mount-madonna-center.json
@@ -7,8 +7,10 @@
   "city": "Watsonville",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["classical-yoga"],
+  "latitude": 36.9092773,
+  "longitude": -121.7529071,
+  "traditions": [
+    "classical-yoga"
+  ],
   "teachers": []
 }

--- a/data/centers/naropa-university.json
+++ b/data/centers/naropa-university.json
@@ -7,8 +7,10 @@
   "city": "Boulder",
   "state": "Colorado",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vajrayana"],
+  "latitude": 40.0149856,
+  "longitude": -105.270545,
+  "traditions": [
+    "vajrayana"
+  ],
   "teachers": []
 }

--- a/data/centers/new-camaldoli-hermitage.json
+++ b/data/centers/new-camaldoli-hermitage.json
@@ -7,8 +7,10 @@
   "city": "Big Sur",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["christian-mysticism"],
+  "latitude": 36.1437044,
+  "longitude": -121.564593,
+  "traditions": [
+    "christian-mysticism"
+  ],
   "teachers": []
 }

--- a/data/centers/new-york-insight.json
+++ b/data/centers/new-york-insight.json
@@ -7,8 +7,11 @@
   "city": "New York",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada", "vipassana-movement"],
+  "latitude": 40.7127281,
+  "longitude": -74.0060152,
+  "traditions": [
+    "theravada",
+    "vipassana-movement"
+  ],
   "teachers": []
 }

--- a/data/centers/omega-institute.json
+++ b/data/centers/omega-institute.json
@@ -7,8 +7,12 @@
   "city": "Rhinebeck",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["classical-yoga", "vipassana-movement", "secular-mindfulness"],
+  "latitude": 41.9267604,
+  "longitude": -73.912763,
+  "traditions": [
+    "classical-yoga",
+    "vipassana-movement",
+    "secular-mindfulness"
+  ],
   "teachers": []
 }

--- a/data/centers/pendle-hill.json
+++ b/data/centers/pendle-hill.json
@@ -7,8 +7,10 @@
   "city": "Wallingford",
   "state": "Pennsylvania",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["quaker-inner-light"],
+  "latitude": 39.9036359,
+  "longitude": -75.3716623,
+  "traditions": [
+    "quaker-inner-light"
+  ],
   "teachers": []
 }

--- a/data/centers/providence-zen-center.json
+++ b/data/centers/providence-zen-center.json
@@ -7,8 +7,10 @@
   "city": "Cumberland",
   "state": "Rhode Island",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
+  "latitude": 41.9667656,
+  "longitude": -71.4328363,
+  "traditions": [
+    "zen"
+  ],
   "teachers": []
 }

--- a/data/centers/rinzai-ji-zen-center.json
+++ b/data/centers/rinzai-ji-zen-center.json
@@ -7,8 +7,10 @@
   "city": "Los Angeles",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
+  "latitude": 34.0536909,
+  "longitude": -118.242766,
+  "traditions": [
+    "zen"
+  ],
   "teachers": []
 }

--- a/data/centers/rochester-zen-center.json
+++ b/data/centers/rochester-zen-center.json
@@ -7,8 +7,10 @@
   "city": "Rochester",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
+  "latitude": 43.157285,
+  "longitude": -77.615214,
+  "traditions": [
+    "zen"
+  ],
   "teachers": []
 }

--- a/data/centers/san-francisco-zen-center.json
+++ b/data/centers/san-francisco-zen-center.json
@@ -7,8 +7,14 @@
   "city": "San Francisco",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
-  "teachers": ["shunryu-suzuki", "norman-fischer", "tenshin-reb-anderson"]
+  "latitude": 37.7879363,
+  "longitude": -122.4075201,
+  "traditions": [
+    "zen"
+  ],
+  "teachers": [
+    "shunryu-suzuki",
+    "norman-fischer",
+    "tenshin-reb-anderson"
+  ]
 }

--- a/data/centers/satchidananda-ashram-yogaville.json
+++ b/data/centers/satchidananda-ashram-yogaville.json
@@ -7,8 +7,11 @@
   "city": "Buckingham",
   "state": "Virginia",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["classical-yoga", "bhakti"],
+  "latitude": 37.5558826,
+  "longitude": -78.5547172,
+  "traditions": [
+    "classical-yoga",
+    "bhakti"
+  ],
   "teachers": []
 }

--- a/data/centers/seattle-insight-meditation-society.json
+++ b/data/centers/seattle-insight-meditation-society.json
@@ -7,8 +7,13 @@
   "city": "Seattle",
   "state": "Washington",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada", "vipassana-movement"],
-  "teachers": ["rodney-smith"]
+  "latitude": 47.6038321,
+  "longitude": -122.330062,
+  "traditions": [
+    "theravada",
+    "vipassana-movement"
+  ],
+  "teachers": [
+    "rodney-smith"
+  ]
 }

--- a/data/centers/shambhala-mountain-center.json
+++ b/data/centers/shambhala-mountain-center.json
@@ -7,8 +7,13 @@
   "city": "Red Feather Lakes",
   "state": "Colorado",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vajrayana"],
-  "teachers": ["sakyong-mipham", "david-nichtern"]
+  "latitude": 40.8076878,
+  "longitude": -105.5756222,
+  "traditions": [
+    "vajrayana"
+  ],
+  "teachers": [
+    "sakyong-mipham",
+    "david-nichtern"
+  ]
 }

--- a/data/centers/shoshoni-yoga-retreat.json
+++ b/data/centers/shoshoni-yoga-retreat.json
@@ -7,8 +7,11 @@
   "city": "Rollinsville",
   "state": "Colorado",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["classical-yoga", "advaita-vedanta"],
+  "latitude": 39.9170921,
+  "longitude": -105.5017521,
+  "traditions": [
+    "classical-yoga",
+    "advaita-vedanta"
+  ],
   "teachers": []
 }

--- a/data/centers/sivananda-yoga-ranch.json
+++ b/data/centers/sivananda-yoga-ranch.json
@@ -7,8 +7,11 @@
   "city": "Woodbourne",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["classical-yoga", "vedanta"],
+  "latitude": 41.7614715,
+  "longitude": -74.599049,
+  "traditions": [
+    "classical-yoga",
+    "vedanta"
+  ],
   "teachers": []
 }

--- a/data/centers/sky-lake-lodge.json
+++ b/data/centers/sky-lake-lodge.json
@@ -7,8 +7,10 @@
   "city": "Rosendale",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vajrayana"],
+  "latitude": 41.8439818,
+  "longitude": -74.0820865,
+  "traditions": [
+    "vajrayana"
+  ],
   "teachers": []
 }

--- a/data/centers/southern-dharma-retreat-center.json
+++ b/data/centers/southern-dharma-retreat-center.json
@@ -7,8 +7,12 @@
   "city": "Hot Springs",
   "state": "North Carolina",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vipassana-movement", "zen", "classical-yoga"],
+  "latitude": 35.8923253,
+  "longitude": -82.8290318,
+  "traditions": [
+    "vipassana-movement",
+    "zen",
+    "classical-yoga"
+  ],
   "teachers": []
 }

--- a/data/centers/st-benedicts-monastery-snowmass.json
+++ b/data/centers/st-benedicts-monastery-snowmass.json
@@ -7,8 +7,12 @@
   "city": "Snowmass",
   "state": "Colorado",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["christian-mysticism"],
-  "teachers": ["father-thomas-keating"]
+  "latitude": 39.3310391,
+  "longitude": -106.9846471,
+  "traditions": [
+    "christian-mysticism"
+  ],
+  "teachers": [
+    "father-thomas-keating"
+  ]
 }

--- a/data/centers/st-josephs-abbey.json
+++ b/data/centers/st-josephs-abbey.json
@@ -7,8 +7,12 @@
   "city": "Spencer",
   "state": "Massachusetts",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["christian-mysticism"],
-  "teachers": ["father-thomas-keating"]
+  "latitude": 42.2436316,
+  "longitude": -71.9934879,
+  "traditions": [
+    "christian-mysticism"
+  ],
+  "teachers": [
+    "father-thomas-keating"
+  ]
 }

--- a/data/centers/tara-mandala.json
+++ b/data/centers/tara-mandala.json
@@ -7,8 +7,12 @@
   "city": "Pagosa Springs",
   "state": "Colorado",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vajrayana"],
-  "teachers": ["tsultrim-allione"]
+  "latitude": 37.2695661,
+  "longitude": -107.010816,
+  "traditions": [
+    "vajrayana"
+  ],
+  "teachers": [
+    "tsultrim-allione"
+  ]
 }

--- a/data/centers/tassajara-zen-mountain-center.json
+++ b/data/centers/tassajara-zen-mountain-center.json
@@ -7,8 +7,12 @@
   "city": "Carmel Valley",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
-  "teachers": ["shunryu-suzuki"]
+  "latitude": 36.4796839,
+  "longitude": -121.732447,
+  "traditions": [
+    "zen"
+  ],
+  "teachers": [
+    "shunryu-suzuki"
+  ]
 }

--- a/data/centers/temple-of-the-universe.json
+++ b/data/centers/temple-of-the-universe.json
@@ -7,8 +7,13 @@
   "city": "Alachua",
   "state": "Florida",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["classical-yoga", "vedanta"],
-  "teachers": ["michael-singer"]
+  "latitude": 29.675568,
+  "longitude": -82.3640109,
+  "traditions": [
+    "classical-yoga",
+    "vedanta"
+  ],
+  "teachers": [
+    "michael-singer"
+  ]
 }

--- a/data/centers/tergar-meditation-community.json
+++ b/data/centers/tergar-meditation-community.json
@@ -7,8 +7,13 @@
   "city": "Minneapolis",
   "state": "Minnesota",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vajrayana", "dzogchen"],
-  "teachers": ["mingyur-rinpoche"]
+  "latitude": 44.9772995,
+  "longitude": -93.2654692,
+  "traditions": [
+    "vajrayana",
+    "dzogchen"
+  ],
+  "teachers": [
+    "mingyur-rinpoche"
+  ]
 }

--- a/data/centers/tibet-house-us.json
+++ b/data/centers/tibet-house-us.json
@@ -7,8 +7,13 @@
   "city": "New York",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vajrayana", "tibetan-buddhism-gelug"],
-  "teachers": ["robert-thurman"]
+  "latitude": 40.7127281,
+  "longitude": -74.0060152,
+  "traditions": [
+    "vajrayana",
+    "tibetan-buddhism-gelug"
+  ],
+  "teachers": [
+    "robert-thurman"
+  ]
 }

--- a/data/centers/upaya-zen-center.json
+++ b/data/centers/upaya-zen-center.json
@@ -7,8 +7,12 @@
   "city": "Santa Fe",
   "state": "New Mexico",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
-  "teachers": ["roshi-joan-halifax"]
+  "latitude": 35.6876096,
+  "longitude": -105.938456,
+  "traditions": [
+    "zen"
+  ],
+  "teachers": [
+    "roshi-joan-halifax"
+  ]
 }

--- a/data/centers/village-zendo.json
+++ b/data/centers/village-zendo.json
@@ -7,8 +7,12 @@
   "city": "New York",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
-  "teachers": ["roshi-enkyo-ohara"]
+  "latitude": 40.7127281,
+  "longitude": -74.0060152,
+  "traditions": [
+    "zen"
+  ],
+  "teachers": [
+    "roshi-enkyo-ohara"
+  ]
 }

--- a/data/centers/weston-priory.json
+++ b/data/centers/weston-priory.json
@@ -7,8 +7,10 @@
   "city": "Weston",
   "state": "Vermont",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["christian-mysticism"],
+  "latitude": 43.2917153,
+  "longitude": -72.7932204,
+  "traditions": [
+    "christian-mysticism"
+  ],
   "teachers": []
 }

--- a/data/centers/woolman-hill.json
+++ b/data/centers/woolman-hill.json
@@ -7,8 +7,10 @@
   "city": "Deerfield",
   "state": "Massachusetts",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["quaker-inner-light"],
+  "latitude": 42.5436951,
+  "longitude": -72.6046649,
+  "traditions": [
+    "quaker-inner-light"
+  ],
   "teachers": []
 }

--- a/data/centers/yokoji-zen-mountain-center.json
+++ b/data/centers/yokoji-zen-mountain-center.json
@@ -7,8 +7,10 @@
   "city": "Mountain Center",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
+  "latitude": 33.7149535,
+  "longitude": -116.7250334,
+  "traditions": [
+    "zen"
+  ],
   "teachers": []
 }

--- a/data/centers/zen-center-of-los-angeles.json
+++ b/data/centers/zen-center-of-los-angeles.json
@@ -7,8 +7,10 @@
   "city": "Los Angeles",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
+  "latitude": 34.0536909,
+  "longitude": -118.242766,
+  "traditions": [
+    "zen"
+  ],
   "teachers": []
 }

--- a/data/centers/zen-center-of-new-york-city.json
+++ b/data/centers/zen-center-of-new-york-city.json
@@ -7,8 +7,10 @@
   "city": "Brooklyn",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
+  "latitude": 40.6526006,
+  "longitude": -73.9497211,
+  "traditions": [
+    "zen"
+  ],
   "teachers": []
 }

--- a/data/centers/zen-center-of-san-diego.json
+++ b/data/centers/zen-center-of-san-diego.json
@@ -7,8 +7,10 @@
   "city": "San Diego",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
+  "latitude": 32.7174202,
+  "longitude": -117.162772,
+  "traditions": [
+    "zen"
+  ],
   "teachers": []
 }

--- a/data/centers/zen-mountain-monastery.json
+++ b/data/centers/zen-mountain-monastery.json
@@ -7,8 +7,10 @@
   "city": "Mount Tremper",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
+  "latitude": 42.0448136,
+  "longitude": -74.2754247,
+  "traditions": [
+    "zen"
+  ],
   "teachers": []
 }

--- a/data/centers/zen-peacemakers.json
+++ b/data/centers/zen-peacemakers.json
@@ -7,8 +7,12 @@
   "city": "Montague",
   "state": "Massachusetts",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
-  "teachers": ["bernie-glassman"]
+  "latitude": 42.5901227,
+  "longitude": -72.5497332,
+  "traditions": [
+    "zen"
+  ],
+  "teachers": [
+    "bernie-glassman"
+  ]
 }

--- a/data/teachers/adyashanti.json
+++ b/data/teachers/adyashanti.json
@@ -9,8 +9,12 @@
   "city": "San Jose",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen", "modern-non-dual", "advaita-vedanta"],
+  "latitude": 37.3361663,
+  "longitude": -121.890591,
+  "traditions": [
+    "zen",
+    "modern-non-dual",
+    "advaita-vedanta"
+  ],
   "centers": []
 }

--- a/data/teachers/ajahn-chah.json
+++ b/data/teachers/ajahn-chah.json
@@ -9,8 +9,10 @@
   "city": "Ubon Ratchathani",
   "state": "Ubon Ratchathani",
   "country": "TH",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada"],
+  "latitude": 15.2274235,
+  "longitude": 104.8589462,
+  "traditions": [
+    "theravada"
+  ],
   "centers": []
 }

--- a/data/teachers/ajahn-lee.json
+++ b/data/teachers/ajahn-lee.json
@@ -9,8 +9,10 @@
   "city": "Bangkok",
   "state": "Bangkok",
   "country": "TH",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada"],
+  "latitude": 13.7393113,
+  "longitude": 100.5166499,
+  "traditions": [
+    "theravada"
+  ],
   "centers": []
 }

--- a/data/teachers/ajahn-pasanno.json
+++ b/data/teachers/ajahn-pasanno.json
@@ -9,8 +9,12 @@
   "city": "Redwood Valley",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada"],
-  "centers": ["abhayagiri-buddhist-monastery"]
+  "latitude": 39.2683315,
+  "longitude": -123.1993752,
+  "traditions": [
+    "theravada"
+  ],
+  "centers": [
+    "abhayagiri-buddhist-monastery"
+  ]
 }

--- a/data/teachers/ajahn-sumedho.json
+++ b/data/teachers/ajahn-sumedho.json
@@ -9,8 +9,8 @@
   "city": "Hemel Hempstead",
   "state": "England",
   "country": "UK",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 51.7511784,
+  "longitude": -0.472528,
   "traditions": [
     "theravada"
   ],

--- a/data/teachers/angel-kyodo-williams.json
+++ b/data/teachers/angel-kyodo-williams.json
@@ -9,8 +9,10 @@
   "city": "Berkeley",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
+  "latitude": 37.8708393,
+  "longitude": -122.272863,
+  "traditions": [
+    "zen"
+  ],
   "centers": []
 }

--- a/data/teachers/annamalai-swami.json
+++ b/data/teachers/annamalai-swami.json
@@ -9,8 +9,10 @@
   "city": "Tiruvannamalai",
   "state": "Tamil Nadu",
   "country": "IN",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["advaita-vedanta"],
+  "latitude": 12.4289282,
+  "longitude": 78.99915,
+  "traditions": [
+    "advaita-vedanta"
+  ],
   "centers": []
 }

--- a/data/teachers/b-alan-wallace.json
+++ b/data/teachers/b-alan-wallace.json
@@ -9,8 +9,11 @@
   "city": "Santa Barbara",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vajrayana", "dzogchen"],
+  "latitude": 34.4221319,
+  "longitude": -119.702667,
+  "traditions": [
+    "vajrayana",
+    "dzogchen"
+  ],
   "centers": []
 }

--- a/data/teachers/baizhang-huaihai.json
+++ b/data/teachers/baizhang-huaihai.json
@@ -9,8 +9,8 @@
   "city": "Nanchang",
   "state": "Jiangxi",
   "country": "CN",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 28.6472124,
+  "longitude": 116.0348483,
   "traditions": [
     "zen",
     "chan-buddhism"

--- a/data/teachers/bassui.json
+++ b/data/teachers/bassui.json
@@ -9,8 +9,10 @@
   "city": "Enzan",
   "state": "Yamanashi",
   "country": "JP",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
+  "latitude": 35.7054703,
+  "longitude": 138.7341835,
+  "traditions": [
+    "zen"
+  ],
   "centers": []
 }

--- a/data/teachers/bernie-glassman.json
+++ b/data/teachers/bernie-glassman.json
@@ -9,8 +9,8 @@
   "city": "Montague",
   "state": "Massachusetts",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 42.5901227,
+  "longitude": -72.5497332,
   "traditions": [
     "zen"
   ],

--- a/data/teachers/bhikkhu-bodhi.json
+++ b/data/teachers/bhikkhu-bodhi.json
@@ -9,8 +9,13 @@
   "city": "Carmel",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada", "early-buddhism"],
-  "centers": ["chuang-yen-monastery"]
+  "latitude": 41.4266361,
+  "longitude": -73.6788272,
+  "traditions": [
+    "theravada",
+    "early-buddhism"
+  ],
+  "centers": [
+    "chuang-yen-monastery"
+  ]
 }

--- a/data/teachers/bks-iyengar.json
+++ b/data/teachers/bks-iyengar.json
@@ -9,8 +9,10 @@
   "city": "Pune",
   "state": "Maharashtra",
   "country": "IN",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["classical-yoga"],
+  "latitude": 18.5213738,
+  "longitude": 73.8545071,
+  "traditions": [
+    "classical-yoga"
+  ],
   "centers": []
 }

--- a/data/teachers/caverly-morgan.json
+++ b/data/teachers/caverly-morgan.json
@@ -9,8 +9,10 @@
   "city": "Portland",
   "state": "Oregon",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
+  "latitude": 45.5202471,
+  "longitude": -122.674194,
+  "traditions": [
+    "zen"
+  ],
   "centers": []
 }

--- a/data/teachers/christiane-wolf.json
+++ b/data/teachers/christiane-wolf.json
@@ -9,8 +9,13 @@
   "city": "Los Angeles",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vipassana-movement", "secular-mindfulness"],
-  "centers": ["insightla"]
+  "latitude": 34.0536909,
+  "longitude": -118.242766,
+  "traditions": [
+    "vipassana-movement",
+    "secular-mindfulness"
+  ],
+  "centers": [
+    "insightla"
+  ]
 }

--- a/data/teachers/christopher-hareesh-wallis.json
+++ b/data/teachers/christopher-hareesh-wallis.json
@@ -9,8 +9,11 @@
   "city": "San Francisco",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["tantra", "kashmir-shaivism"],
+  "latitude": 37.7879363,
+  "longitude": -122.4075201,
+  "traditions": [
+    "tantra",
+    "kashmir-shaivism"
+  ],
   "centers": []
 }

--- a/data/teachers/cynthia-bourgeault.json
+++ b/data/teachers/cynthia-bourgeault.json
@@ -9,8 +9,12 @@
   "city": "Eagle Island",
   "state": "Maine",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["christian-mysticism"],
-  "centers": ["center-for-action-and-contemplation"]
+  "latitude": 43.7110349,
+  "longitude": -70.0527324,
+  "traditions": [
+    "christian-mysticism"
+  ],
+  "centers": [
+    "center-for-action-and-contemplation"
+  ]
 }

--- a/data/teachers/dan-harris.json
+++ b/data/teachers/dan-harris.json
@@ -9,8 +9,11 @@
   "city": "New York",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["secular-mindfulness", "vipassana-movement"],
+  "latitude": 40.7127281,
+  "longitude": -74.0060152,
+  "traditions": [
+    "secular-mindfulness",
+    "vipassana-movement"
+  ],
   "centers": []
 }

--- a/data/teachers/daniel-brown.json
+++ b/data/teachers/daniel-brown.json
@@ -9,8 +9,11 @@
   "city": "Newton",
   "state": "Massachusetts",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vajrayana", "dzogchen"],
+  "latitude": 42.3300435,
+  "longitude": -71.194862,
+  "traditions": [
+    "vajrayana",
+    "dzogchen"
+  ],
   "centers": []
 }

--- a/data/teachers/david-nichtern.json
+++ b/data/teachers/david-nichtern.json
@@ -9,8 +9,12 @@
   "city": "New York",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vajrayana"],
-  "centers": ["shambhala-mountain-center"]
+  "latitude": 40.7127281,
+  "longitude": -74.0060152,
+  "traditions": [
+    "vajrayana"
+  ],
+  "centers": [
+    "shambhala-mountain-center"
+  ]
 }

--- a/data/teachers/dilgo-khyentse-rinpoche.json
+++ b/data/teachers/dilgo-khyentse-rinpoche.json
@@ -9,8 +9,11 @@
   "city": "Thimphu",
   "state": "Thimphu",
   "country": "BT",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vajrayana", "dzogchen"],
+  "latitude": 27.4713546,
+  "longitude": 89.6336729,
+  "traditions": [
+    "vajrayana",
+    "dzogchen"
+  ],
   "centers": []
 }

--- a/data/teachers/donald-rothberg.json
+++ b/data/teachers/donald-rothberg.json
@@ -9,8 +9,8 @@
   "city": "Woodacre",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 38.004312,
+  "longitude": -122.636938,
   "traditions": [
     "theravada",
     "vipassana-movement"

--- a/data/teachers/dudjom-rinpoche.json
+++ b/data/teachers/dudjom-rinpoche.json
@@ -9,8 +9,11 @@
   "city": "Boudhanath",
   "state": "Bagmati",
   "country": "NP",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vajrayana", "dzogchen"],
+  "latitude": 27.7209963,
+  "longitude": 85.3622531,
+  "traditions": [
+    "vajrayana",
+    "dzogchen"
+  ],
   "centers": []
 }

--- a/data/teachers/dzigar-kongtrul-rinpoche.json
+++ b/data/teachers/dzigar-kongtrul-rinpoche.json
@@ -9,8 +9,8 @@
   "city": "Crestone",
   "state": "Colorado",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 37.995443,
+  "longitude": -105.6991929,
   "traditions": [
     "vajrayana",
     "dzogchen"

--- a/data/teachers/father-thomas-keating.json
+++ b/data/teachers/father-thomas-keating.json
@@ -9,8 +9,8 @@
   "city": "Snowmass",
   "state": "Colorado",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 39.3310391,
+  "longitude": -106.9846471,
   "traditions": [
     "christian-mysticism"
   ],

--- a/data/teachers/gabor-mate.json
+++ b/data/teachers/gabor-mate.json
@@ -9,8 +9,12 @@
   "city": "Vancouver",
   "state": "British Columbia",
   "country": "CA",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["secular-mindfulness"],
-  "centers": ["upaya-zen-center"]
+  "latitude": 49.2608724,
+  "longitude": -123.113952,
+  "traditions": [
+    "secular-mindfulness"
+  ],
+  "centers": [
+    "upaya-zen-center"
+  ]
 }

--- a/data/teachers/gangaji.json
+++ b/data/teachers/gangaji.json
@@ -9,8 +9,11 @@
   "city": "Ashland",
   "state": "Oregon",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["advaita-vedanta", "modern-non-dual"],
+  "latitude": 42.1972487,
+  "longitude": -122.7153995,
+  "traditions": [
+    "advaita-vedanta",
+    "modern-non-dual"
+  ],
   "centers": []
 }

--- a/data/teachers/geoffrey-shugen-arnold.json
+++ b/data/teachers/geoffrey-shugen-arnold.json
@@ -9,8 +9,12 @@
   "city": "Mt Tremper",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
-  "centers": ["zen-mountain-monastery"]
+  "latitude": 42.0448136,
+  "longitude": -74.2754247,
+  "traditions": [
+    "zen"
+  ],
+  "centers": [
+    "zen-mountain-monastery"
+  ]
 }

--- a/data/teachers/george-mumford.json
+++ b/data/teachers/george-mumford.json
@@ -9,8 +9,8 @@
   "city": "Boston",
   "state": "Massachusetts",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 42.3588336,
+  "longitude": -71.0578303,
   "traditions": [
     "vipassana-movement",
     "secular-mindfulness"

--- a/data/teachers/hafiz.json
+++ b/data/teachers/hafiz.json
@@ -9,8 +9,10 @@
   "city": "Shiraz",
   "state": "Fars",
   "country": "IR",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["sufism"],
+  "latitude": 29.6060218,
+  "longitude": 52.5378041,
+  "traditions": [
+    "sufism"
+  ],
   "centers": []
 }

--- a/data/teachers/hazrat-inayat-khan.json
+++ b/data/teachers/hazrat-inayat-khan.json
@@ -9,8 +9,10 @@
   "city": "Baroda",
   "state": "Gujarat",
   "country": "IN",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["sufism"],
+  "latitude": 22.2973142,
+  "longitude": 73.1942567,
+  "traditions": [
+    "sufism"
+  ],
   "centers": []
 }

--- a/data/teachers/hongzhi.json
+++ b/data/teachers/hongzhi.json
@@ -9,8 +9,8 @@
   "city": "Ningbo",
   "state": "Zhejiang",
   "country": "CN",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 29.8622194,
+  "longitude": 121.6203873,
   "traditions": [
     "zen",
     "chan-buddhism"

--- a/data/teachers/ilie-cioara.json
+++ b/data/teachers/ilie-cioara.json
@@ -9,8 +9,10 @@
   "city": "Bucharest",
   "state": "Bucharest",
   "country": "RO",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["modern-non-dual"],
+  "latitude": 44.4356445,
+  "longitude": 26.1009263,
+  "traditions": [
+    "modern-non-dual"
+  ],
   "centers": []
 }

--- a/data/teachers/jack-engler.json
+++ b/data/teachers/jack-engler.json
@@ -9,8 +9,13 @@
   "city": "Cambridge",
   "state": "Massachusetts",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada", "vipassana-movement"],
-  "centers": ["insight-meditation-society"]
+  "latitude": 42.3656347,
+  "longitude": -71.1040018,
+  "traditions": [
+    "theravada",
+    "vipassana-movement"
+  ],
+  "centers": [
+    "insight-meditation-society"
+  ]
 }

--- a/data/teachers/jack-kornfield.json
+++ b/data/teachers/jack-kornfield.json
@@ -9,8 +9,14 @@
   "city": "Woodacre",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada", "vipassana-movement"],
-  "centers": ["spirit-rock", "insight-meditation-society"]
+  "latitude": 38.004312,
+  "longitude": -122.636938,
+  "traditions": [
+    "theravada",
+    "vipassana-movement"
+  ],
+  "centers": [
+    "spirit-rock",
+    "insight-meditation-society"
+  ]
 }

--- a/data/teachers/james-finley.json
+++ b/data/teachers/james-finley.json
@@ -9,8 +9,8 @@
   "city": "Santa Monica",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 34.0194704,
+  "longitude": -118.491227,
   "traditions": [
     "christian-mysticism"
   ],

--- a/data/teachers/jan-chozen-bays.json
+++ b/data/teachers/jan-chozen-bays.json
@@ -9,8 +9,12 @@
   "city": "Clatskanie",
   "state": "Oregon",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
-  "centers": ["great-vow-zen-monastery"]
+  "latitude": 46.1036879,
+  "longitude": -123.2048168,
+  "traditions": [
+    "zen"
+  ],
+  "centers": [
+    "great-vow-zen-monastery"
+  ]
 }

--- a/data/teachers/jean-klein.json
+++ b/data/teachers/jean-klein.json
@@ -9,8 +9,11 @@
   "city": "Santa Barbara",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["advaita-vedanta", "modern-non-dual"],
+  "latitude": 34.4221319,
+  "longitude": -119.702667,
+  "traditions": [
+    "advaita-vedanta",
+    "modern-non-dual"
+  ],
   "centers": []
 }

--- a/data/teachers/jody-hojin-kimmel.json
+++ b/data/teachers/jody-hojin-kimmel.json
@@ -9,8 +9,12 @@
   "city": "Mt Tremper",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
-  "centers": ["zen-mountain-monastery"]
+  "latitude": 42.0448136,
+  "longitude": -74.2754247,
+  "traditions": [
+    "zen"
+  ],
+  "centers": [
+    "zen-mountain-monastery"
+  ]
 }

--- a/data/teachers/jon-kabat-zinn.json
+++ b/data/teachers/jon-kabat-zinn.json
@@ -9,8 +9,12 @@
   "city": "Lexington",
   "state": "Massachusetts",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["secular-mindfulness", "vipassana-movement", "zen"],
+  "latitude": 42.4473175,
+  "longitude": -71.2245003,
+  "traditions": [
+    "secular-mindfulness",
+    "vipassana-movement",
+    "zen"
+  ],
   "centers": []
 }

--- a/data/teachers/joseph-goldstein.json
+++ b/data/teachers/joseph-goldstein.json
@@ -9,8 +9,13 @@
   "city": "Barre",
   "state": "Massachusetts",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada", "vipassana-movement"],
-  "centers": ["insight-meditation-society"]
+  "latitude": 42.4228006,
+  "longitude": -72.1051592,
+  "traditions": [
+    "theravada",
+    "vipassana-movement"
+  ],
+  "centers": [
+    "insight-meditation-society"
+  ]
 }

--- a/data/teachers/kabir-helminski.json
+++ b/data/teachers/kabir-helminski.json
@@ -9,8 +9,10 @@
   "city": "Watsonville",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["sufism"],
+  "latitude": 36.9092773,
+  "longitude": -121.7529071,
+  "traditions": [
+    "sufism"
+  ],
   "centers": []
 }

--- a/data/teachers/kaira-jewel-lingo.json
+++ b/data/teachers/kaira-jewel-lingo.json
@@ -9,8 +9,8 @@
   "city": "Durham",
   "state": "North Carolina",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 35.996653,
+  "longitude": -78.9018053,
   "traditions": [
     "vipassana-movement",
     "zen"

--- a/data/teachers/kavitha-chinnaiyan.json
+++ b/data/teachers/kavitha-chinnaiyan.json
@@ -9,8 +9,12 @@
   "city": "Rochester",
   "state": "Michigan",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["tantra", "kashmir-shaivism", "vedanta"],
+  "latitude": 42.680588,
+  "longitude": -83.1338214,
+  "traditions": [
+    "tantra",
+    "kashmir-shaivism",
+    "vedanta"
+  ],
   "centers": []
 }

--- a/data/teachers/krishna-das.json
+++ b/data/teachers/krishna-das.json
@@ -9,8 +9,10 @@
   "city": "New York",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["bhakti"],
+  "latitude": 40.7127281,
+  "longitude": -74.0060152,
+  "traditions": [
+    "bhakti"
+  ],
   "centers": []
 }

--- a/data/teachers/lama-rod-owens.json
+++ b/data/teachers/lama-rod-owens.json
@@ -9,8 +9,8 @@
   "city": "Atlanta",
   "state": "Georgia",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 33.7544657,
+  "longitude": -84.3898151,
   "traditions": [
     "vajrayana",
     "tibetan-buddhism-gelug"

--- a/data/teachers/larry-rosenberg.json
+++ b/data/teachers/larry-rosenberg.json
@@ -9,8 +9,8 @@
   "city": "Cambridge",
   "state": "Massachusetts",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 42.3656347,
+  "longitude": -71.1040018,
   "traditions": [
     "theravada",
     "vipassana-movement"

--- a/data/teachers/loch-kelly.json
+++ b/data/teachers/loch-kelly.json
@@ -9,8 +9,11 @@
   "city": "New York",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["dzogchen", "modern-non-dual"],
+  "latitude": 40.7127281,
+  "longitude": -74.0060152,
+  "traditions": [
+    "dzogchen",
+    "modern-non-dual"
+  ],
   "centers": []
 }

--- a/data/teachers/madeline-klyne.json
+++ b/data/teachers/madeline-klyne.json
@@ -9,8 +9,8 @@
   "city": "Cambridge",
   "state": "Massachusetts",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 42.3656347,
+  "longitude": -71.1040018,
   "traditions": [
     "theravada",
     "vipassana-movement"

--- a/data/teachers/meister-eckhart.json
+++ b/data/teachers/meister-eckhart.json
@@ -9,8 +9,8 @@
   "city": "Cologne",
   "state": "North Rhine-Westphalia",
   "country": "DE",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 50.938361,
+  "longitude": 6.959974,
   "traditions": [
     "christian-mysticism"
   ],

--- a/data/teachers/michael-singer.json
+++ b/data/teachers/michael-singer.json
@@ -9,8 +9,13 @@
   "city": "Alachua",
   "state": "Florida",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["classical-yoga", "vedanta"],
-  "centers": ["temple-of-the-universe"]
+  "latitude": 29.675568,
+  "longitude": -82.3640109,
+  "traditions": [
+    "classical-yoga",
+    "vedanta"
+  ],
+  "centers": [
+    "temple-of-the-universe"
+  ]
 }

--- a/data/teachers/michael-taft.json
+++ b/data/teachers/michael-taft.json
@@ -9,8 +9,12 @@
   "city": "Berkeley",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["modern-non-dual", "zen", "tantra"],
+  "latitude": 37.8708393,
+  "longitude": -122.272863,
+  "traditions": [
+    "modern-non-dual",
+    "zen",
+    "tantra"
+  ],
   "centers": []
 }

--- a/data/teachers/mingyur-rinpoche.json
+++ b/data/teachers/mingyur-rinpoche.json
@@ -9,8 +9,13 @@
   "city": "Minneapolis",
   "state": "Minnesota",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vajrayana", "dzogchen"],
-  "centers": ["tergar-meditation-community"]
+  "latitude": 44.9772995,
+  "longitude": -93.2654692,
+  "traditions": [
+    "vajrayana",
+    "dzogchen"
+  ],
+  "centers": [
+    "tergar-meditation-community"
+  ]
 }

--- a/data/teachers/monshin-nannette-overley.json
+++ b/data/teachers/monshin-nannette-overley.json
@@ -9,8 +9,12 @@
   "city": "Santa Fe",
   "state": "New Mexico",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
-  "centers": ["upaya-zen-center"]
+  "latitude": 35.6876096,
+  "longitude": -105.938456,
+  "traditions": [
+    "zen"
+  ],
+  "centers": [
+    "upaya-zen-center"
+  ]
 }

--- a/data/teachers/narayan-helen-liebenson.json
+++ b/data/teachers/narayan-helen-liebenson.json
@@ -9,8 +9,8 @@
   "city": "Cambridge",
   "state": "Massachusetts",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 42.3656347,
+  "longitude": -71.1040018,
   "traditions": [
     "theravada",
     "vipassana-movement"

--- a/data/teachers/naropa.json
+++ b/data/teachers/naropa.json
@@ -9,8 +9,8 @@
   "city": "Nalanda",
   "state": "Bihar",
   "country": "IN",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 25.1364914,
+  "longitude": 85.4436546,
   "traditions": [
     "vajrayana"
   ],

--- a/data/teachers/nisargadatta-maharaj.json
+++ b/data/teachers/nisargadatta-maharaj.json
@@ -9,8 +9,8 @@
   "city": "Mumbai",
   "state": "Maharashtra",
   "country": "IN",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 19.054999,
+  "longitude": 72.8692035,
   "traditions": [
     "advaita-vedanta"
   ],

--- a/data/teachers/noah-levine.json
+++ b/data/teachers/noah-levine.json
@@ -9,8 +9,11 @@
   "city": "Los Angeles",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada", "vipassana-movement"],
+  "latitude": 34.0536909,
+  "longitude": -118.242766,
+  "traditions": [
+    "theravada",
+    "vipassana-movement"
+  ],
   "centers": []
 }

--- a/data/teachers/norman-fischer.json
+++ b/data/teachers/norman-fischer.json
@@ -9,8 +9,12 @@
   "city": "Muir Beach",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
-  "centers": ["san-francisco-zen-center"]
+  "latitude": 37.8661174,
+  "longitude": -122.5898587,
+  "traditions": [
+    "zen"
+  ],
+  "centers": [
+    "san-francisco-zen-center"
+  ]
 }

--- a/data/teachers/oren-jay-sofer.json
+++ b/data/teachers/oren-jay-sofer.json
@@ -9,8 +9,8 @@
   "city": "San Francisco",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 37.7879363,
+  "longitude": -122.4075201,
   "traditions": [
     "theravada",
     "vipassana-movement"

--- a/data/teachers/pablo-das.json
+++ b/data/teachers/pablo-das.json
@@ -9,8 +9,12 @@
   "city": "Los Angeles",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vipassana-movement"],
-  "centers": ["insightla"]
+  "latitude": 34.0536909,
+  "longitude": -118.242766,
+  "traditions": [
+    "vipassana-movement"
+  ],
+  "centers": [
+    "insightla"
+  ]
 }

--- a/data/teachers/pema-chodron.json
+++ b/data/teachers/pema-chodron.json
@@ -9,8 +9,13 @@
   "city": "Pleasant Bay",
   "state": "Nova Scotia",
   "country": "CA",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vajrayana", "tibetan-buddhism-gelug"],
-  "centers": ["gampo-abbey"]
+  "latitude": 46.8230805,
+  "longitude": -60.7998526,
+  "traditions": [
+    "vajrayana",
+    "tibetan-buddhism-gelug"
+  ],
+  "centers": [
+    "gampo-abbey"
+  ]
 }

--- a/data/teachers/phillip-moffitt.json
+++ b/data/teachers/phillip-moffitt.json
@@ -9,8 +9,13 @@
   "city": "Marin County",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada", "vipassana-movement"],
-  "centers": ["spirit-rock"]
+  "latitude": 38.0409144,
+  "longitude": -122.6199638,
+  "traditions": [
+    "theravada",
+    "vipassana-movement"
+  ],
+  "centers": [
+    "spirit-rock"
+  ]
 }

--- a/data/teachers/ram-dass.json
+++ b/data/teachers/ram-dass.json
@@ -9,8 +9,11 @@
   "city": "Maui",
   "state": "Hawaii",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["bhakti", "vedanta"],
+  "latitude": 20.8029568,
+  "longitude": -156.3106833,
+  "traditions": [
+    "bhakti",
+    "vedanta"
+  ],
   "centers": []
 }

--- a/data/teachers/ramana-maharshi.json
+++ b/data/teachers/ramana-maharshi.json
@@ -9,8 +9,8 @@
   "city": "Tiruvannamalai",
   "state": "Tamil Nadu",
   "country": "IN",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 12.4289282,
+  "longitude": 78.99915,
   "traditions": [
     "advaita-vedanta"
   ],

--- a/data/teachers/reggie-ray.json
+++ b/data/teachers/reggie-ray.json
@@ -9,8 +9,8 @@
   "city": "Crestone",
   "state": "Colorado",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 37.995443,
+  "longitude": -105.6991929,
   "traditions": [
     "vajrayana"
   ],

--- a/data/teachers/richard-rohr.json
+++ b/data/teachers/richard-rohr.json
@@ -9,8 +9,12 @@
   "city": "Albuquerque",
   "state": "New Mexico",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["christian-mysticism"],
-  "centers": ["center-for-action-and-contemplation"]
+  "latitude": 35.0841034,
+  "longitude": -106.650985,
+  "traditions": [
+    "christian-mysticism"
+  ],
+  "centers": [
+    "center-for-action-and-contemplation"
+  ]
 }

--- a/data/teachers/robert-svoboda.json
+++ b/data/teachers/robert-svoboda.json
@@ -9,8 +9,11 @@
   "city": "Albuquerque",
   "state": "New Mexico",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["tantra", "classical-yoga"],
+  "latitude": 35.0841034,
+  "longitude": -106.650985,
+  "traditions": [
+    "tantra",
+    "classical-yoga"
+  ],
   "centers": []
 }

--- a/data/teachers/robert-thurman.json
+++ b/data/teachers/robert-thurman.json
@@ -9,8 +9,13 @@
   "city": "New York",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vajrayana", "tibetan-buddhism-gelug"],
-  "centers": ["tibet-house-us"]
+  "latitude": 40.7127281,
+  "longitude": -74.0060152,
+  "traditions": [
+    "vajrayana",
+    "tibetan-buddhism-gelug"
+  ],
+  "centers": [
+    "tibet-house-us"
+  ]
 }

--- a/data/teachers/rodney-smith.json
+++ b/data/teachers/rodney-smith.json
@@ -9,8 +9,8 @@
   "city": "Seattle",
   "state": "Washington",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 47.6038321,
+  "longitude": -122.330062,
   "traditions": [
     "theravada",
     "vipassana-movement"

--- a/data/teachers/rolf-gates.json
+++ b/data/teachers/rolf-gates.json
@@ -9,8 +9,12 @@
   "city": "Santa Cruz",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["classical-yoga"],
-  "centers": ["kripalu-center"]
+  "latitude": 36.9743626,
+  "longitude": -122.0294673,
+  "traditions": [
+    "classical-yoga"
+  ],
+  "centers": [
+    "kripalu-center"
+  ]
 }

--- a/data/teachers/roshi-enkyo-ohara.json
+++ b/data/teachers/roshi-enkyo-ohara.json
@@ -9,8 +9,12 @@
   "city": "New York",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
-  "centers": ["village-zendo"]
+  "latitude": 40.7127281,
+  "longitude": -74.0060152,
+  "traditions": [
+    "zen"
+  ],
+  "centers": [
+    "village-zendo"
+  ]
 }

--- a/data/teachers/roshi-joan-halifax.json
+++ b/data/teachers/roshi-joan-halifax.json
@@ -9,8 +9,13 @@
   "city": "Santa Fe",
   "state": "New Mexico",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen", "mahayana"],
-  "centers": ["upaya-zen-center"]
+  "latitude": 35.6876096,
+  "longitude": -105.938456,
+  "traditions": [
+    "zen",
+    "mahayana"
+  ],
+  "centers": [
+    "upaya-zen-center"
+  ]
 }

--- a/data/teachers/roshi-robert-kennedy.json
+++ b/data/teachers/roshi-robert-kennedy.json
@@ -9,8 +9,11 @@
   "city": "Jersey City",
   "state": "New Jersey",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen", "christian-mysticism"],
+  "latitude": 40.7215682,
+  "longitude": -74.047455,
+  "traditions": [
+    "zen",
+    "christian-mysticism"
+  ],
   "centers": []
 }

--- a/data/teachers/rumi.json
+++ b/data/teachers/rumi.json
@@ -9,8 +9,8 @@
   "city": "Konya",
   "state": "Konya",
   "country": "TR",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 37.872734,
+  "longitude": 32.4924376,
   "traditions": [
     "sufism"
   ],

--- a/data/teachers/ryokan.json
+++ b/data/teachers/ryokan.json
@@ -9,8 +9,10 @@
   "city": "Izumozaki",
   "state": "Niigata",
   "country": "JP",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
+  "latitude": 37.5306685,
+  "longitude": 138.7095075,
+  "traditions": [
+    "zen"
+  ],
   "centers": []
 }

--- a/data/teachers/sadhguru.json
+++ b/data/teachers/sadhguru.json
@@ -9,8 +9,10 @@
   "city": "Coimbatore",
   "state": "Tamil Nadu",
   "country": "IN",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["classical-yoga"],
+  "latitude": 11.0018115,
+  "longitude": 76.9628425,
+  "traditions": [
+    "classical-yoga"
+  ],
   "centers": []
 }

--- a/data/teachers/sakyong-mipham.json
+++ b/data/teachers/sakyong-mipham.json
@@ -9,8 +9,12 @@
   "city": "Halifax",
   "state": "Nova Scotia",
   "country": "CA",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vajrayana"],
-  "centers": ["shambhala-mountain-center"]
+  "latitude": 44.648618,
+  "longitude": -63.5859487,
+  "traditions": [
+    "vajrayana"
+  ],
+  "centers": [
+    "shambhala-mountain-center"
+  ]
 }

--- a/data/teachers/sharon-salzberg.json
+++ b/data/teachers/sharon-salzberg.json
@@ -9,8 +9,13 @@
   "city": "New York",
   "state": "New York",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada", "vipassana-movement"],
-  "centers": ["insight-meditation-society"]
+  "latitude": 40.7127281,
+  "longitude": -74.0060152,
+  "traditions": [
+    "theravada",
+    "vipassana-movement"
+  ],
+  "centers": [
+    "insight-meditation-society"
+  ]
 }

--- a/data/teachers/shinzen-young.json
+++ b/data/teachers/shinzen-young.json
@@ -9,8 +9,12 @@
   "city": "Burlington",
   "state": "Vermont",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vipassana-movement", "secular-mindfulness", "zen"],
+  "latitude": 44.4761601,
+  "longitude": -73.212906,
+  "traditions": [
+    "vipassana-movement",
+    "secular-mindfulness",
+    "zen"
+  ],
   "centers": []
 }

--- a/data/teachers/shunryu-suzuki.json
+++ b/data/teachers/shunryu-suzuki.json
@@ -9,8 +9,13 @@
   "city": "San Francisco",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
-  "centers": ["san-francisco-zen-center", "tassajara-zen-mountain-center"]
+  "latitude": 37.7879363,
+  "longitude": -122.4075201,
+  "traditions": [
+    "zen"
+  ],
+  "centers": [
+    "san-francisco-zen-center",
+    "tassajara-zen-mountain-center"
+  ]
 }

--- a/data/teachers/spring-washam.json
+++ b/data/teachers/spring-washam.json
@@ -9,8 +9,14 @@
   "city": "Oakland",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada", "vipassana-movement"],
-  "centers": ["east-bay-meditation-center", "spirit-rock"]
+  "latitude": 37.8044557,
+  "longitude": -122.271356,
+  "traditions": [
+    "theravada",
+    "vipassana-movement"
+  ],
+  "centers": [
+    "east-bay-meditation-center",
+    "spirit-rock"
+  ]
 }

--- a/data/teachers/st-teresa-of-avila.json
+++ b/data/teachers/st-teresa-of-avila.json
@@ -9,8 +9,10 @@
   "city": "Avila",
   "state": "Castile and León",
   "country": "ES",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["christian-mysticism"],
+  "latitude": 40.656478,
+  "longitude": -4.7002172,
+  "traditions": [
+    "christian-mysticism"
+  ],
   "centers": []
 }

--- a/data/teachers/stephen-batchelor.json
+++ b/data/teachers/stephen-batchelor.json
@@ -9,8 +9,8 @@
   "city": "Aquitaine",
   "state": "Nouvelle-Aquitaine",
   "country": "France",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 46.5669966,
+  "longitude": 0.2879417,
   "traditions": [
     "secular-mindfulness",
     "early-buddhism"

--- a/data/teachers/swami-sivananda.json
+++ b/data/teachers/swami-sivananda.json
@@ -9,8 +9,11 @@
   "city": "Rishikesh",
   "state": "Uttarakhand",
   "country": "IN",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vedanta", "classical-yoga"],
+  "latitude": 30.1086537,
+  "longitude": 78.2916193,
+  "traditions": [
+    "vedanta",
+    "classical-yoga"
+  ],
   "centers": []
 }

--- a/data/teachers/swami-vivekananda.json
+++ b/data/teachers/swami-vivekananda.json
@@ -9,8 +9,8 @@
   "city": "Kolkata",
   "state": "West Bengal",
   "country": "IN",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 22.5726459,
+  "longitude": 88.3638953,
   "traditions": [
     "vedanta",
     "classical-yoga"

--- a/data/teachers/sylvia-boorstein.json
+++ b/data/teachers/sylvia-boorstein.json
@@ -9,8 +9,14 @@
   "city": "Sonoma County",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada", "vipassana-movement"],
-  "centers": ["spirit-rock", "insight-meditation-society"]
+  "latitude": 38.5110803,
+  "longitude": -122.8473388,
+  "traditions": [
+    "theravada",
+    "vipassana-movement"
+  ],
+  "centers": [
+    "spirit-rock",
+    "insight-meditation-society"
+  ]
 }

--- a/data/teachers/t-krishnamacharya.json
+++ b/data/teachers/t-krishnamacharya.json
@@ -9,8 +9,10 @@
   "city": "Mysore",
   "state": "Karnataka",
   "country": "IN",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["classical-yoga"],
+  "latitude": 12.3051828,
+  "longitude": 76.6553609,
+  "traditions": [
+    "classical-yoga"
+  ],
   "centers": []
 }

--- a/data/teachers/tara-brach.json
+++ b/data/teachers/tara-brach.json
@@ -9,8 +9,13 @@
   "city": "Bethesda",
   "state": "Maryland",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada", "vipassana-movement"],
-  "centers": ["insight-meditation-community-of-washington"]
+  "latitude": 38.9812726,
+  "longitude": -77.1233587,
+  "traditions": [
+    "theravada",
+    "vipassana-movement"
+  ],
+  "centers": [
+    "insight-meditation-community-of-washington"
+  ]
 }

--- a/data/teachers/tenshin-reb-anderson.json
+++ b/data/teachers/tenshin-reb-anderson.json
@@ -9,8 +9,12 @@
   "city": "San Francisco",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen"],
-  "centers": ["san-francisco-zen-center"]
+  "latitude": 37.7879363,
+  "longitude": -122.4075201,
+  "traditions": [
+    "zen"
+  ],
+  "centers": [
+    "san-francisco-zen-center"
+  ]
 }

--- a/data/teachers/tenzin-wangyal-rinpoche.json
+++ b/data/teachers/tenzin-wangyal-rinpoche.json
@@ -9,8 +9,13 @@
   "city": "Charlottesville",
   "state": "Virginia",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["dzogchen", "vajrayana"],
-  "centers": ["ligmincha-international"]
+  "latitude": 38.029306,
+  "longitude": -78.4766781,
+  "traditions": [
+    "dzogchen",
+    "vajrayana"
+  ],
+  "centers": [
+    "ligmincha-international"
+  ]
 }

--- a/data/teachers/thich-nhat-hanh.json
+++ b/data/teachers/thich-nhat-hanh.json
@@ -9,8 +9,15 @@
   "city": "Escondido",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["zen", "mahayana"],
-  "centers": ["deer-park-monastery", "blue-cliff-monastery", "magnolia-grove-monastery"]
+  "latitude": 33.1216751,
+  "longitude": -117.0814849,
+  "traditions": [
+    "zen",
+    "mahayana"
+  ],
+  "centers": [
+    "deer-park-monastery",
+    "blue-cliff-monastery",
+    "magnolia-grove-monastery"
+  ]
 }

--- a/data/teachers/tilopa.json
+++ b/data/teachers/tilopa.json
@@ -9,8 +9,8 @@
   "city": "Nalanda",
   "state": "Bihar",
   "country": "IN",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 25.1364914,
+  "longitude": 85.4436546,
   "traditions": [
     "vajrayana"
   ],

--- a/data/teachers/trudy-goodman.json
+++ b/data/teachers/trudy-goodman.json
@@ -9,8 +9,8 @@
   "city": "Los Angeles",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 34.0536909,
+  "longitude": -118.242766,
   "traditions": [
     "theravada",
     "vipassana-movement"

--- a/data/teachers/tsultrim-allione.json
+++ b/data/teachers/tsultrim-allione.json
@@ -9,8 +9,12 @@
   "city": "Pagosa Springs",
   "state": "Colorado",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["vajrayana"],
-  "centers": ["tara-mandala"]
+  "latitude": 37.2695661,
+  "longitude": -107.010816,
+  "traditions": [
+    "vajrayana"
+  ],
+  "centers": [
+    "tara-mandala"
+  ]
 }

--- a/data/teachers/tuere-sala.json
+++ b/data/teachers/tuere-sala.json
@@ -9,8 +9,8 @@
   "city": "Seattle",
   "state": "Washington",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 47.6038321,
+  "longitude": -122.330062,
   "traditions": [
     "theravada",
     "vipassana-movement"

--- a/data/teachers/tulku-urgyen-rinpoche.json
+++ b/data/teachers/tulku-urgyen-rinpoche.json
@@ -9,8 +9,8 @@
   "city": "Kathmandu",
   "state": "Bagmati",
   "country": "NP",
-  "latitude": null,
-  "longitude": null,
+  "latitude": 27.708317,
+  "longitude": 85.3205817,
   "traditions": [
     "vajrayana",
     "dzogchen"

--- a/data/teachers/victoria-cary.json
+++ b/data/teachers/victoria-cary.json
@@ -9,8 +9,14 @@
   "city": "San Francisco",
   "state": "California",
   "country": "US",
-  "latitude": null,
-  "longitude": null,
-  "traditions": ["theravada", "vipassana-movement"],
-  "centers": ["spirit-rock", "insight-meditation-society"]
+  "latitude": 37.7879363,
+  "longitude": -122.4075201,
+  "traditions": [
+    "theravada",
+    "vipassana-movement"
+  ],
+  "centers": [
+    "spirit-rock",
+    "insight-meditation-society"
+  ]
 }

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "start": "npx serve out",
     "lint": "eslint",
     "test": "vitest run",
-    "test:watch": "vitest"
+    "test:watch": "vitest",
+    "geocode": "npx tsx scripts/geocode.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.2.0",

--- a/scripts/geocode.ts
+++ b/scripts/geocode.ts
@@ -1,0 +1,126 @@
+import * as fs from "fs";
+import * as path from "path";
+
+const DATA_DIR = path.join(__dirname, "..", "data");
+const NOMINATIM_URL = "https://nominatim.openstreetmap.org/search";
+const USER_AGENT = "lineage.guide geocoder (https://lineage.guide)";
+const RATE_LIMIT_MS = 1000;
+
+interface Entry {
+  city?: string | null;
+  state?: string | null;
+  country?: string | null;
+  latitude?: number | null;
+  longitude?: number | null;
+  [key: string]: unknown;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+async function geocode(
+  city: string,
+  state: string | null | undefined,
+  country: string | null | undefined
+): Promise<{ lat: number; lng: number } | null> {
+  const parts = [city, state, country].filter(Boolean).join(",");
+  const url = `${NOMINATIM_URL}?q=${encodeURIComponent(parts)}&format=json&limit=1`;
+
+  const res = await fetch(url, {
+    headers: { "User-Agent": USER_AGENT },
+  });
+
+  if (!res.ok) {
+    console.error(`  HTTP ${res.status} for "${parts}"`);
+    return null;
+  }
+
+  const data = await res.json();
+  if (!Array.isArray(data) || data.length === 0) {
+    return null;
+  }
+
+  return { lat: parseFloat(data[0].lat), lng: parseFloat(data[0].lon) };
+}
+
+async function processDirectory(dirName: string): Promise<{
+  geocoded: number;
+  skippedCoords: number;
+  skippedNoCity: number;
+  failed: number;
+}> {
+  const dir = path.join(DATA_DIR, dirName);
+  const files = fs.readdirSync(dir).filter((f) => f.endsWith(".json"));
+  const stats = { geocoded: 0, skippedCoords: 0, skippedNoCity: 0, failed: 0 };
+  const total = files.length;
+
+  for (let i = 0; i < files.length; i++) {
+    const filePath = path.join(dir, files[i]);
+    const raw = fs.readFileSync(filePath, "utf-8");
+    const entry: Entry = JSON.parse(raw);
+
+    if (entry.latitude != null && entry.longitude != null) {
+      stats.skippedCoords++;
+      continue;
+    }
+
+    if (!entry.city) {
+      stats.skippedNoCity++;
+      continue;
+    }
+
+    await sleep(RATE_LIMIT_MS);
+    const result = await geocode(entry.city, entry.state, entry.country);
+
+    if (result) {
+      entry.latitude = result.lat;
+      entry.longitude = result.lng;
+      fs.writeFileSync(filePath, JSON.stringify(entry, null, 2) + "\n");
+      console.log(
+        `Geocoding ${dirName} ${i + 1}/${total}: ${entry.name ?? files[i]} → ${result.lat}, ${result.lng}`
+      );
+      stats.geocoded++;
+    } else {
+      console.log(
+        `Geocoding ${dirName} ${i + 1}/${total}: ${entry.name ?? files[i]} → FAILED`
+      );
+      stats.failed++;
+    }
+  }
+
+  return stats;
+}
+
+async function main() {
+  console.log("Starting geocoding...\n");
+
+  const teacherStats = await processDirectory("teachers");
+  console.log("\n--- Teachers ---");
+  console.log(`  Geocoded: ${teacherStats.geocoded}`);
+  console.log(`  Skipped (already have coords): ${teacherStats.skippedCoords}`);
+  console.log(`  Skipped (no city): ${teacherStats.skippedNoCity}`);
+  console.log(`  Failed: ${teacherStats.failed}`);
+
+  const centerStats = await processDirectory("centers");
+  console.log("\n--- Centers ---");
+  console.log(`  Geocoded: ${centerStats.geocoded}`);
+  console.log(`  Skipped (already have coords): ${centerStats.skippedCoords}`);
+  console.log(`  Skipped (no city): ${centerStats.skippedNoCity}`);
+  console.log(`  Failed: ${centerStats.failed}`);
+
+  const total = {
+    geocoded: teacherStats.geocoded + centerStats.geocoded,
+    skippedCoords: teacherStats.skippedCoords + centerStats.skippedCoords,
+    skippedNoCity: teacherStats.skippedNoCity + centerStats.skippedNoCity,
+    failed: teacherStats.failed + centerStats.failed,
+  };
+
+  console.log("\n=== TOTAL ===");
+  console.log(`  Geocoded: ${total.geocoded}`);
+  console.log(`  Skipped (already have coords): ${total.skippedCoords}`);
+  console.log(`  Skipped (no city): ${total.skippedNoCity}`);
+  console.log(`  Failed: ${total.failed}`);
+}
+
+main().catch(console.error);


### PR DESCRIPTION
## Summary
- Create batch geocoding script using OpenStreetMap Nominatim
- Geocode all teachers and centers with city/state data
- Write coordinates back into JSON files

Closes #117

## Test plan
- [x] Script runs without errors
- [x] Spot-check coordinates for known locations
- [x] `npm run build` passes
- [x] Re-running script skips already-geocoded entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)