### PR TITLE
feat: traditions page sidebar nav and editorial hero

### DIFF
--- a/src/app/traditions/page.tsx
+++ b/src/app/traditions/page.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import type { Metadata } from "next";
 import { PageLayout } from "@/components/page-layout";
-import { Breadcrumbs } from "@/components/breadcrumbs";
 import { Badge } from "@/components/ui/badge";
 import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { getAllTraditions } from "@/lib/data";
@@ -22,6 +21,21 @@ export const metadata: Metadata = {
 
 const familyOrder = ["Buddhist", "Vedic-Yogic", "Taoist", "Christian Contemplative", "Islamic Contemplative", "Modern Secular", "Other"];
 
+/** Map family names to short emoji-style icons for sidebar nav */
+const familyIcons: Record<string, string> = {
+  "Buddhist": "\u{1F4FF}",
+  "Vedic-Yogic": "\u{1F549}\uFE0F",
+  "Taoist": "\u{2622}\uFE0F",
+  "Christian Contemplative": "\u{271E}",
+  "Islamic Contemplative": "\u{2B50}",
+  "Modern Secular": "\u{1F52C}",
+  "Other": "\u{1F30D}",
+};
+
+function familySlug(family: string): string {
+  return family.toLowerCase().replace(/\s+/g, "-");
+}
+
 function groupByFamily(traditions: ParsedTradition[]) {
   const grouped = new Map<string, ParsedTradition[]>();
   for (const t of traditions) {
@@ -41,38 +55,79 @@ export default function TraditionsPage() {
 
   return (
     <PageLayout>
-      <Breadcrumbs items={[{ label: "Traditions" }]} />
+      <div className="flex gap-12">
+        {/* Sidebar — hidden on mobile, sticky on desktop */}
+        <aside className="hidden lg:block w-56 shrink-0">
+          <nav className="sticky top-24">
+            <h2 className="font-serif text-lg font-semibold mb-1">Traditions</h2>
+            <p className="uppercase tracking-wider text-xs text-muted-foreground mb-6">
+              The Digital Archivist
+            </p>
+            <ul className="space-y-2">
+              <li>
+                <a
+                  href="#overview"
+                  className="text-sm text-muted-foreground hover:text-foreground transition-colors"
+                >
+                  Overview
+                </a>
+              </li>
+              {groups.map(({ family }) => (
+                <li key={family}>
+                  <a
+                    href={`#${familySlug(family)}`}
+                    className="text-sm text-muted-foreground hover:text-foreground transition-colors flex items-center gap-2"
+                  >
+                    <span className="text-base" aria-hidden="true">
+                      {familyIcons[family] ?? "\u{1F4D6}"}
+                    </span>
+                    {family}
+                  </a>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </aside>
 
-      <header className="mb-10">
-        <h1 className="mb-3">Contemplative Traditions</h1>
-        <p className="text-lg text-muted-foreground leading-relaxed max-w-2xl">
-          An overview of the contemplative paths — how they connect, where they
-          diverge, and what practice looks like in each.
-        </p>
-      </header>
+        {/* Main content */}
+        <div className="flex-1 min-w-0">
+          {/* Hero */}
+          <header id="overview" className="mb-16">
+            <h1 className="font-serif text-4xl md:text-5xl lg:text-6xl font-semibold tracking-tight mb-6">
+              The Tapestry of Ancestral Wisdom
+            </h1>
+            <p className="text-lg text-muted-foreground max-w-2xl leading-relaxed">
+              Explore the foundational currents of human thought. This directory
+              serves as a scholarly preservation of lineages that have shaped
+              consciousness for millennia.
+            </p>
+          </header>
 
-      {groups.map(({ family, traditions }) => (
-        <section key={family} className="mb-12">
-          <h2 className="mb-4 flex items-center gap-3">
-            {family}
-            <Badge variant="family">{traditions.length}</Badge>
-          </h2>
-          <div className="grid gap-4 sm:grid-cols-2">
-            {traditions.map((t) => (
-              <Link key={t.slug} href={`/traditions/${t.slug}`} className="group">
-                <Card accent="terracotta" className="h-full group-hover:bg-accent/50">
-                  <CardHeader>
-                    <CardTitle className="group-hover:text-primary transition-colors">
-                      {t.name}
-                    </CardTitle>
-                    <CardDescription>{t.summary}</CardDescription>
-                  </CardHeader>
-                </Card>
-              </Link>
-            ))}
-          </div>
-        </section>
-      ))}
+          {/* Family sections — kept intact for #160 to restyle */}
+          {groups.map(({ family, traditions }) => (
+            <section key={family} id={familySlug(family)} className="mb-12 scroll-mt-24">
+              <h2 className="mb-4 flex items-center gap-3">
+                {family}
+                <Badge variant="family">{traditions.length}</Badge>
+              </h2>
+              <div className="grid gap-4 sm:grid-cols-2">
+                {traditions.map((t) => (
+                  <Link key={t.slug} href={`/traditions/${t.slug}`} className="group">
+                    <Card accent="terracotta" className="h-full group-hover:bg-accent/50">
+                      <CardHeader>
+                        <CardTitle className="group-hover:text-primary transition-colors">
+                          {t.name}
+                        </CardTitle>
+                        <CardDescription>{t.summary}</CardDescription>
+                      </CardHeader>
+                    </Card>
+                  </Link>
+                ))}
+              </div>
+            </section>
+          ))}
+        </div>
+      </div>
     </PageLayout>
   );
 }


### PR DESCRIPTION
## Summary
- Rewrote traditions page with two-column layout: sticky left sidebar + main content area
- Sidebar shows "Traditions / THE DIGITAL ARCHIVIST" heading with family nav links (with emoji icons) that anchor-scroll to sections
- Large editorial hero: "The Tapestry of Ancestral Wisdom" in serif display type with scholarly subtitle
- Sidebar hidden on mobile (responsive single-column fallback)
- Existing family grouping and tradition cards preserved intact for #160

Closes #159

## Test plan
- [ ] Desktop: sidebar visible, sticky on scroll, nav links scroll to correct sections
- [ ] Mobile: sidebar hidden, hero and sections display in single column
- [ ] All family sections have correct `id` attributes matching sidebar hrefs
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)