### PR TITLE
chore: backfill teacher photo fields (#128)

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
     "lint": "eslint",
     "test": "vitest run",
     "test:watch": "vitest",
-    "geocode": "npx tsx scripts/geocode.ts"
+    "geocode": "npx tsx scripts/geocode.ts",
+    "backfill-photos": "npx tsx scripts/backfill-photos.ts"
   },
   "dependencies": {
     "@base-ui/react": "^1.2.0",

--- a/scripts/__tests__/backfill-photos.test.ts
+++ b/scripts/__tests__/backfill-photos.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { matchPhotos } from "../backfill-photos";
+
+describe("matchPhotos", () => {
+  it("matches teacher slugs to image files", () => {
+    const teachers = [
+      { slug: "jack-kornfield", photo: null },
+      { slug: "no-image-teacher", photo: null },
+      { slug: "already-set", photo: "/images/teachers/already-set.jpg" },
+    ];
+    const imageFiles = ["jack-kornfield.jpg", "already-set.jpg"];
+
+    const result = matchPhotos(teachers, imageFiles);
+
+    expect(result.updated).toEqual([
+      { slug: "jack-kornfield", photo: "/images/teachers/jack-kornfield.jpg" },
+    ]);
+    expect(result.alreadyCorrect).toEqual(["already-set"]);
+    expect(result.unmatched).toEqual(["no-image-teacher"]);
+  });
+
+  it("is idempotent - does not re-update already correct photos", () => {
+    const teachers = [
+      { slug: "pema-chodron", photo: "/images/teachers/pema-chodron.jpg" },
+    ];
+    const imageFiles = ["pema-chodron.jpg"];
+
+    const result = matchPhotos(teachers, imageFiles);
+
+    expect(result.updated).toEqual([]);
+    expect(result.alreadyCorrect).toEqual(["pema-chodron"]);
+  });
+
+  it("handles multiple image extensions", () => {
+    const teachers = [{ slug: "rumi", photo: null }];
+    const imageFiles = ["rumi.png"];
+
+    const result = matchPhotos(teachers, imageFiles);
+
+    expect(result.updated).toEqual([
+      { slug: "rumi", photo: "/images/teachers/rumi.png" },
+    ]);
+  });
+});

--- a/scripts/backfill-photos.ts
+++ b/scripts/backfill-photos.ts
@@ -1,0 +1,84 @@
+import fs from "node:fs";
+import path from "node:path";
+
+interface TeacherPhotoInfo {
+  slug: string;
+  photo: string | null;
+}
+
+interface MatchResult {
+  updated: { slug: string; photo: string }[];
+  alreadyCorrect: string[];
+  unmatched: string[];
+}
+
+export function matchPhotos(
+  teachers: TeacherPhotoInfo[],
+  imageFiles: string[]
+): MatchResult {
+  const imageMap = new Map<string, string>();
+  for (const file of imageFiles) {
+    const slug = path.parse(file).name;
+    imageMap.set(slug, file);
+  }
+
+  const updated: { slug: string; photo: string }[] = [];
+  const alreadyCorrect: string[] = [];
+  const unmatched: string[] = [];
+
+  for (const teacher of teachers) {
+    const imageFile = imageMap.get(teacher.slug);
+    if (imageFile) {
+      const expectedPhoto = `/images/teachers/${imageFile}`;
+      if (teacher.photo === expectedPhoto) {
+        alreadyCorrect.push(teacher.slug);
+      } else {
+        updated.push({ slug: teacher.slug, photo: expectedPhoto });
+      }
+    } else {
+      unmatched.push(teacher.slug);
+    }
+  }
+
+  return { updated, alreadyCorrect, unmatched };
+}
+
+if (process.argv[1] && process.argv[1].includes("backfill-photos")) {
+  const rootDir = path.resolve(path.dirname(new URL(import.meta.url).pathname), "..");
+  const teachersDir = path.join(rootDir, "data", "teachers");
+  const imagesDir = path.join(rootDir, "public", "images", "teachers");
+
+  const imageFiles = fs.readdirSync(imagesDir);
+  const teacherFiles = fs.readdirSync(teachersDir).filter((f) => f.endsWith(".json"));
+
+  const teachers: TeacherPhotoInfo[] = teacherFiles.map((f) => {
+    const data = JSON.parse(fs.readFileSync(path.join(teachersDir, f), "utf-8"));
+    return { slug: data.slug, photo: data.photo };
+  });
+
+  const result = matchPhotos(teachers, imageFiles);
+
+  // Write updates
+  for (const { slug, photo } of result.updated) {
+    const filePath = path.join(teachersDir, `${slug}.json`);
+    const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    data.photo = photo;
+    fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + "\n");
+  }
+
+  // Ensure unmatched have photo: null
+  for (const slug of result.unmatched) {
+    const filePath = path.join(teachersDir, `${slug}.json`);
+    const data = JSON.parse(fs.readFileSync(filePath, "utf-8"));
+    if (data.photo !== null) {
+      data.photo = null;
+      fs.writeFileSync(filePath, JSON.stringify(data, null, 2) + "\n");
+    }
+  }
+
+  console.log(`\nBackfill complete:`);
+  console.log(`  Updated:         ${result.updated.length}`);
+  console.log(`  Already correct: ${result.alreadyCorrect.length}`);
+  console.log(`  No image:        ${result.unmatched.length}`);
+  console.log(`  Total teachers:  ${teachers.length}`);
+}


### PR DESCRIPTION
## Summary

- Add `scripts/backfill-photos.ts` that matches teacher slugs to images in `public/images/teachers/` and populates the `photo` field
- Add test suite in `scripts/__tests__/backfill-photos.test.ts` covering matching, idempotency, and multiple extensions
- Add `backfill-photos` npm script to `package.json`

## Results

- **30 teachers** already had correct photo fields (no changes needed)
- **107 teachers** have no matching image (`photo: null`)
- **137 total** teachers processed
- Script is idempotent: re-running produces no changes

## Test plan

- [x] Unit tests pass (`vitest run`)
- [x] Script runs successfully (`npm run backfill-photos`)
- [x] `npm run build` passes
- [x] Script is idempotent (re-run produces same output)

Closes #128

🤖 Generated with [Claude Code](https://claude.com/claude-code)