### PR TITLE
feat: add resource categories and group display (#45)

### DIFF
--- a/data/resources/a-brief-introduction-to-jainism-and-sikhism.json
+++ b/data/resources/a-brief-introduction-to-jainism-and-sikhism.json
@@ -2,6 +2,7 @@
   "title": "A Brief Introduction to Jainism and Sikhism",
   "slug": "a-brief-introduction-to-jainism-and-sikhism",
   "type": "book",
+  "category": "encyclopedia",
   "url": "https://bookshop.org/a/122188/9781506450384",
   "author": "Christopher Partridge",
   "year": 2018,

--- a/data/resources/a-path-with-heart.json
+++ b/data/resources/a-path-with-heart.json
@@ -2,6 +2,7 @@
   "title": "A Path with Heart",
   "slug": "a-path-with-heart",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9780553372113",
   "author": "Jack Kornfield",
   "year": 1993,

--- a/data/resources/a-testament-of-devotion.json
+++ b/data/resources/a-testament-of-devotion.json
@@ -2,6 +2,7 @@
   "title": "A Testament of Devotion",
   "slug": "a-testament-of-devotion",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9780060642129",
   "author": "Thomas R. Kelly",
   "year": 1941,

--- a/data/resources/access-to-insight.json
+++ b/data/resources/access-to-insight.json
@@ -2,11 +2,14 @@
   "title": "Access to Insight",
   "slug": "access-to-insight",
   "type": "website",
+  "category": "web_resource",
   "url": "https://accesstoinsight.org",
   "author": null,
   "year": 1993,
   "description": "Comprehensive online library of Theravada Buddhist texts including suttas, commentaries, and practice guides translated from Pali.",
-  "traditions": ["theravada"],
+  "traditions": [
+    "theravada"
+  ],
   "teachers": [],
   "centers": []
 }

--- a/data/resources/awakening-buddha-within.json
+++ b/data/resources/awakening-buddha-within.json
@@ -2,6 +2,7 @@
   "title": "Awakening the Buddha Within",
   "slug": "awakening-buddha-within",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9780767901574",
   "author": "Lama Surya Das",
   "year": 1997,

--- a/data/resources/awakening-of-the-heart.json
+++ b/data/resources/awakening-of-the-heart.json
@@ -2,6 +2,7 @@
   "title": "Awakening of the Heart",
   "slug": "awakening-of-the-heart",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9781937006112",
   "author": "Thich Nhat Hanh",
   "year": 2012,

--- a/data/resources/be-as-you-are.json
+++ b/data/resources/be-as-you-are.json
@@ -2,6 +2,7 @@
   "title": "Be As You Are: The Teachings of Sri Ramana Maharshi",
   "slug": "be-as-you-are",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9780140190625",
   "author": "David Godman",
   "year": 1985,

--- a/data/resources/be-here-now.json
+++ b/data/resources/be-here-now.json
@@ -2,6 +2,7 @@
   "title": "Be Here Now",
   "slug": "be-here-now",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9780517543054",
   "author": "Ram Dass",
   "year": 1971,

--- a/data/resources/bhagavad-gita.json
+++ b/data/resources/bhagavad-gita.json
@@ -2,6 +2,7 @@
   "title": "The Bhagavad Gita",
   "slug": "bhagavad-gita",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9781586380199",
   "author": "Eknath Easwaran",
   "year": 1985,

--- a/data/resources/bhakti-yoga.json
+++ b/data/resources/bhakti-yoga.json
@@ -2,6 +2,7 @@
   "title": "Bhakti Yoga: Tales and Teachings from the Bhagavata Purana",
   "slug": "bhakti-yoga",
   "type": "book",
+  "category": "academic",
   "url": "https://bookshop.org/a/122188/9780865477759",
   "author": "Edwin F. Bryant",
   "year": 2017,

--- a/data/resources/breath-by-breath.json
+++ b/data/resources/breath-by-breath.json
@@ -2,6 +2,7 @@
   "title": "Breath by Breath",
   "slug": "breath-by-breath",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9781590301364",
   "author": "Larry Rosenberg",
   "year": 1998,

--- a/data/resources/cloud-of-unknowing.json
+++ b/data/resources/cloud-of-unknowing.json
@@ -2,6 +2,7 @@
   "title": "The Cloud of Unknowing",
   "slug": "cloud-of-unknowing",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9780060737757",
   "author": null,
   "year": 1375,

--- a/data/resources/cutting-through-spiritual-materialism.json
+++ b/data/resources/cutting-through-spiritual-materialism.json
@@ -2,6 +2,7 @@
   "title": "Cutting Through Spiritual Materialism",
   "slug": "cutting-through-spiritual-materialism",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9781570629570",
   "author": "Chogyam Trungpa",
   "year": 1973,

--- a/data/resources/dharma-seed.json
+++ b/data/resources/dharma-seed.json
@@ -2,11 +2,20 @@
   "title": "Dharma Seed",
   "slug": "dharma-seed",
   "type": "podcast",
+  "category": "web_resource",
   "url": "https://dharmaseed.org",
   "author": null,
   "year": 1983,
   "description": "Vast archive of dharma talks from Theravada and Insight Meditation teachers including Joseph Goldstein, Jack Kornfield, and Gil Fronsdal.",
-  "traditions": ["theravada", "vipassana-movement"],
-  "teachers": ["gil-fronsdal"],
-  "centers": ["spirit-rock", "insight-meditation-center"]
+  "traditions": [
+    "theravada",
+    "vipassana-movement"
+  ],
+  "teachers": [
+    "gil-fronsdal"
+  ],
+  "centers": [
+    "spirit-rock",
+    "insight-meditation-center"
+  ]
 }

--- a/data/resources/diamond-sutra.json
+++ b/data/resources/diamond-sutra.json
@@ -2,6 +2,7 @@
   "title": "The Diamond Sutra",
   "slug": "diamond-sutra",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9781582432564",
   "author": "Red Pine",
   "year": 2001,

--- a/data/resources/essential-rumi.json
+++ b/data/resources/essential-rumi.json
@@ -2,6 +2,7 @@
   "title": "The Essential Rumi",
   "slug": "essential-rumi",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9780062509598",
   "author": "Coleman Barks",
   "year": 1995,

--- a/data/resources/fire-inside.json
+++ b/data/resources/fire-inside.json
@@ -2,6 +2,7 @@
   "title": "The Fire Inside: The Dharma of James Baldwin and Audre Lorde",
   "slug": "fire-inside",
   "type": "book",
+  "category": "academic",
   "url": "https://bookshop.org/a/122188/9798889842583",
   "author": "Rima Vesely-Flad",
   "year": 2025,

