### PR TITLE
feat: restyle teacher directory with photos and 3-column grid

### DIFF
--- a/src/components/teachers-client.tsx
+++ b/src/components/teachers-client.tsx
@@ -279,6 +279,9 @@ export function TeachersClient({ teachers, traditionNames }: TeachersClientProps
                         <img
                           src={teacher.photo}
                           alt={teacher.name}
+                          width={64}
+                          height={64}
+                          loading="lazy"
                           className="w-16 h-16 rounded-full object-cover"
                         />
                       ) : (


### PR DESCRIPTION
## Summary
- **3-column grid** on desktop (`lg:grid-cols-3`), 2 on tablet, 1 on mobile
- **Teacher photos**: circular 64px crop with fallback avatar SVG for teachers without images
- **Card layout**: photo on left, name/location/tradition badges on right
- **Tonal layering**: removed `border-t border-border` on proximity section, replaced with subtle background
- **Gradient button** on proximity search to match Stitch system
- Proximity search still fully functional

Closes #132

## Test plan
- [x] Existing teacher data tests pass (5/5)
- [x] `npm run build` passes
- [ ] Visual: 3-col grid, circular photos, fallback avatars
- [ ] Proximity search: enter location, see distance sort

🤖 Generated with [Claude Code](https://claude.com/claude-code)