### PR TITLE
fix: tradition card contrast, revert masters, terracotta map border

### DIFF
--- a/src/app/traditions/page.tsx
+++ b/src/app/traditions/page.tsx
@@ -80,7 +80,7 @@ function ImageCard({ t }: { t: ParsedTradition }) {
   const gradient = getGradient(t.slug);
   return (
     <Link href={`/traditions/${t.slug}`} className="group block">
-      <div className="border border-border/50 rounded overflow-hidden">
+      <div className="border border-border bg-white rounded overflow-hidden">
         <div className="relative h-40 overflow-hidden">
           <Image
             src={`/images/traditions/${t.slug}.jpg`}
@@ -139,7 +139,7 @@ function QuoteCalloutWithGrid({ traditions }: { traditions: ParsedTradition[] })
           <Link
             key={t.slug}
             href={`/traditions/${t.slug}`}
-            className="group block border border-border/50 rounded p-4"
+            className="group block border border-border bg-white rounded p-4"
           >
             <h3 className="font-serif font-medium mb-1 group-hover:text-primary transition-colors">
               {t.name}
@@ -189,7 +189,7 @@ function HeroImageWithCards({ traditions }: { traditions: ParsedTradition[] }) {
           <Link
             key={t.slug}
             href={`/traditions/${t.slug}`}
-            className="group block border border-border/50 rounded p-4"
+            className="group block border border-border bg-white rounded p-4"
           >
             <h3 className="font-serif font-medium mb-1 group-hover:text-primary transition-colors">
               {t.name}

--- a/src/components/masters-client.tsx
+++ b/src/components/masters-client.tsx
@@ -166,11 +166,11 @@ export function MastersClient({ masters, traditionNames, families }: MastersClie
                 {family}
               </h2>
 
-              <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-4">
+              <div className="grid grid-cols-1 md:grid-cols-2 xl:grid-cols-3 gap-x-8 gap-y-0">
                 {members.map((master) => (
                   <div
                     key={master.slug}
-                    className="flex gap-4 rounded-lg border border-border bg-white p-4"
+                    className="flex gap-4 py-6"
                   >
                     {/* Photo */}
                     {master.photo ? (

--- a/src/components/tradition-map/tradition-map.tsx
+++ b/src/components/tradition-map/tradition-map.tsx
@@ -222,7 +222,7 @@ export function TraditionMap({ traditions, resourceMap = {} }: TraditionMapProps
       <div className="flex flex-col lg:flex-row gap-6">
         {/* Map column */}
         <div className="flex-1 min-w-0">
-          <div className="bg-[#faf8f5] rounded-lg border border-[#e8e4df]">
+          <div className="bg-[#faf8f5] rounded-lg border-2 border-[#c0956c]">
             <svg
               ref={svgRef}
               className="w-full h-auto"


### PR DESCRIPTION
## Summary
- **Traditions page**: Cards get `bg-white` + full `border-border` — white-on-cream lift like the teachers page
- **Masters page**: Reverted to the original open layout (no card containers) — the previous style worked better for that page's editorial feel
- **Map page**: Swapped the faint `border-[#e8e4df]` for a warm `border-2 border-[#c0956c]` terracotta frame

## Test plan
- [ ] /traditions — image cards and text cards should have white backgrounds with visible borders
- [ ] /masters — should look identical to how it did before PR #178
- [ ] /map — map container should have a warm terracotta outline

🤖 Generated with [Claude Code](https://claude.com/claude-code)