### PR TITLE
Add proximity search to teacher directory

### DIFF
--- a/src/components/teachers-client.tsx
+++ b/src/components/teachers-client.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import type { Teacher } from "@/lib/types";
 import type { SearchFilters } from "@/lib/search";
 import { filterTeachers } from "@/lib/search";
+import { geocodeLocation, sortByDistance } from "@/lib/geo";
 import { Input } from "@/components/ui/input";
 import { Select } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
@@ -19,6 +20,16 @@ export function TeachersClient({ teachers, traditionNames }: TeachersClientProps
   const [query, setQuery] = useState("");
   const [selectedTraditions, setSelectedTraditions] = useState<string[]>([]);
   const [selectedState, setSelectedState] = useState("");
+
+  // Proximity search state
+  const [locationQuery, setLocationQuery] = useState("");
+  const [activeLocation, setActiveLocation] = useState<{
+    query: string;
+    lat: number;
+    lng: number;
+  } | null>(null);
+  const [locationLoading, setLocationLoading] = useState(false);
+  const [locationError, setLocationError] = useState("");
 
   const states = useMemo(() => {
     const s = new Set<string>();
@@ -37,10 +48,16 @@ export function TeachersClient({ teachers, traditionNames }: TeachersClientProps
     [query, selectedTraditions, selectedState]
   );
 
-  const results = useMemo(
+  const filtered = useMemo(
     () => filterTeachers(teachers, filters),
     [teachers, filters]
   );
+
+  // Apply proximity sort after filtering
+  const results = useMemo(() => {
+    if (!activeLocation) return filtered;
+    return sortByDistance(filtered, activeLocation.lat, activeLocation.lng);
+  }, [filtered, activeLocation]);
 
   const toggleTradition = useCallback((slug: string) => {
     setSelectedTraditions((prev) =>
@@ -54,8 +71,39 @@ export function TeachersClient({ teachers, traditionNames }: TeachersClientProps
     setSelectedState("");
   }, []);
 
+  const handleLocationSearch = useCallback(async () => {
+    const trimmed = locationQuery.trim();
+    if (!trimmed) return;
+
+    setLocationLoading(true);
+    setLocationError("");
+
+    const coords = await geocodeLocation(trimmed);
+
+    if (coords) {
+      setActiveLocation({ query: trimmed, lat: coords.lat, lng: coords.lng });
+    } else {
+      setLocationError("Could not find location. Try a different city or zip code.");
+      setActiveLocation(null);
+    }
+
+    setLocationLoading(false);
+  }, [locationQuery]);
+
+  const clearLocation = useCallback(() => {
+    setLocationQuery("");
+    setActiveLocation(null);
+    setLocationError("");
+  }, []);
+
   const hasActiveFilters =
     query !== "" || selectedTraditions.length > 0 || selectedState !== "";
+
+  // Helper to get distance for a result (works whether sorted or not)
+  const getDistance = (teacher: (typeof results)[number]): number | null => {
+    if (!activeLocation) return null;
+    return "distance" in teacher ? (teacher as { distance: number | null }).distance : null;
+  };
 
   return (
     <div>
@@ -110,6 +158,91 @@ export function TeachersClient({ teachers, traditionNames }: TeachersClientProps
             );
           })}
         </div>
+
+        {/* Proximity search */}
+        <div className="border-t border-border pt-4">
+          <label className="block font-sans text-sm text-muted-foreground mb-2">
+            Sort by distance from...
+          </label>
+          <div className="flex gap-2">
+            <Input
+              placeholder="City or zip code"
+              value={locationQuery}
+              onChange={(e) => setLocationQuery(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter") handleLocationSearch();
+              }}
+              aria-label="Enter city or zip code for proximity search"
+              className="flex-1"
+            />
+            <button
+              onClick={handleLocationSearch}
+              disabled={locationLoading || !locationQuery.trim()}
+              className="px-4 py-2 font-sans text-sm bg-primary text-primary-foreground rounded-md hover:bg-primary/90 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {locationLoading ? (
+                <span className="inline-flex items-center gap-1.5">
+                  <svg
+                    className="animate-spin h-4 w-4"
+                    xmlns="http://www.w3.org/2000/svg"
+                    fill="none"
+                    viewBox="0 0 24 24"
+                  >
+                    <circle
+                      className="opacity-25"
+                      cx="12"
+                      cy="12"
+                      r="10"
+                      stroke="currentColor"
+                      strokeWidth="4"
+                    />
+                    <path
+                      className="opacity-75"
+                      fill="currentColor"
+                      d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z"
+                    />
+                  </svg>
+                  Searching
+                </span>
+              ) : (
+                "Search"
+              )}
+            </button>
+          </div>
+
+          {locationError && (
+            <p className="font-sans text-sm text-destructive mt-2">{locationError}</p>
+          )}
+
+          {activeLocation && (
+            <div className="flex items-center gap-2 mt-2 font-sans text-sm text-muted-foreground">
+              <span>
+                Sorted by distance from{" "}
+                <span className="font-medium text-foreground">{activeLocation.query}</span>
+              </span>
+              <button
+                onClick={clearLocation}
+                className="text-muted-foreground hover:text-foreground transition-colors"
+                aria-label="Clear location sort"
+              >
+                <svg
+                  xmlns="http://www.w3.org/2000/svg"
+                  width="16"
+                  height="16"
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="2"
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                >
+                  <line x1="18" y1="6" x2="6" y2="18" />
+                  <line x1="6" y1="6" x2="18" y2="18" />
+                </svg>
+              </button>
+            </div>
+          )}
+        </div>
       </div>
 
       <p className="font-sans text-sm text-muted-foreground mb-4">
@@ -134,28 +267,40 @@ export function TeachersClient({ teachers, traditionNames }: TeachersClientProps
         </div>
       ) : (
         <div className="grid gap-4 sm:grid-cols-2">
-          {results.map((teacher) => (
-            <Link key={teacher.slug} href={`/teachers/${teacher.slug}`} className="group">
-              <Card accent="terracotta" className="h-full group-hover:shadow-md">
-                <CardHeader>
-                  <CardTitle className="group-hover:text-primary transition-colors">
-                    {teacher.name}
-                  </CardTitle>
-                  <CardDescription>
-                    {teacher.city}, {teacher.state}
-                    {teacher.country !== "US" && ` · ${teacher.country}`}
-                  </CardDescription>
-                </CardHeader>
-                <div className="flex flex-wrap gap-1.5 px-5 pb-5">
-                  {teacher.traditions.map((slug) => (
-                    <Badge key={slug} variant="tradition">
-                      {traditionNames[slug] ?? slug}
-                    </Badge>
-                  ))}
-                </div>
-              </Card>
-            </Link>
-          ))}
+          {results.map((teacher) => {
+            const distance = getDistance(teacher);
+            return (
+              <Link key={teacher.slug} href={`/teachers/${teacher.slug}`} className="group">
+                <Card accent="terracotta" className="h-full group-hover:shadow-md">
+                  <CardHeader>
+                    <div className="flex items-start justify-between gap-2">
+                      <div>
+                        <CardTitle className="group-hover:text-primary transition-colors">
+                          {teacher.name}
+                        </CardTitle>
+                        <CardDescription>
+                          {teacher.city}, {teacher.state}
+                          {teacher.country !== "US" && ` · ${teacher.country}`}
+                        </CardDescription>
+                      </div>
+                      {distance != null && (
+                        <span className="font-sans text-sm text-muted-foreground whitespace-nowrap">
+                          {Math.round(distance)} mi
+                        </span>
+                      )}
+                    </div>
+                  </CardHeader>
+                  <div className="flex flex-wrap gap-1.5 px-5 pb-5">
+                    {teacher.traditions.map((slug) => (
+                      <Badge key={slug} variant="tradition">
+                        {traditionNames[slug] ?? slug}
+                      </Badge>
+                    ))}
+                  </div>
+                </Card>
+              </Link>
+            );
+          })}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- Add city/zip input to teacher directory for proximity-based sorting
- Teachers sorted by distance with miles displayed on each card
- Loading and error states for geocoding
- Works alongside existing name/state/tradition filters

Closes #119

## Test plan
- [ ] Enter a US city → teachers sort by distance
- [ ] Enter a zip code → teachers sort by distance
- [ ] Distance shown on each teacher card
- [ ] Teachers without coordinates appear at bottom
- [ ] Clear button resets to alphabetical sort
- [ ] Loading spinner shows during geocoding
- [ ] Error message for invalid location
- [ ] Existing filters still work alongside proximity sort
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)