--- a/data/resources/full-catastrophe-living.json
+++ b/data/resources/full-catastrophe-living.json
@@ -2,6 +2,7 @@
   "title": "Full Catastrophe Living",
   "slug": "full-catastrophe-living",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9780345536938",
   "author": "Jon Kabat-Zinn",
   "year": 1990,

--- a/data/resources/gnosticism-new-light.json
+++ b/data/resources/gnosticism-new-light.json
@@ -2,6 +2,7 @@
   "title": "Gnosticism: New Light on the Ancient Tradition of Inner Knowing",
   "slug": "gnosticism-new-light",
   "type": "book",
+  "category": "academic",
   "url": "https://bookshop.org/a/122188/9780835608169",
   "author": "Stephan A. Hoeller",
   "year": 2002,

--- a/data/resources/heart-of-the-buddhas-teaching.json
+++ b/data/resources/heart-of-the-buddhas-teaching.json
@@ -2,6 +2,7 @@
   "title": "The Heart of the Buddha's Teaching",
   "slug": "heart-of-the-buddhas-teaching",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9780767903691",
   "author": "Thich Nhat Hanh",
   "year": 1998,

--- a/data/resources/i-am-that.json
+++ b/data/resources/i-am-that.json
@@ -2,6 +2,7 @@
   "title": "I Am That",
   "slug": "i-am-that",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9780893860462",
   "author": "Nisargadatta Maharaj",
   "year": 1973,

--- a/data/resources/interior-castle.json
+++ b/data/resources/interior-castle.json
@@ -2,6 +2,7 @@
   "title": "The Interior Castle",
   "slug": "interior-castle",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9780486461458",
   "author": "Teresa of Avila",
   "year": 1577,

--- a/data/resources/jainism-at-a-glance.json
+++ b/data/resources/jainism-at-a-glance.json
@@ -2,6 +2,7 @@
   "title": "Jainism at a Glance",
   "slug": "jainism-at-a-glance",
   "type": "book",
+  "category": "encyclopedia",
   "url": "https://bookshop.org/a/122188/9781452841854",
   "author": "Subhash C. Jain",
   "year": 2013,

--- a/data/resources/joy-of-living.json
+++ b/data/resources/joy-of-living.json
@@ -2,6 +2,7 @@
   "title": "The Joy of Living",
   "slug": "joy-of-living",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9780307347312",
   "author": "Yongey Mingyur Rinpoche",
   "year": 2007,

--- a/data/resources/kabbalah-very-short-introduction.json
+++ b/data/resources/kabbalah-very-short-introduction.json
@@ -2,6 +2,7 @@
   "title": "Kabbalah: A Very Short Introduction",
   "slug": "kabbalah-very-short-introduction",
   "type": "book",
+  "category": "encyclopedia",
   "url": "https://bookshop.org/a/122188/9780195327052",
   "author": "Joseph Dan",
   "year": 2006,

--- a/data/resources/kashmir-shaivism-secret-supreme.json
+++ b/data/resources/kashmir-shaivism-secret-supreme.json
@@ -2,6 +2,7 @@
   "title": "Kashmir Shaivism: The Secret Supreme",
   "slug": "kashmir-shaivism-secret-supreme",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9781548539894",
   "author": "Swami Lakshmanjoo",
   "year": 1988,

--- a/data/resources/know-yourself-balyani.json
+++ b/data/resources/know-yourself-balyani.json
@@ -2,11 +2,17 @@
   "title": "Know Yourself: An Explanation of the Oneness of Being",
   "slug": "know-yourself-balyani",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9780904975659",
   "author": "Awhad al-Din Balyani",
   "year": 2011,
   "description": "A concise 13th-century Sufi treatise on the unity of being, exploring the principle 'Whosoever knows their self, knows their Lord.' Translated by Cecilia Twinch, with commentary drawing on Ibn Arabi's tradition. Frequently referenced by Rupert Spira in his non-dual teachings.",
-  "traditions": ["sufism", "modern-non-dual"],
-  "teachers": ["rupert-spira"],
+  "traditions": [
+    "sufism",
+    "modern-non-dual"
+  ],
+  "teachers": [
+    "rupert-spira"
+  ],
   "centers": []
 }

--- a/data/resources/liberation-av-neryah.json
+++ b/data/resources/liberation-av-neryah.json
@@ -2,11 +2,16 @@
   "title": "Liberation: A Spiritual Autobiography",
   "slug": "liberation-av-neryah",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9789893515716",
   "author": "Av Neryah",
   "year": 2023,
   "description": "A comprehensive account of a journey toward spiritual liberation, weaving together mystical experiences, personal struggles, and an exposition of the highest teachings of nonduality.",
-  "traditions": ["modern-non-dual"],
-  "teachers": ["av-neryah"],
+  "traditions": [
+    "modern-non-dual"
+  ],
+  "teachers": [
+    "av-neryah"
+  ],
   "centers": []
 }

--- a/data/resources/light-on-yoga.json
+++ b/data/resources/light-on-yoga.json
@@ -2,6 +2,7 @@
   "title": "Light on Yoga",
   "slug": "light-on-yoga",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9780805210316",
   "author": "B.K.S. Iyengar",
   "year": 1966,

--- a/data/resources/living-dharma.json
+++ b/data/resources/living-dharma.json
@@ -2,6 +2,7 @@
   "title": "Living Dharma",
   "slug": "living-dharma",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9781590308325",
   "author": "Jack Kornfield",
   "year": 1996,

--- a/data/resources/lovingkindness.json
+++ b/data/resources/lovingkindness.json
@@ -2,6 +2,7 @@
   "title": "Lovingkindness: The Revolutionary Art of Happiness",
   "slug": "lovingkindness",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9781570629037",
   "author": "Sharon Salzberg",
   "year": 1995,

--- a/data/resources/mindfulness-a-practical-guide-to-awakening.json
+++ b/data/resources/mindfulness-a-practical-guide-to-awakening.json
@@ -2,6 +2,7 @@
   "title": "Mindfulness: A Practical Guide to Awakening",
   "slug": "mindfulness-a-practical-guide-to-awakening",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9781622036059",
   "author": "Joseph Goldstein",
   "year": 2013,

--- a/data/resources/mindfulness-in-plain-english.json
+++ b/data/resources/mindfulness-in-plain-english.json
@@ -2,6 +2,7 @@
   "title": "Mindfulness in Plain English",
   "slug": "mindfulness-in-plain-english",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9780861719068",
   "author": "Bhante Gunaratana",
   "year": 1991,

