### PR TITLE
feat: switch cards to flat style site-wide

### DIFF
--- a/src/app/centers/[slug]/page.tsx
+++ b/src/app/centers/[slug]/page.tsx
@@ -98,7 +98,7 @@ export default async function CenterPage({ params }: { params: Promise<{ slug: s
             <div className="grid gap-4 sm:grid-cols-2">
               {teachers.map((teacher) => (
                 <Link key={teacher.slug} href={`/teachers/${teacher.slug}`} className="group">
-                  <Card className="h-full group-hover:shadow-md">
+                  <Card className="h-full group-hover:bg-accent/50">
                     <CardHeader>
                       <CardTitle className="group-hover:text-primary transition-colors">
                         {teacher.name}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -94,7 +94,7 @@ export default function Home() {
       <section className="grid gap-6 sm:grid-cols-2 mb-20">
         {sections.map((section) => (
           <Link key={section.href} href={section.href} className="group">
-            <div className="h-full rounded bg-card p-6 shadow-ambient transition-shadow group-hover:shadow-md">
+            <div className="h-full rounded bg-card p-6 border border-border/50 transition-colors group-hover:bg-accent/50">
               <div className="text-primary mb-4">{section.icon}</div>
               <h3 className="text-lg mb-2 group-hover:text-primary transition-colors">
                 {section.title}
@@ -115,7 +115,7 @@ export default function Home() {
         <div className="max-w-4xl mx-auto flex flex-col md:flex-row items-center gap-10">
           {/* Map preview */}
           <div className="flex-1 w-full">
-            <div className="rounded bg-card shadow-ambient overflow-hidden p-6">
+            <div className="rounded bg-card border border-border/50 overflow-hidden p-6">
               <svg
                 viewBox="0 0 500 280"
                 className="w-full h-auto"

--- a/src/app/teachers/[slug]/page.tsx
+++ b/src/app/teachers/[slug]/page.tsx
@@ -126,7 +126,7 @@ export default async function TeacherPage({ params }: { params: Promise<{ slug: 
             <div className="grid gap-4 sm:grid-cols-2">
               {centers.map((center) => (
                 <Link key={center.slug} href={`/centers/${center.slug}`} className="group">
-                  <Card className="h-full group-hover:shadow-md">
+                  <Card className="h-full group-hover:bg-accent/50">
                     <CardHeader>
                       <CardTitle className="group-hover:text-primary transition-colors">
                         {center.name}

--- a/src/app/teachers/location/[state]/page.tsx
+++ b/src/app/teachers/location/[state]/page.tsx
@@ -70,7 +70,7 @@ export default async function StateTeachersPage({
             href={`/teachers/${teacher.slug}`}
             className="group"
           >
-            <Card accent="terracotta" className="h-full group-hover:shadow-md">
+            <Card accent="terracotta" className="h-full group-hover:bg-accent/50">
               <CardHeader>
                 <CardTitle className="group-hover:text-primary transition-colors">
                   {teacher.name}

--- a/src/app/teachers/page.tsx
+++ b/src/app/teachers/page.tsx
@@ -52,7 +52,7 @@ export default function TeachersPage() {
             href={`/teachers/${teacher.slug}`}
             className="group"
           >
-            <Card className="h-full group-hover:shadow-md transition-shadow">
+            <Card className="h-full group-hover:bg-accent/50">
               <div className="flex items-start gap-4">
                 <div className="shrink-0">
                   {teacher.photo ? (

--- a/src/app/traditions/[slug]/page.tsx
+++ b/src/app/traditions/[slug]/page.tsx
@@ -84,7 +84,7 @@ export default async function TraditionPage({ params }: { params: Promise<{ slug
           <div className="grid gap-4 sm:grid-cols-2">
             {teachers.map((teacher) => (
               <Link key={teacher.slug} href={`/teachers/${teacher.slug}`} className="group">
-                <Card className="h-full group-hover:shadow-md">
+                <Card className="h-full group-hover:bg-accent/50">
                   <CardHeader>
                     <CardTitle className="group-hover:text-primary transition-colors">
                       {teacher.name}
@@ -107,7 +107,7 @@ export default async function TraditionPage({ params }: { params: Promise<{ slug
           <div className="grid gap-4 sm:grid-cols-2">
             {centers.map((center) => (
               <Link key={center.slug} href={`/centers/${center.slug}`} className="group">
-                <Card className="h-full group-hover:shadow-md">
+                <Card className="h-full group-hover:bg-accent/50">
                   <CardHeader>
                     <CardTitle className="group-hover:text-primary transition-colors">
                       {center.name}
@@ -130,7 +130,7 @@ export default async function TraditionPage({ params }: { params: Promise<{ slug
           <div className="grid gap-4">
             {related.map((r) => (
               <Link key={r.slug} href={`/traditions/${r.slug}`} className="group">
-                <Card className="group-hover:shadow-md">
+                <Card className="group-hover:bg-accent/50">
                   <CardHeader>
                     <div className="flex items-center gap-2 mb-1">
                       <CardTitle className="group-hover:text-primary transition-colors">

--- a/src/app/traditions/page.tsx
+++ b/src/app/traditions/page.tsx
@@ -60,7 +60,7 @@ export default function TraditionsPage() {
           <div className="grid gap-4 sm:grid-cols-2">
             {traditions.map((t) => (
               <Link key={t.slug} href={`/traditions/${t.slug}`} className="group">
-                <Card accent="terracotta" className="h-full group-hover:shadow-md">
+                <Card accent="terracotta" className="h-full group-hover:bg-accent/50">
                   <CardHeader>
                     <CardTitle className="group-hover:text-primary transition-colors">
                       {t.name}

--- a/src/components/__tests__/design-system.test.tsx
+++ b/src/components/__tests__/design-system.test.tsx
@@ -19,9 +19,9 @@ describe("Card", () => {
     const card = screen.getByTestId("card");
     expect(card).toHaveTextContent("Content");
     expect(card.className).toContain("bg-card");
-    // Stitch: no 1px borders, use shadow-ambient instead
-    expect(card.className).not.toContain("border-border");
-    expect(card.className).toContain("shadow-ambient");
+    // Flat cards: subtle border, no shadows
+    expect(card.className).toContain("border-border/50");
+    expect(card.className).not.toContain("shadow");
   });
 
   it("renders with terracotta accent", () => {

--- a/src/components/centers-client.tsx
+++ b/src/components/centers-client.tsx
@@ -139,7 +139,7 @@ export function CentersClient({ centers, traditionNames }: CentersClientProps) {
         <div className="grid gap-4 sm:grid-cols-2">
           {results.map((center) => (
             <Link key={center.slug} href={`/centers/${center.slug}`} className="group">
-              <Card accent="green" className="h-full group-hover:shadow-md">
+              <Card accent="green" className="h-full group-hover:bg-accent/50">
                 <CardHeader>
                   <CardTitle className="group-hover:text-primary transition-colors">
                     {center.name}

--- a/src/components/path-card.tsx
+++ b/src/components/path-card.tsx
@@ -8,7 +8,7 @@ interface PathCardProps {
 export function PathCard({ path }: PathCardProps) {
   return (
     <Link href={`/library/${path.slug}`} className="group">
-      <div className="h-full bg-card shadow-ambient rounded transition-shadow hover:shadow-md">
+      <div className="h-full bg-card border border-border/50 rounded transition-colors hover:bg-accent/50">
         <div className="h-32 rounded-t bg-gradient-to-br from-surface-container-low to-surface-dim flex items-end p-4">
           <h3 className="font-serif text-lg text-foreground/90 leading-snug">
             {path.title}

--- a/src/components/resource-list.tsx
+++ b/src/components/resource-list.tsx
@@ -42,7 +42,7 @@ export function ResourceList({ resources }: ResourceListProps) {
                 href={resource.url}
                 target="_blank"
                 rel="noopener noreferrer"
-                className="block rounded-lg bg-card p-4 shadow-ambient transition-shadow hover:shadow-md"
+                className="block rounded-lg bg-card p-4 border border-border/50 transition-colors hover:bg-accent/50"
               >
                 <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:gap-3">
                   <span className="font-serif text-base font-medium text-foreground">

--- a/src/components/search-client.tsx
+++ b/src/components/search-client.tsx
@@ -158,7 +158,7 @@ export function SearchClient({
               <Link key={`${result.type}-${item.slug}`} href={href} className="group">
                 <Card
                   accent={isTeacher ? "terracotta" : "green"}
-                  className="h-full group-hover:shadow-md"
+                  className="h-full group-hover:bg-accent/50"
                 >
                   <CardHeader>
                     <div className="flex items-center gap-2 mb-1">

--- a/src/components/tradition-map/tradition-map.tsx
+++ b/src/components/tradition-map/tradition-map.tsx
@@ -323,7 +323,7 @@ export function TraditionMap({ traditions, resourceMap = {} }: TraditionMapProps
                 {filteredResources.map((r) => (
                   <div
                     key={r.slug}
-                    className="bg-white border border-[#e8e4df] rounded-lg p-3 hover:shadow-md transition-all duration-200"
+                    className="bg-white border border-[#e8e4df] rounded-lg p-3 hover:bg-accent/50 transition-all duration-200"
                   >
                     <a
                       href={r.url}

--- a/src/components/ui/card.tsx
+++ b/src/components/ui/card.tsx
@@ -9,7 +9,7 @@ function Card({ className, accent = "none", ...props }: CardProps) {
     <div
       data-slot="card"
       className={cn(
-        "rounded bg-card p-5 shadow-ambient transition-shadow hover:shadow-md",
+        "rounded border border-border/50 bg-card p-5 transition-colors hover:bg-accent/50",
         accent === "terracotta" && "border-t-2 border-t-primary",
         accent === "green" && "border-t-2 border-t-chart-2",
         className


### PR DESCRIPTION
## Summary
- Removed `shadow-ambient` and `hover:shadow-md` from the Card component, replaced with `border border-border/50` and `hover:bg-accent/50`
- Audited and updated all 13 files that used shadow classes on cards or card-like elements (homepage, teachers, traditions, centers, search, path-card, resource-list, tradition-map)
- Updated design system test to assert flat card styling

## Test plan
- [x] `npm run build` passes
- [x] Design system tests pass (15/15)
- [ ] Visual check: teachers, traditions, centers, library, homepage cards render flat with subtle border
- [ ] Hover states show background color shift instead of shadow elevation

Closes #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)