### PR TITLE
feat: redesign site footer with multi-column layout (#130)

### DIFF
--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -1,28 +1,88 @@
 import Link from "next/link";
 
+const footerColumns = [
+  {
+    heading: "Lineage",
+    links: [
+      { label: "Home", href: "/" },
+      { label: "About", href: "/about" },
+    ],
+  },
+  {
+    heading: "Explore",
+    links: [
+      { label: "Map", href: "/map" },
+      { label: "Library", href: "/library" },
+      { label: "Resources", href: "/resources" },
+    ],
+  },
+  {
+    heading: "Directory",
+    links: [
+      { label: "Teachers", href: "/teachers" },
+      { label: "Masters", href: "/masters" },
+      { label: "Centers", href: "/centers" },
+    ],
+  },
+  {
+    heading: "Connect",
+    links: [
+      {
+        label: "Suggest an Edit",
+        href: "https://github.com/meninoebom/lineage/issues",
+        external: true,
+      },
+      {
+        label: "GitHub",
+        href: "https://github.com/meninoebom/lineage",
+        external: true,
+      },
+    ],
+  },
+] as const;
+
 export function SiteFooter() {
   return (
-    <footer className="border-t border-border mt-auto">
-      <div className="mx-auto max-w-5xl px-6 py-8 flex flex-col sm:flex-row items-center justify-between gap-4">
-        <p className="font-sans text-sm text-muted-foreground">
-          &copy; {new Date().getFullYear()} Lineage. An editorial directory of contemplative traditions.
-        </p>
-        <nav className="flex items-center gap-6">
-          <Link
-            href="/about"
-            className="font-sans text-sm text-muted-foreground hover:text-primary transition-colors"
-          >
-            About
-          </Link>
-          <a
-            href="https://github.com/meninoebom/lineage/issues"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="font-sans text-sm text-muted-foreground hover:text-primary transition-colors"
-          >
-            Suggest an Edit
-          </a>
-        </nav>
+    <footer className="bg-surface-container-low mt-auto">
+      <div className="mx-auto max-w-5xl px-6 py-12">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-8">
+          {footerColumns.map((column) => (
+            <div key={column.heading}>
+              <h3 className="font-serif text-sm font-medium text-foreground">
+                {column.heading}
+              </h3>
+              <ul className="mt-3 space-y-2">
+                {column.links.map((link) => (
+                  <li key={link.label}>
+                    {"external" in link && link.external ? (
+                      <a
+                        href={link.href}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="font-sans text-sm text-muted-foreground hover:text-primary transition-colors"
+                      >
+                        {link.label}
+                      </a>
+                    ) : (
+                      <Link
+                        href={link.href}
+                        className="font-sans text-sm text-muted-foreground hover:text-primary transition-colors"
+                      >
+                        {link.label}
+                      </Link>
+                    )}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          ))}
+        </div>
+        <div className="pt-8 pb-6">
+          <p className="font-sans text-sm text-muted-foreground">
+            &copy; {new Date().getFullYear()} Lineage. An editorial directory of
+            contemplative traditions.
+          </p>
+        </div>
       </div>
     </footer>
   );


### PR DESCRIPTION
## Summary
- Replace single-row footer with 4-column grid layout (Lineage, Explore, Directory, Connect)
- Uses `bg-surface-container-low` tonal layering instead of border-based separation
- Responsive: 1 column mobile, 2 columns tablet, 4 columns desktop
- Data-driven column rendering via `footerColumns` array for easy maintenance

Closes #130

## Test plan
- [ ] Verify 4-column layout on desktop viewports
- [ ] Verify single-column stacking on mobile
- [ ] Verify all links navigate correctly
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)