--- a/data/resources/mingyur-rinpoche-happiness-is-here.json
+++ b/data/resources/mingyur-rinpoche-happiness-is-here.json
@@ -2,11 +2,15 @@
   "title": "Yongey Mingyur Rinpoche: Happiness Is Here and Now",
   "slug": "mingyur-rinpoche-happiness-is-here",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/watch?v=C_T7UPBkNI0",
   "author": "Yongey Mingyur Rinpoche",
   "year": 2018,
   "description": "Tibetan Buddhist master teaches how awareness and panic can coexist, using humor and directness to convey meditation essentials.",
-  "traditions": ["tibetan-buddhism-gelug", "vajrayana"],
+  "traditions": [
+    "tibetan-buddhism-gelug",
+    "vajrayana"
+  ],
   "teachers": [],
   "centers": []
 }

--- a/data/resources/nature-of-consciousness.json
+++ b/data/resources/nature-of-consciousness.json
@@ -2,6 +2,7 @@
   "title": "The Nature of Consciousness",
   "slug": "nature-of-consciousness",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9781684030002",
   "author": "Rupert Spira",
   "year": 2017,

--- a/data/resources/neoplatonism.json
+++ b/data/resources/neoplatonism.json
@@ -2,6 +2,7 @@
   "title": "Neoplatonism",
   "slug": "neoplatonism",
   "type": "book",
+  "category": "academic",
   "url": "https://bookshop.org/a/122188/9781844651252",
   "author": "Pauliina Remes",
   "year": 2008,

--- a/data/resources/origins-of-yoga-and-tantra.json
+++ b/data/resources/origins-of-yoga-and-tantra.json
@@ -2,6 +2,7 @@
   "title": "The Origins of Yoga and Tantra",
   "slug": "origins-of-yoga-and-tantra",
   "type": "book",
+  "category": "academic",
   "url": "https://bookshop.org/a/122188/9780521695343",
   "author": "Geoffrey Samuel",
   "year": 2008,

--- a/data/resources/philokalia.json
+++ b/data/resources/philokalia.json
@@ -2,6 +2,7 @@
   "title": "The Philokalia",
   "slug": "philokalia",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9780571130139",
   "author": null,
   "year": 1782,

--- a/data/resources/plotinus-introduction-to-the-enneads.json
+++ b/data/resources/plotinus-introduction-to-the-enneads.json
@@ -2,6 +2,7 @@
   "title": "Plotinus: An Introduction to the Enneads",
   "slug": "plotinus-introduction-to-the-enneads",
   "type": "book",
+  "category": "academic",
   "url": "https://bookshop.org/a/122188/9780198751472",
   "author": "Dominic J. O'Meara",
   "year": 1993,

--- a/data/resources/precious-treasury-of-the-way-of-abiding.json
+++ b/data/resources/precious-treasury-of-the-way-of-abiding.json
@@ -2,11 +2,14 @@
   "title": "The Precious Treasury of the Way of Abiding",
   "slug": "precious-treasury-of-the-way-of-abiding",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9781881847090",
   "author": "Longchenpa (Longchen Rabjam)",
   "year": 1998,
   "description": "One of Longchenpa's Seven Treasuries, presenting the Dzogchen view of the nature of mind. Translated by Richard Barron (Lama Chökyi Nyima) as part of Padma Publishing's long-term project to bring the Seven Treasuries into English.",
-  "traditions": ["dzogchen"],
+  "traditions": [
+    "dzogchen"
+  ],
   "teachers": [],
   "centers": []
 }

--- a/data/resources/quaker-spirituality.json
+++ b/data/resources/quaker-spirituality.json
@@ -2,6 +2,7 @@
   "title": "Quaker Spirituality: Selected Writings",
   "slug": "quaker-spirituality",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9780809125104",
   "author": "Douglas V. Steere",
   "year": 1984,

--- a/data/resources/radical-acceptance.json
+++ b/data/resources/radical-acceptance.json
@@ -2,6 +2,7 @@
   "title": "Radical Acceptance",
   "slug": "radical-acceptance",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9780553380996",
   "author": "Tara Brach",
   "year": 2003,

--- a/data/resources/rupert-spira-the-nature-of-experience.json
+++ b/data/resources/rupert-spira-the-nature-of-experience.json
@@ -2,11 +2,17 @@
   "title": "Rupert Spira: The Nature of Experience",
   "slug": "rupert-spira-the-nature-of-experience",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/watch?v=XhLgSrecbII",
   "author": "Rupert Spira",
   "year": 2019,
   "description": "Talk exploring how all experience is made of consciousness, using direct investigation rather than belief or philosophy.",
-  "traditions": ["advaita-vedanta", "modern-non-dual"],
-  "teachers": ["rupert-spira"],
+  "traditions": [
+    "advaita-vedanta",
+    "modern-non-dual"
+  ],
+  "teachers": [
+    "rupert-spira"
+  ],
   "centers": []
 }

--- a/data/resources/satipatthana-direct-path.json
+++ b/data/resources/satipatthana-direct-path.json
@@ -2,6 +2,7 @@
   "title": "Satipatthana: The Direct Path to Realization",
   "slug": "satipatthana-direct-path",
   "type": "book",
+  "category": "academic",
   "url": "https://bookshop.org/a/122188/9781899579549",
   "author": "Bhikkhu Analayo",
   "year": 2003,

--- a/data/resources/shiva-sutras.json
+++ b/data/resources/shiva-sutras.json
@@ -2,6 +2,7 @@
   "title": "Shiva Sutras: The Supreme Awakening",
   "slug": "shiva-sutras",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9780983783374",
   "author": "Swami Lakshmanjoo",
   "year": 2007,

--- a/data/resources/tai-chi-classics.json
+++ b/data/resources/tai-chi-classics.json
@@ -2,6 +2,7 @@
   "title": "Tai Chi Classics",
   "slug": "tai-chi-classics",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9781570627491",
   "author": "Waysun Liao",
   "year": 1977,

--- a/data/resources/tantra-illuminated.json
+++ b/data/resources/tantra-illuminated.json
@@ -2,6 +2,7 @@
   "title": "Tantra Illuminated",
   "slug": "tantra-illuminated",
   "type": "book",
+  "category": "academic",
   "url": "https://bookshop.org/a/122188/9780989761307",
   "author": "Christopher D. Wallis",
   "year": 2012,

--- a/data/resources/tao-te-ching.json
+++ b/data/resources/tao-te-ching.json
@@ -2,6 +2,7 @@
   "title": "Tao Te Ching",
   "slug": "tao-te-ching",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9780060812454",
   "author": "Laozi",
   "year": null,

--- a/data/resources/that-which-is.json
+++ b/data/resources/that-which-is.json
@@ -2,6 +2,7 @@
   "title": "That Which Is: Tattvartha Sutra",
   "slug": "that-which-is",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9780300165296",
   "author": "Umasvati",
   "year": 200,

