### PR TITLE
feat: switch serif font to Cormorant Garamond, rebrand to Lineage.guide

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,10 +1,12 @@
 import type { Metadata } from "next";
-import { Noto_Serif, Inter } from "next/font/google";
+import { Cormorant_Garamond, Inter } from "next/font/google";
 import { defaultMetadata } from "@/lib/seo";
 import "./globals.css";
 
-const notoSerif = Noto_Serif({
+const cormorantGaramond = Cormorant_Garamond({
   subsets: ["latin"],
+  weight: ["400", "500", "600", "700"],
+  style: ["normal", "italic"],
   variable: "--font-serif",
   display: "swap",
 });
@@ -33,7 +35,7 @@ export default function RootLayout({
   children: React.ReactNode;
 }>) {
   return (
-    <html lang="en" className={`${notoSerif.variable} ${inter.variable}`}>
+    <html lang="en" className={`${cormorantGaramond.variable} ${inter.variable}`}>
       <body className="antialiased">{children}</body>
     </html>
   );

--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -1,8 +1,9 @@
 import Link from "next/link";
+import { cn } from "@/lib/utils";
 
 const footerColumns = [
   {
-    heading: "Lineage",
+    heading: "Lineage.guide",
     links: [
       { label: "Home", href: "/" },
       { label: "About", href: "/about" },
@@ -48,7 +49,7 @@ export function SiteFooter() {
         <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-8">
           {footerColumns.map((column) => (
             <div key={column.heading}>
-              <h3 className="font-serif text-sm font-medium text-foreground">
+              <h3 className={cn("text-sm font-medium text-foreground", column.heading === "Lineage.guide" ? "font-serif italic" : "font-serif")}>
                 {column.heading}
               </h3>
               <ul className="mt-3 space-y-2">
@@ -79,7 +80,8 @@ export function SiteFooter() {
         </div>
         <div className="pt-8 pb-6">
           <p className="font-sans text-sm text-muted-foreground">
-            &copy; {new Date().getFullYear()} Lineage. An editorial directory of
+            &copy; {new Date().getFullYear()}{" "}
+            <span className="font-serif italic">Lineage.guide</span>. An editorial directory of
             contemplative traditions.
           </p>
         </div>

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -29,7 +29,7 @@ export function SiteHeader() {
           href="/"
           className="font-serif text-xl italic tracking-tight text-foreground hover:text-primary transition-colors"
         >
-          Lineage
+          Lineage.guide
         </Link>
 
         {/* Desktop nav */}


### PR DESCRIPTION
## Summary
- Replace Noto Serif with Cormorant Garamond (weights 400/500/600/700, normal + italic) for a higher-contrast editorial serif
- Update branding from "Lineage" to "Lineage.guide" in header and footer with italic serif styling
- `--font-serif` CSS variable unchanged so all existing `font-serif` usage picks up the new font automatically

Closes #156

## Test plan
- [ ] Verify Cormorant Garamond loads on all pages (check Network tab for font files)
- [ ] Header shows "Lineage.guide" in italic serif
- [ ] Footer column heading and copyright line show "Lineage.guide" in italic serif
- [ ] Display headings and card titles render correctly with new font
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)