### PR TITLE
fix: restore card contrast on teachers and masters pages

### DIFF
--- a/src/components/masters-client.tsx
+++ b/src/components/masters-client.tsx
@@ -166,11 +166,11 @@ export function MastersClient({ masters, traditionNames, families }: MastersClie
                 {family}
               </h2>
 
-              <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-x-8 gap-y-0">
+              <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
                 {members.map((master) => (
                   <div
                     key={master.slug}
-                    className="flex gap-4 py-6"
+                    className="flex gap-4 rounded-lg border border-border bg-white p-4"
                   >
                     {/* Photo */}
                     {master.photo ? (

--- a/src/components/teachers-client.tsx
+++ b/src/components/teachers-client.tsx
@@ -112,7 +112,7 @@ export function TeachersClient({ teachers, traditionNames }: TeachersClientProps
               href={`/teachers/${teacher.slug}`}
               className="group"
             >
-              <div className="h-full rounded-lg border border-border/50 p-4 group-hover:bg-accent/50 transition-colors">
+              <div className="h-full rounded-lg border border-border bg-white p-4 group-hover:bg-accent/50 transition-colors">
                 <div className="flex items-start gap-4">
                   <div className="shrink-0">
                     {teacher.photo ? (


### PR DESCRIPTION
## Summary
- **Teachers**: `border-border/50` → `border-border bg-white` — cards now visually separate from the cream background
- **Masters**: Added card container (`rounded-lg border border-border bg-white p-4`) — cards were previously just floating content with no boundary

## Test plan
- [ ] /teachers — cards should have visible borders and white backgrounds
- [ ] /masters — each master should sit in a distinct card
- [ ] Hover states still work on teacher cards

🤖 Generated with [Claude Code](https://claude.com/claude-code)