### PR TITLE
feat: add mobile nav bar to traditions page

### DIFF
--- a/src/app/traditions/page.tsx
+++ b/src/app/traditions/page.tsx
@@ -255,6 +255,19 @@ export default function TraditionsPage() {
             </p>
           </header>
 
+          {/* Mobile family nav -- horizontal scrollable pills */}
+          <nav className="lg:hidden flex overflow-x-auto gap-2 pb-2 -mx-2 px-2 mb-8">
+            {groups.map(({ family }) => (
+              <a
+                key={family}
+                href={`#${familySlug(family)}`}
+                className="shrink-0 px-3 py-1.5 text-sm border border-border/50 rounded-full text-muted-foreground hover:text-foreground hover:bg-accent/50 transition-colors whitespace-nowrap"
+              >
+                {family}
+              </a>
+            ))}
+          </nav>
+
           {/* Family sections */}
           {groups.map(({ family, traditions: familyTraditions }, index) => (
             <section key={family} id={familySlug(family)} className="mb-12 scroll-mt-24">


### PR DESCRIPTION
## Summary
- Adds a horizontal scrollable pill nav bar below the hero on the traditions page
- Visible only on mobile/tablet (`lg:hidden`), hidden on desktop where the sidebar handles navigation
- Each family renders as a pill-style anchor link (`#family-slug`) matching the sidebar links

Closes #166

## Test plan
- [ ] On mobile viewport, verify horizontal pill nav appears between hero and first family section
- [ ] Verify pills scroll horizontally when families overflow
- [ ] Verify each pill scrolls to the correct family section
- [ ] On desktop (≥1024px), verify the pill nav is hidden
- [ ] `npm run build` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)