### PR TITLE
fix: reduce hero padding

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -77,7 +77,7 @@ export default function Home() {
       heroContent={
         <>
           {/* Hero image + headline */}
-          <section className="relative flex items-center justify-center text-center overflow-hidden py-32 md:py-44 pb-48 md:pb-56">
+          <section className="relative flex items-center justify-center text-center overflow-hidden pt-24 md:pt-32 pb-36 md:pb-40">
             <Image
               src="/images/hero-bg.jpg"
               alt=""


### PR DESCRIPTION
## Summary
- Reduce hero top padding from `py-32/44` to `pt-24/32`
- Reduce hero bottom padding from `pb-48/56` to `pb-36/40`
- Cards now appear higher, closer to the hero content

🤖 Generated with [Claude Code](https://claude.com/claude-code)