### PR TITLE
feat: restyle library page with visual path cards (#134)

### DIFF
--- a/src/app/library/page.tsx
+++ b/src/app/library/page.tsx
@@ -26,7 +26,7 @@ export default function LibraryPage() {
     <PageLayout>
       <Breadcrumbs items={[{ label: "Library" }]} />
 
-      <header className="mb-10">
+      <header className="mb-16">
         <h1 className="mb-3">Library</h1>
         <p className="text-lg text-muted-foreground leading-relaxed max-w-2xl">
           Curated reading paths through the contemplative traditions — each a
@@ -42,18 +42,18 @@ export default function LibraryPage() {
         </p>
       </header>
 
-      <section className="mb-12">
-        <h2 className="mb-4">Tradition Paths</h2>
-        <div className="grid gap-4 sm:grid-cols-2">
+      <section className="mb-20">
+        <h2 className="mb-6">Tradition Paths</h2>
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {traditionPaths.map((path) => (
             <PathCard key={path.slug} path={path} />
           ))}
         </div>
       </section>
 
-      <section className="mb-12">
-        <h2 className="mb-4">Thematic Paths</h2>
-        <div className="grid gap-4 sm:grid-cols-2">
+      <section className="mb-20">
+        <h2 className="mb-6">Thematic Paths</h2>
+        <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3">
           {thematicPaths.map((path) => (
             <PathCard key={path.slug} path={path} />
           ))}

--- a/src/components/path-card.tsx
+++ b/src/components/path-card.tsx
@@ -1,5 +1,4 @@
 import Link from "next/link";
-import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import type { ResolvedPath } from "@/lib/types";
 
 interface PathCardProps {
@@ -9,12 +8,16 @@ interface PathCardProps {
 export function PathCard({ path }: PathCardProps) {
   return (
     <Link href={`/library/${path.slug}`} className="group">
-      <Card accent="terracotta" className="h-full group-hover:shadow-md">
-        <CardHeader>
-          <CardTitle className="group-hover:text-primary transition-colors">
+      <div className="h-full bg-card shadow-ambient rounded transition-shadow hover:shadow-md">
+        <div className="h-32 rounded-t bg-gradient-to-br from-surface-container-low to-surface-dim flex items-end p-4">
+          <h3 className="font-serif text-lg text-foreground/90 leading-snug">
             {path.title}
-          </CardTitle>
-          <CardDescription className="mb-3">{path.description}</CardDescription>
+          </h3>
+        </div>
+        <div className="p-5 pt-4">
+          <p className="text-sm text-muted-foreground mb-4 leading-relaxed">
+            {path.description}
+          </p>
           <ul className="space-y-1 text-sm text-muted-foreground">
             {path.resources.map((r) => (
               <li key={r.slug} className="truncate">
@@ -25,8 +28,8 @@ export function PathCard({ path }: PathCardProps) {
               </li>
             ))}
           </ul>
-        </CardHeader>
-      </Card>
+        </div>
+      </div>
     </Link>
   );
 }


### PR DESCRIPTION
## Summary
- Restyled path cards with decorative gradient header (`from-surface-container-low to-surface-dim`), serif title overlay, and tonal layering (no borders, `bg-card shadow-ambient`)
- Updated grid to 3 columns on desktop (`sm:grid-cols-2 lg:grid-cols-3`) with generous section spacing (`mb-16`/`mb-20`)
- Preserved cross-link to `/resources` and "Title — Author" resource list format

Closes #134

## Test plan
- [ ] Verify gradient area appears at top of each path card
- [ ] Confirm title renders in serif font (Noto Serif via `font-serif`)
- [ ] Check 3-column layout on desktop, 2-col on tablet, 1-col on mobile
- [ ] Verify hover state shows `shadow-md` elevation
- [ ] Confirm "Browse the full collection" link to `/resources` works
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)