--- a/data/resources/the-complete-book-of-tai-chi-chuan.json
+++ b/data/resources/the-complete-book-of-tai-chi-chuan.json
@@ -2,6 +2,7 @@
   "title": "The Complete Book of Tai Chi Chuan",
   "slug": "the-complete-book-of-tai-chi-chuan",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9780804834407",
   "author": "Wong Kiew Kit",
   "year": 1996,

--- a/data/resources/the-conference-of-the-birds.json
+++ b/data/resources/the-conference-of-the-birds.json
@@ -2,6 +2,7 @@
   "title": "The Conference of the Birds",
   "slug": "the-conference-of-the-birds",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9780140444346",
   "author": "Farid ud-Din Attar",
   "year": 1177,

--- a/data/resources/the-crystal-and-the-way-of-light.json
+++ b/data/resources/the-crystal-and-the-way-of-light.json
@@ -2,6 +2,7 @@
   "title": "The Crystal and the Way of Light",
   "slug": "the-crystal-and-the-way-of-light",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9781559391351",
   "author": "Chogyal Namkhai Norbu",
   "year": 1986,

--- a/data/resources/the-end-of-your-world.json
+++ b/data/resources/the-end-of-your-world.json
@@ -2,6 +2,7 @@
   "title": "The End of Your World",
   "slug": "the-end-of-your-world",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9781591797791",
   "author": "Adyashanti",
   "year": 2008,

--- a/data/resources/the-essential-kabbalah.json
+++ b/data/resources/the-essential-kabbalah.json
@@ -2,6 +2,7 @@
   "title": "The Essential Kabbalah",
   "slug": "the-essential-kabbalah",
   "type": "book",
+  "category": "encyclopedia",
   "url": "https://bookshop.org/a/122188/9780062511638",
   "author": "Daniel C. Matt",
   "year": 1995,

--- a/data/resources/the-gnostic-gospels.json
+++ b/data/resources/the-gnostic-gospels.json
@@ -2,6 +2,7 @@
   "title": "The Gnostic Gospels",
   "slug": "the-gnostic-gospels",
   "type": "book",
+  "category": "academic",
   "url": "https://bookshop.org/a/122188/9780679724537",
   "author": "Elaine Pagels",
   "year": 1979,

--- a/data/resources/the-gospel-of-thomas.json
+++ b/data/resources/the-gospel-of-thomas.json
@@ -2,6 +2,7 @@
   "title": "The Gospel of Thomas: The Gnostic Wisdom of Jesus",
   "slug": "the-gospel-of-thomas",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9781594770463",
   "author": "Jean-Yves Leloup",
   "year": 2005,

--- a/data/resources/the-heart-of-sufism.json
+++ b/data/resources/the-heart-of-sufism.json
@@ -2,6 +2,7 @@
   "title": "The Heart of Sufism",
   "slug": "the-heart-of-sufism",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9781570624025",
   "author": "Hazrat Inayat Khan",
   "year": 1999,

--- a/data/resources/the-journal-of-george-fox.json
+++ b/data/resources/the-journal-of-george-fox.json
@@ -2,6 +2,7 @@
   "title": "The Journal of George Fox",
   "slug": "the-journal-of-george-fox",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9780140433999",
   "author": "George Fox",
   "year": 1694,

--- a/data/resources/the-miracle-of-mindfulness.json
+++ b/data/resources/the-miracle-of-mindfulness.json
@@ -2,6 +2,7 @@
   "title": "The Miracle of Mindfulness",
   "slug": "the-miracle-of-mindfulness",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9780807012390",
   "author": "Thich Nhat Hanh",
   "year": 1975,

--- a/data/resources/the-philokalia-selections.json
+++ b/data/resources/the-philokalia-selections.json
@@ -2,6 +2,7 @@
   "title": "The Philokalia: The Eastern Christian Spiritual Texts",
   "slug": "the-philokalia-selections",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9781594731037",
   "author": "Allyne Smith",
   "year": 2006,

--- a/data/resources/the-places-that-scare-you.json
+++ b/data/resources/the-places-that-scare-you.json
@@ -2,6 +2,7 @@
   "title": "The Places That Scare You",
   "slug": "the-places-that-scare-you",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9781570629211",
   "author": "Pema Chödrön",
   "year": 2001,

--- a/data/resources/the-platform-sutra-red-pine.json
+++ b/data/resources/the-platform-sutra-red-pine.json
@@ -2,6 +2,7 @@
   "title": "The Platform Sutra: The Zen Teaching of Hui-neng",
   "slug": "the-platform-sutra-red-pine",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9781593761776",
   "author": "Red Pine",
   "year": 2006,

--- a/data/resources/the-platform-sutra.json
+++ b/data/resources/the-platform-sutra.json
@@ -2,6 +2,7 @@
   "title": "The Platform Sutra of the Sixth Patriarch",
   "slug": "the-platform-sutra",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9780231083614",
   "author": "Huineng",
   "year": 780,

--- a/data/resources/the-tao-of-pooh.json
+++ b/data/resources/the-tao-of-pooh.json
@@ -2,6 +2,7 @@
   "title": "The Tao of Pooh",
   "slug": "the-tao-of-pooh",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9780140067477",
   "author": "Benjamin Hoff",
   "year": 1982,

--- a/data/resources/the-tibetan-yogas-of-dream-and-sleep.json
+++ b/data/resources/the-tibetan-yogas-of-dream-and-sleep.json
@@ -2,6 +2,7 @@
   "title": "The Tibetan Yogas of Dream and Sleep",
   "slug": "the-tibetan-yogas-of-dream-and-sleep",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9781559391016",
   "author": "Tenzin Wangyal Rinpoche",
   "year": 1998,

--- a/data/resources/the-upanishads.json
+++ b/data/resources/the-upanishads.json
@@ -2,6 +2,7 @@
   "title": "The Upanishads",
   "slug": "the-upanishads",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9781586380212",
   "author": "Eknath Easwaran",
   "year": 1987,

--- a/data/resources/the-way-of-a-pilgrim.json
+++ b/data/resources/the-way-of-a-pilgrim.json
@@ -2,6 +2,7 @@
   "title": "The Way of a Pilgrim",
   "slug": "the-way-of-a-pilgrim",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9781570628078",
   "author": "Anonymous",
   "year": 1884,

--- a/data/resources/the-way-of-qigong.json
+++ b/data/resources/the-way-of-qigong.json
@@ -2,6 +2,7 @@
   "title": "The Way of Qigong",
   "slug": "the-way-of-qigong",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9780345421098",
   "author": "Kenneth S. Cohen",
   "year": 1997,

