### PR TITLE
fix: warm gray map background and stronger source typography

### DIFF
--- a/src/components/tradition-map/tradition-map.tsx
+++ b/src/components/tradition-map/tradition-map.tsx
@@ -222,7 +222,7 @@ export function TraditionMap({ traditions, resourceMap = {} }: TraditionMapProps
       <div className="flex flex-col lg:flex-row gap-6">
         {/* Map column */}
         <div className="flex-1 min-w-0">
-          <div className="bg-[#faf8f5] rounded-lg border-2 border-[#c0956c]">
+          <div className="bg-[#eee9e3] rounded-lg border border-[#e2dbd3]">
             <svg
               ref={svgRef}
               className="w-full h-auto"
@@ -329,14 +329,14 @@ export function TraditionMap({ traditions, resourceMap = {} }: TraditionMapProps
                       href={r.url}
                       target="_blank"
                       rel="noopener noreferrer"
-                      className="text-[14px] leading-snug hover:text-primary transition-colors"
-                      style={{ color: "#2a2a2a" }}
+                      className="text-[14px] font-semibold leading-snug hover:text-primary transition-colors"
+                      style={{ color: "#1a1a1a" }}
                     >
                       {r.title}{" "}
                       <span className="text-[#aaa] text-xs">↗</span>
                     </a>
                     {r.author && (
-                      <p className="text-[13px] mt-0.5" style={{ color: "#c0553a" }}>
+                      <p className="text-[13px] mt-0.5" style={{ color: "#9e4a3a" }}>
                         {r.author}
                       </p>
                     )}
@@ -350,7 +350,7 @@ export function TraditionMap({ traditions, resourceMap = {} }: TraditionMapProps
                             aria-pressed={t.slug === selectedSlug}
                             className="hover:underline transition-colors cursor-pointer"
                             style={{
-                              color: t.slug === selectedSlug ? "#c0553a" : "#999",
+                              color: t.slug === selectedSlug ? "#9e4a3a" : "#777",
                             }}
                           >
                             {t.name}


### PR DESCRIPTION
## Summary
- **Map background**: `#faf8f5` (cream, same as page) → `#eee9e3` (warm gray) with subtle `#e2dbd3` border — the background shift alone frames the map against the page
- **Source titles**: Added `font-semibold` + darkened to `#1a1a1a`
- **Author names**: `#c0553a` → `#9e4a3a` (the core terracotta accent from the Lapham's palette)
- **Tradition tags**: `#999` → `#777`

## Research
Datawrapper and Atlassian data viz guidelines recommend light gray (not white) map backgrounds — it creates a natural "canvas" that foreground elements pop off of. The warm gray chosen here harmonizes with the site's cream palette rather than going cool/neutral.

## Test plan
- [ ] /map — map container should be noticeably distinct from the page background
- [ ] Source titles should feel bolder; author names darker rust; tradition tags more legible
- [ ] Node labels and edges still read clearly against the slightly darker background

🤖 Generated with [Claude Code](https://claude.com/claude-code)