### PR TITLE
feat: full-viewport homepage hero

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -73,35 +73,36 @@ const sections = [
 
 export default function Home() {
   return (
-    <PageLayout>
-      {/* Hero */}
-      <section className="relative -mx-6 px-6 py-28 md:py-36 mb-20 text-center overflow-hidden">
-        <Image
-          src="/images/hero-bg.jpg"
-          alt=""
-          fill
-          className="object-cover object-center"
-          sizes="100vw"
-          priority
-        />
-        <div className="absolute inset-0 bg-background/60" />
-        <div className="relative z-10">
-          <h1 className="font-serif text-5xl sm:text-6xl lg:text-7xl font-semibold tracking-tight mb-6">
-            The Contemplative Landscape
-          </h1>
-          <p className="text-lg text-muted-foreground leading-relaxed max-w-2xl mx-auto mb-8">
-            Explore how the world&apos;s great contemplative traditions connect,
-            diverge, and speak to one another across time.
-          </p>
-          <Link
-            href="/map"
-            className="inline-flex items-center gap-2 bg-gradient-to-br from-primary to-primary-container text-primary-foreground px-6 py-3 rounded font-sans text-sm hover:opacity-90 transition-opacity"
-          >
-            Explore the Map &rarr;
-          </Link>
-        </div>
-      </section>
-
+    <PageLayout
+      heroContent={
+        <section className="relative min-h-[100dvh] flex items-center justify-center text-center overflow-hidden">
+          <Image
+            src="/images/hero-bg.jpg"
+            alt=""
+            fill
+            className="object-cover object-center"
+            sizes="100vw"
+            priority
+          />
+          <div className="absolute inset-0 bg-background/40" />
+          <div className="relative z-10 px-6">
+            <h1 className="font-serif text-5xl sm:text-6xl lg:text-7xl font-semibold tracking-tight mb-6">
+              The Contemplative Landscape
+            </h1>
+            <p className="text-lg text-muted-foreground leading-relaxed max-w-2xl mx-auto mb-8">
+              Explore how the world&apos;s great contemplative traditions connect,
+              diverge, and speak to one another across time.
+            </p>
+            <Link
+              href="/map"
+              className="inline-flex items-center gap-2 bg-gradient-to-br from-primary to-primary-container text-primary-foreground px-6 py-3 rounded font-sans text-sm hover:opacity-90 transition-opacity"
+            >
+              Explore the Map &rarr;
+            </Link>
+          </div>
+        </section>
+      }
+    >
       {/* Feature cards */}
       <section className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4 mb-20">
         {sections.map((section) => (

--- a/src/components/page-layout.tsx
+++ b/src/components/page-layout.tsx
@@ -3,12 +3,14 @@ import { SiteFooter } from "./site-footer";
 
 interface PageLayoutProps {
   children: React.ReactNode;
+  heroContent?: React.ReactNode;
 }
 
-export function PageLayout({ children }: PageLayoutProps) {
+export function PageLayout({ children, heroContent }: PageLayoutProps) {
   return (
     <div className="flex min-h-screen flex-col">
       <SiteHeader />
+      {heroContent}
       <main className="mx-auto w-full max-w-5xl flex-1 px-6 py-10">
         {children}
       </main>


### PR DESCRIPTION
## Summary
- Move hero section into a `heroContent` slot on `PageLayout` so it renders full-width outside the `max-w-5xl` main wrapper
- Hero now fills the full viewport height (`min-h-[100dvh]`) with centered content
- Lightened overlay opacity for more visible background image

## Test plan
- [ ] Homepage hero fills full viewport on desktop and mobile
- [ ] Other pages using `PageLayout` are unaffected
- [ ] Content is vertically centered over the mountain image

🤖 Generated with [Claude Code](https://claude.com/claude-code)