--- a/data/resources/the-way-of-the-bodhisattva.json
+++ b/data/resources/the-way-of-the-bodhisattva.json
@@ -2,6 +2,7 @@
   "title": "The Way of the Bodhisattva",
   "slug": "the-way-of-the-bodhisattva",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9781590303887",
   "author": "Shantideva",
   "year": 700,

--- a/data/resources/tibetan-book-of-living-and-dying.json
+++ b/data/resources/tibetan-book-of-living-and-dying.json
@@ -2,6 +2,7 @@
   "title": "The Tibetan Book of Living and Dying",
   "slug": "tibetan-book-of-living-and-dying",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9780062508348",
   "author": "Sogyal Rinpoche",
   "year": 1992,

--- a/data/resources/waking-up-app.json
+++ b/data/resources/waking-up-app.json
@@ -2,11 +2,17 @@
   "title": "Waking Up with Sam Harris",
   "slug": "waking-up-app",
   "type": "podcast",
+  "category": "web_resource",
   "url": "https://www.wakingup.com",
   "author": "Sam Harris",
   "year": 2018,
   "description": "Meditation app and podcast exploring mindfulness, consciousness, and non-dual awareness from a secular, science-informed perspective.",
-  "traditions": ["secular-mindfulness", "advaita-vedanta"],
-  "teachers": ["rupert-spira"],
+  "traditions": [
+    "secular-mindfulness",
+    "advaita-vedanta"
+  ],
+  "teachers": [
+    "rupert-spira"
+  ],
   "centers": []
 }

--- a/data/resources/way-of-zen.json
+++ b/data/resources/way-of-zen.json
@@ -2,6 +2,7 @@
   "title": "The Way of Zen",
   "slug": "way-of-zen",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9780375705106",
   "author": "Alan Watts",
   "year": 1957,

--- a/data/resources/what-the-buddha-taught.json
+++ b/data/resources/what-the-buddha-taught.json
@@ -2,6 +2,7 @@
   "title": "What the Buddha Taught",
   "slug": "what-the-buddha-taught",
   "type": "book",
+  "category": "academic",
   "url": "https://bookshop.org/a/122188/9780802130310",
   "author": "Walpola Rahula",
   "year": 1959,

--- a/data/resources/when-things-fall-apart.json
+++ b/data/resources/when-things-fall-apart.json
@@ -2,6 +2,7 @@
   "title": "When Things Fall Apart",
   "slug": "when-things-fall-apart",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9781611803438",
   "author": "Pema Chödrön",
   "year": 1997,

--- a/data/resources/wherever-you-go-there-you-are.json
+++ b/data/resources/wherever-you-go-there-you-are.json
@@ -2,6 +2,7 @@
   "title": "Wherever You Go, There You Are",
   "slug": "wherever-you-go-there-you-are",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9781401307783",
   "author": "Jon Kabat-Zinn",
   "year": 1994,

--- a/data/resources/wisdom-masters-ajahn-chah.json
+++ b/data/resources/wisdom-masters-ajahn-chah.json
@@ -2,11 +2,16 @@
   "title": "Ajahn Chah — Wisdom of the Masters",
   "slug": "wisdom-masters-ajahn-chah",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Ajahn+Chah",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Ajahn Chah, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["theravada"],
