### PR TITLE
fix: improve map label readability and visual contrast

### DIFF
--- a/src/components/tradition-map/map-edge.tsx
+++ b/src/components/tradition-map/map-edge.tsx
@@ -30,14 +30,14 @@ export function MapEdge({
   if (hidden) return null;
 
   const isBranch = edge.connectionType === "branch_of";
-  const strokeColor = isBranch ? "rgb(180, 140, 100)" : "rgb(140, 140, 160)";
-  const strokeWidth = highlighted ? 2.5 : 1.5;
+  const strokeColor = isBranch ? "rgb(160, 115, 70)" : "rgb(110, 110, 135)";
+  const strokeWidth = highlighted ? 3 : 2;
   const dashArray = isBranch ? undefined : "6 4";
 
   const midY = (sourcePos.y + targetPos.y) / 2;
   const pathD = `M ${sourcePos.x} ${sourcePos.y} C ${sourcePos.x} ${midY}, ${targetPos.x} ${midY}, ${targetPos.x} ${targetPos.y}`;
 
-  const opacity = dimmed ? 0.12 : highlighted ? 1 : 0.5;
+  const opacity = dimmed ? 0.15 : highlighted ? 1 : 0.65;
 
   return (
     <g

--- a/src/components/tradition-map/map-node.tsx
+++ b/src/components/tradition-map/map-node.tsx
@@ -34,7 +34,9 @@ export function MapNode({
 }: MapNodeProps) {
   const colors = FAMILY_COLORS[node.family];
   const inverseScale = 1 / zoomScale;
-  const radius = highlighted ? 7 : 5;
+  // Scale font with zoom so labels stay proportional to circles
+  const fontSize = Math.round(12 * Math.max(1, Math.pow(zoomScale, 0.65)));
+  const radius = highlighted ? 8 : 6;
   const opacity = dimmed ? 0.2 : 1;
 
   return (
@@ -58,12 +60,14 @@ export function MapNode({
         }
       }}
     >
-      {/* Colored circle */}
+      {/* Colored circle with stroke for contrast */}
       <circle
         cx={position.x}
         cy={position.y}
         r={radius}
         fill={colors.fill}
+        stroke={colors.stroke}
+        strokeWidth={1.5}
         style={{ transition: "r 0.2s ease" }}
       />
 
@@ -74,10 +78,10 @@ export function MapNode({
           y={4}
           textAnchor="start"
           className="select-none"
-          fill={highlighted ? "#333" : dimmed ? "rgba(51,51,51,0.2)" : "#333"}
-          fontSize={12}
+          fill={highlighted ? colors.text : dimmed ? "rgba(51,51,51,0.2)" : colors.text}
+          fontSize={fontSize}
           fontFamily="system-ui, sans-serif"
-          fontWeight={highlighted ? 600 : 400}
+          fontWeight={highlighted ? 600 : 500}
           style={{ transition: "fill 0.2s ease, font-weight 0.2s ease" }}
         >
           {node.name}

--- a/src/components/tradition-map/map-time-axis.tsx
+++ b/src/components/tradition-map/map-time-axis.tsx
@@ -57,7 +57,7 @@ export function MapTimeAxis({
               y1={y}
               x2={xMax}
               y2={y}
-              stroke="#e5e5e5"
+              stroke="#d8d4ce"
               strokeWidth={1}
             />
             {/* Era label */}
@@ -65,8 +65,9 @@ export function MapTimeAxis({
               x={x}
               y={y + 4}
               textAnchor="start"
-              fill="#999"
-              fontSize={12}
+              fill="#777"
+              fontSize={13}
+              fontWeight={500}
               fontFamily="system-ui, sans-serif"
             >
               {era.label}


### PR DESCRIPTION
## Summary
- **Label sizing on zoom**: Labels now scale partially with zoom (`pow(zoomScale, 0.65)`) so they stay proportional to node circles instead of becoming tiny at higher zoom levels
- **Visual contrast**: Node labels use family-specific colors instead of flat `#333`, circles are slightly larger (r=6/8) with a stroke outline, edges are darker/thicker with higher base opacity, and time axis labels are bolder

## Test plan
- [ ] Open /map, zoom in 3-4× — labels should grow and remain readable
- [ ] Verify each tradition family's labels show in their distinct color
- [ ] Check edges are visible against the cream background without hovering
- [ ] Confirm time axis era labels (1000 BCE, etc.) are clearly legible

🤖 Generated with [Claude Code](https://claude.com/claude-code)