-  "teachers": ["ajahn-chah"],
+  "traditions": [
+    "theravada"
+  ],
+  "teachers": [
+    "ajahn-chah"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-ajahn-lee.json
+++ b/data/resources/wisdom-masters-ajahn-lee.json
@@ -2,11 +2,16 @@
   "title": "Ajahn Lee — Wisdom of the Masters",
   "slug": "wisdom-masters-ajahn-lee",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Ajahn+Lee",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Ajahn Lee, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["theravada"],
-  "teachers": ["ajahn-lee"],
+  "traditions": [
+    "theravada"
+  ],
+  "teachers": [
+    "ajahn-lee"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-annamalai-swami.json
+++ b/data/resources/wisdom-masters-annamalai-swami.json
@@ -2,11 +2,16 @@
   "title": "Annamalai Swami — Wisdom of the Masters",
   "slug": "wisdom-masters-annamalai-swami",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Annamalai+Swami",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Annamalai Swami, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["advaita-vedanta"],
-  "teachers": ["annamalai-swami"],
+  "traditions": [
+    "advaita-vedanta"
+  ],
+  "teachers": [
+    "annamalai-swami"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-ayu-khandro.json
+++ b/data/resources/wisdom-masters-ayu-khandro.json
@@ -2,11 +2,17 @@
   "title": "Ayu Khandro — Wisdom of the Masters",
   "slug": "wisdom-masters-ayu-khandro",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Ayu+Khandro",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Ayu Khandro, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["vajrayana", "dzogchen"],
-  "teachers": ["ayu-khandro"],
+  "traditions": [
+    "vajrayana",
+    "dzogchen"
+  ],
+  "teachers": [
+    "ayu-khandro"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-baizhang-huaihai.json
+++ b/data/resources/wisdom-masters-baizhang-huaihai.json
@@ -2,11 +2,17 @@
   "title": "Baizhang Huaihai — Wisdom of the Masters",
   "slug": "wisdom-masters-baizhang-huaihai",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Baizhang+Huaihai",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Baizhang Huaihai, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["zen", "chan-buddhism"],
-  "teachers": ["baizhang-huaihai"],
+  "traditions": [
+    "zen",
+    "chan-buddhism"
+  ],
+  "teachers": [
+    "baizhang-huaihai"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-bassui.json
+++ b/data/resources/wisdom-masters-bassui.json
@@ -2,11 +2,16 @@
   "title": "Bassui — Wisdom of the Masters",
   "slug": "wisdom-masters-bassui",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Bassui",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Bassui, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["zen"],
-  "teachers": ["bassui"],
+  "traditions": [
+    "zen"
+  ],
+  "teachers": [
+    "bassui"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-dilgo-khyentse-rinpoche.json
+++ b/data/resources/wisdom-masters-dilgo-khyentse-rinpoche.json
@@ -2,11 +2,17 @@
   "title": "Dilgo Khyentse Rinpoche — Wisdom of the Masters",
   "slug": "wisdom-masters-dilgo-khyentse-rinpoche",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Dilgo+Khyentse+Rinpoche",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Dilgo Khyentse Rinpoche, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["vajrayana", "dzogchen"],
-  "teachers": ["dilgo-khyentse-rinpoche"],
+  "traditions": [
+    "vajrayana",
+    "dzogchen"
+  ],
+  "teachers": [
+    "dilgo-khyentse-rinpoche"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-dudjom-rinpoche.json
+++ b/data/resources/wisdom-masters-dudjom-rinpoche.json
@@ -2,11 +2,17 @@
   "title": "Dudjom Rinpoche — Wisdom of the Masters",
   "slug": "wisdom-masters-dudjom-rinpoche",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Dudjom+Rinpoche",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Dudjom Rinpoche, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["vajrayana", "dzogchen"],
-  "teachers": ["dudjom-rinpoche"],
+  "traditions": [
+    "vajrayana",
+    "dzogchen"
+  ],
+  "teachers": [
+    "dudjom-rinpoche"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-father-thomas-keating.json
+++ b/data/resources/wisdom-masters-father-thomas-keating.json
@@ -2,11 +2,16 @@
   "title": "Thomas Keating — Wisdom of the Masters",
   "slug": "wisdom-masters-father-thomas-keating",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Thomas+Keating",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Thomas Keating, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["christian-mysticism"],
-  "teachers": ["father-thomas-keating"],
+  "traditions": [
+    "christian-mysticism"
+  ],
+  "teachers": [
+    "father-thomas-keating"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-hafiz.json
+++ b/data/resources/wisdom-masters-hafiz.json
@@ -2,11 +2,16 @@
   "title": "Hafiz — Wisdom of the Masters",
   "slug": "wisdom-masters-hafiz",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/results?search_query=wisdom+of+the+masters+hafiz",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio readings of Hafiz's poetry from the Wisdom of the Masters YouTube channel by Samaneri Jayasāra.",
-  "traditions": ["sufism"],
-  "teachers": ["hafiz"],
+  "traditions": [
+    "sufism"
+  ],
+  "teachers": [
+    "hafiz"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-hongzhi.json
+++ b/data/resources/wisdom-masters-hongzhi.json
@@ -2,11 +2,17 @@
   "title": "Hongzhi — Wisdom of the Masters",
   "slug": "wisdom-masters-hongzhi",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Hongzhi",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Hongzhi, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["zen", "chan-buddhism"],
-  "teachers": ["hongzhi"],
+  "traditions": [
+    "zen",
+    "chan-buddhism"
+  ],
+  "teachers": [
+    "hongzhi"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-ilie-cioara.json
+++ b/data/resources/wisdom-masters-ilie-cioara.json
@@ -2,11 +2,16 @@
   "title": "Ilie Cioara — Wisdom of the Masters",
   "slug": "wisdom-masters-ilie-cioara",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Ilie+Cioara",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Ilie Cioara, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["modern-non-dual"],
-  "teachers": ["ilie-cioara"],
+  "traditions": [
+    "modern-non-dual"
+  ],
+  "teachers": [
+    "ilie-cioara"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-jean-klein.json
+++ b/data/resources/wisdom-masters-jean-klein.json
@@ -2,11 +2,17 @@
   "title": "Jean Klein — Wisdom of the Masters",
   "slug": "wisdom-masters-jean-klein",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Jean+Klein",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Jean Klein, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["advaita-vedanta", "modern-non-dual"],
-  "teachers": ["jean-klein"],
+  "traditions": [
+    "advaita-vedanta",
+    "modern-non-dual"
+  ],
+  "teachers": [
+    "jean-klein"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-lama-shabkar.json
+++ b/data/resources/wisdom-masters-lama-shabkar.json
@@ -2,11 +2,17 @@
   "title": "Lama Shabkar — Wisdom of the Masters",
   "slug": "wisdom-masters-lama-shabkar",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Lama+Shabkar",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Lama Shabkar, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["vajrayana", "dzogchen"],
-  "teachers": ["lama-shabkar"],
+  "traditions": [
+    "vajrayana",
+    "dzogchen"
+  ],
+  "teachers": [
+    "lama-shabkar"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-longchenpa.json
+++ b/data/resources/wisdom-masters-longchenpa.json
@@ -2,11 +2,17 @@
   "title": "Longchenpa — Wisdom of the Masters",
   "slug": "wisdom-masters-longchenpa",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Longchenpa",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Longchenpa, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["dzogchen", "vajrayana"],
-  "teachers": ["longchenpa"],
+  "traditions": [
+    "dzogchen",
+    "vajrayana"
+  ],
+  "teachers": [
+    "longchenpa"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-meister-eckhart.json
+++ b/data/resources/wisdom-masters-meister-eckhart.json
@@ -2,11 +2,16 @@
   "title": "Meister Eckhart — Wisdom of the Masters",
   "slug": "wisdom-masters-meister-eckhart",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Meister+Eckhart",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Meister Eckhart, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["christian-mysticism"],
-  "teachers": ["meister-eckhart"],
+  "traditions": [
+    "christian-mysticism"
+  ],
+  "teachers": [
+    "meister-eckhart"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-naropa.json
+++ b/data/resources/wisdom-masters-naropa.json
@@ -2,11 +2,16 @@
   "title": "Naropa — Wisdom of the Masters",
   "slug": "wisdom-masters-naropa",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Naropa",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Naropa, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["vajrayana"],
-  "teachers": ["naropa"],
+  "traditions": [
+    "vajrayana"
+  ],
+  "teachers": [
+    "naropa"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-nisargadatta-maharaj.json
+++ b/data/resources/wisdom-masters-nisargadatta-maharaj.json
@@ -2,11 +2,16 @@
   "title": "Nisargadatta Maharaj — Wisdom of the Masters",
   "slug": "wisdom-masters-nisargadatta-maharaj",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Nisargadatta+Maharaj",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Nisargadatta Maharaj, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["advaita-vedanta"],
-  "teachers": ["nisargadatta-maharaj"],
+  "traditions": [
+    "advaita-vedanta"
+  ],
+  "teachers": [
+    "nisargadatta-maharaj"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-padmasambhava.json
+++ b/data/resources/wisdom-masters-padmasambhava.json
@@ -2,11 +2,17 @@
   "title": "Padmasambhava — Wisdom of the Masters",
   "slug": "wisdom-masters-padmasambhava",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Padmasambhava",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Padmasambhava, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["vajrayana", "dzogchen"],
-  "teachers": ["padmasambhava"],
+  "traditions": [
+    "vajrayana",
+    "dzogchen"
+  ],
+  "teachers": [
+    "padmasambhava"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-patanjali.json
+++ b/data/resources/wisdom-masters-patanjali.json
@@ -2,11 +2,16 @@
   "title": "Patanjali — Wisdom of the Masters",
   "slug": "wisdom-masters-patanjali",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/results?search_query=wisdom+of+the+masters+patanjali",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings on Patanjali's Yoga Sutras from the Wisdom of the Masters YouTube channel by Samaneri Jayasāra.",
-  "traditions": ["classical-yoga"],
-  "teachers": ["patanjali"],
+  "traditions": [
+    "classical-yoga"
+  ],
+  "teachers": [
+    "patanjali"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-patrul-rinpoche.json
+++ b/data/resources/wisdom-masters-patrul-rinpoche.json
@@ -2,11 +2,17 @@
   "title": "Patrul Rinpoche — Wisdom of the Masters",
   "slug": "wisdom-masters-patrul-rinpoche",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Patrul+Rinpoche",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Patrul Rinpoche, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["vajrayana", "dzogchen"],
-  "teachers": ["patrul-rinpoche"],
+  "traditions": [
+    "vajrayana",
+    "dzogchen"
+  ],
+  "teachers": [
+    "patrul-rinpoche"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-ramana-maharshi.json
+++ b/data/resources/wisdom-masters-ramana-maharshi.json
@@ -2,11 +2,16 @@
   "title": "Ramana Maharshi — Wisdom of the Masters",
   "slug": "wisdom-masters-ramana-maharshi",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Ramana+Maharshi",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Ramana Maharshi, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["advaita-vedanta"],
-  "teachers": ["ramana-maharshi"],
+  "traditions": [
+    "advaita-vedanta"
+  ],
+  "teachers": [
+    "ramana-maharshi"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-rumi.json
+++ b/data/resources/wisdom-masters-rumi.json
@@ -2,11 +2,16 @@
   "title": "Rumi — Wisdom of the Masters",
   "slug": "wisdom-masters-rumi",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Rumi",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Rumi, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["sufism"],
-  "teachers": ["rumi"],
+  "traditions": [
+    "sufism"
+  ],
+  "teachers": [
+    "rumi"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-ryokan.json
+++ b/data/resources/wisdom-masters-ryokan.json
@@ -2,11 +2,16 @@
   "title": "Ryokan — Wisdom of the Masters",
   "slug": "wisdom-masters-ryokan",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Ryokan",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Ryokan, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["zen"],
-  "teachers": ["ryokan"],
+  "traditions": [
+    "zen"
+  ],
+  "teachers": [
+    "ryokan"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-seng-tsan.json
+++ b/data/resources/wisdom-masters-seng-tsan.json
@@ -2,11 +2,17 @@
   "title": "Seng T'san — Wisdom of the Masters",
   "slug": "wisdom-masters-seng-tsan",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Seng+T'san",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Seng T'san, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["zen", "chan-buddhism"],
-  "teachers": ["seng-tsan"],
+  "traditions": [
+    "zen",
+    "chan-buddhism"
+  ],
+  "teachers": [
+    "seng-tsan"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-st-teresa-of-avila.json
+++ b/data/resources/wisdom-masters-st-teresa-of-avila.json
@@ -2,11 +2,16 @@
   "title": "St. Teresa of Avila — Wisdom of the Masters",
   "slug": "wisdom-masters-st-teresa-of-avila",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=St.+Teresa+of+Avila",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from St. Teresa of Avila, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["christian-mysticism"],
-  "teachers": ["st-teresa-of-avila"],
+  "traditions": [
+    "christian-mysticism"
+  ],
+  "teachers": [
+    "st-teresa-of-avila"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-tilopa.json
+++ b/data/resources/wisdom-masters-tilopa.json
@@ -2,11 +2,16 @@
   "title": "Tilopa — Wisdom of the Masters",
   "slug": "wisdom-masters-tilopa",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Tilopa",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Tilopa, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["vajrayana"],
-  "teachers": ["tilopa"],
+  "traditions": [
+    "vajrayana"
+  ],
+  "teachers": [
+    "tilopa"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-tulku-urgyen-rinpoche.json
+++ b/data/resources/wisdom-masters-tulku-urgyen-rinpoche.json
@@ -2,11 +2,17 @@
   "title": "Tulku Urgyen Rinpoche — Wisdom of the Masters",
   "slug": "wisdom-masters-tulku-urgyen-rinpoche",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/@SamaneriJayasara/search?query=Tulku+Urgyen+Rinpoche",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings and readings from Tulku Urgyen Rinpoche, curated by Samaneri Jayasāra on the Wisdom of the Masters channel.",
-  "traditions": ["vajrayana", "dzogchen"],
-  "teachers": ["tulku-urgyen-rinpoche"],
+  "traditions": [
+    "vajrayana",
+    "dzogchen"
+  ],
+  "teachers": [
+    "tulku-urgyen-rinpoche"
+  ],
   "centers": []
 }

--- a/data/resources/wisdom-masters-vivekananda.json
+++ b/data/resources/wisdom-masters-vivekananda.json
@@ -2,11 +2,17 @@
   "title": "Swami Vivekananda — Wisdom of the Masters",
   "slug": "wisdom-masters-vivekananda",
   "type": "video",
+  "category": "web_resource",
   "url": "https://www.youtube.com/results?search_query=wisdom+of+the+masters+swami+vivekananda",
   "author": "Samaneri Jayasāra",
   "year": null,
   "description": "Audio teachings on Swami Vivekananda from the Wisdom of the Masters YouTube channel by Samaneri Jayasāra.",
-  "traditions": ["vedanta", "classical-yoga"],
-  "teachers": ["swami-vivekananda"],
+  "traditions": [
+    "vedanta",
+    "classical-yoga"
+  ],
+  "teachers": [
+    "swami-vivekananda"
+  ],
   "centers": []
 }

--- a/data/resources/yoga-sutras-of-patanjali.json
+++ b/data/resources/yoga-sutras-of-patanjali.json
@@ -2,6 +2,7 @@
   "title": "The Yoga Sutras of Patanjali",
   "slug": "yoga-sutras-of-patanjali",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9781938477072",
   "author": "Patanjali",
   "year": null,

--- a/data/resources/zen-mind-beginners-mind.json
+++ b/data/resources/zen-mind-beginners-mind.json
@@ -2,6 +2,7 @@
   "title": "Zen Mind, Beginner's Mind",
   "slug": "zen-mind-beginners-mind",
   "type": "book",
+  "category": "popular",
   "url": "https://bookshop.org/a/122188/9781611808414",
   "author": "Shunryu Suzuki",
   "year": 1970,

--- a/data/resources/zohar.json
+++ b/data/resources/zohar.json
@@ -2,6 +2,7 @@
   "title": "The Zohar: Pritzker Edition",
   "slug": "zohar",
   "type": "book",
+  "category": "primary_text",
   "url": "https://bookshop.org/a/122188/9780804747479",
   "author": "Daniel C. Matt",
   "year": 2003,

--- a/src/components/resource-list.tsx
+++ b/src/components/resource-list.tsx
@@ -1,4 +1,20 @@
-import type { Resource, ResourceType } from "@/lib/types";
+import type { Resource, ResourceCategory, ResourceType } from "@/lib/types";
+
+const CATEGORY_ORDER: ResourceCategory[] = [
+  "primary_text",
+  "academic",
+  "encyclopedia",
+  "popular",
+  "web_resource",
+];
+
+const CATEGORY_LABELS: Record<ResourceCategory, string> = {
+  primary_text: "Primary Texts",
+  academic: "Academic Works",
+  encyclopedia: "Encyclopedias",
+  popular: "Popular Works",
+  web_resource: "Web Resources",
+};
 
 const TYPE_ORDER: ResourceType[] = ["book", "video", "podcast", "article", "website"];
 
@@ -17,51 +33,74 @@ interface ResourceListProps {
 export function ResourceList({ resources }: ResourceListProps) {
   if (resources.length === 0) return null;
 
-  const grouped = TYPE_ORDER.reduce<Partial<Record<ResourceType, Resource[]>>>(
-    (acc, type) => {
-      const items = resources.filter((r) => r.type === type);
-      if (items.length > 0) acc[type] = items;
-      return acc;
-    },
-    {}
-  );
+  // Group resources by category, then by type within each category
+  const groupedByCategory = CATEGORY_ORDER.reduce<
+    Partial<Record<ResourceCategory, Partial<Record<ResourceType, Resource[]>>>>
+  >((acc, category) => {
+    const categoryItems = resources.filter((r) => r.category === category);
+    if (categoryItems.length === 0) return acc;
+
+    const byType = TYPE_ORDER.reduce<Partial<Record<ResourceType, Resource[]>>>(
+      (typeAcc, type) => {
+        const items = categoryItems.filter((r) => r.type === type);
+        if (items.length > 0) typeAcc[type] = items;
+        return typeAcc;
+      },
+      {}
+    );
+
+    if (Object.keys(byType).length > 0) acc[category] = byType;
+    return acc;
+  }, {});
 
   return (
     <section className="mb-12">
       <h2 className="mb-6">Resources</h2>
 
-      {TYPE_ORDER.filter((type) => grouped[type]).map((type) => (
-        <div key={type} className="mb-8 last:mb-0">
-          <h3 className="font-sans text-sm font-semibold uppercase tracking-widest text-muted-foreground mb-4">
-            {TYPE_LABELS[type]}
-          </h3>
-          <div className="space-y-4">
-            {grouped[type]!.map((resource) => (
-              <a
-                key={resource.slug}
-                href={resource.url}
-                target="_blank"
-                rel="noopener noreferrer"
-                className="block rounded-lg bg-card p-4 border border-border/50 transition-colors hover:bg-accent/50"
-              >
-                <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:gap-3">
-                  <span className="font-serif text-base font-medium text-foreground">
-                    {resource.title}
-                  </span>
-                  {resource.author && (
-                    <span className="font-sans text-sm text-muted-foreground">
-                      {resource.author}
-                    </span>
-                  )}
+      {CATEGORY_ORDER.filter((category) => groupedByCategory[category]).map(
+        (category) => (
+          <div key={category} className="mb-10 last:mb-0">
+            <h3 className="font-serif text-lg font-semibold text-foreground mb-4 border-b border-border/50 pb-2">
+              {CATEGORY_LABELS[category]}
+            </h3>
+
+            {TYPE_ORDER.filter(
+              (type) => groupedByCategory[category]?.[type]
+            ).map((type) => (
+              <div key={type} className="mb-6 last:mb-0">
+                <h4 className="font-sans text-sm font-semibold uppercase tracking-widest text-muted-foreground mb-3">
+                  {TYPE_LABELS[type]}
+                </h4>
+                <div className="space-y-4">
+                  {groupedByCategory[category]![type]!.map((resource) => (
+                    <a
+                      key={resource.slug}
+                      href={resource.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="block rounded-lg bg-card p-4 border border-border/50 transition-colors hover:bg-accent/50"
+                    >
+                      <div className="flex flex-col gap-1 sm:flex-row sm:items-baseline sm:gap-3">
+                        <span className="font-serif text-base font-medium text-foreground">
+                          {resource.title}
+                        </span>
+                        {resource.author && (
+                          <span className="font-sans text-sm text-muted-foreground">
+                            {resource.author}
+                          </span>
+                        )}
+                      </div>
+                      <p className="mt-1 font-sans text-sm leading-relaxed text-muted-foreground">
+                        {resource.description}
+                      </p>
+                    </a>
+                  ))}
                 </div>
-                <p className="mt-1 font-sans text-sm leading-relaxed text-muted-foreground">
-                  {resource.description}
-                </p>
-              </a>
+              </div>
             ))}
           </div>
-        </div>
-      ))}
+        )
+      )}
     </section>
   );
 }

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -47,6 +47,7 @@ function isCenter(obj: unknown): obj is Center {
 }
 
 const VALID_RESOURCE_TYPES = ["book", "podcast", "video", "article", "website"];
+const VALID_RESOURCE_CATEGORIES = ["primary_text", "academic", "popular", "encyclopedia", "web_resource"];
 
 function isResource(obj: unknown): obj is Resource {
   const r = obj as Record<string, unknown>;
@@ -55,6 +56,8 @@ function isResource(obj: unknown): obj is Resource {
     typeof r.slug === "string" &&
     typeof r.type === "string" &&
     VALID_RESOURCE_TYPES.includes(r.type as string) &&
+    typeof r.category === "string" &&
+    VALID_RESOURCE_CATEGORIES.includes(r.category as string) &&
     typeof r.url === "string" &&
     (r.author === null || typeof r.author === "string") &&
     (r.year === null || typeof r.year === "number") &&

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -44,10 +44,18 @@ export interface Teacher {
 
 export type ResourceType = "book" | "podcast" | "video" | "article" | "website";
 
+export type ResourceCategory =
+  | "primary_text"
+  | "academic"
+  | "popular"
+  | "encyclopedia"
+  | "web_resource";
+
 export interface Resource {
   title: string;
   slug: string;
   type: ResourceType;
+  category: ResourceCategory;
   url: string;
   author: string | null;
   year: number | null;


### PR DESCRIPTION
## Summary
- Added `ResourceCategory` type (`primary_text` | `academic` | `popular` | `encyclopedia` | `web_resource`) to `src/lib/types.ts`
- Added required `category` field to `Resource` interface
- Categorized all 107 resource JSON files in `data/resources/`
- Updated `ResourceList` component to group by category (primary texts -> academic -> encyclopedia -> popular -> web) with type sub-groups within each category
- Updated `isResource` validator in `src/lib/data.ts` to check the new field

## Test plan
- [x] `npm run build` passes
- [ ] Verify resource pages render with category groupings
- [ ] Spot-check categorizations (e.g., Bhagavad Gita = primary_text, Access to Insight = web_resource)

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)