### PR TITLE
fix: darken map background, remove border, trim footer tagline

### DIFF
--- a/src/components/site-footer.tsx
+++ b/src/components/site-footer.tsx
@@ -29,7 +29,7 @@ export function SiteFooter() {
         </nav>
 
         <p className="uppercase tracking-wider text-xs text-muted-foreground text-center lg:text-right">
-          &copy; 2024 Lineage.guide. Preserving the light of history.
+          &copy; 2024 Lineage.guide.
         </p>
       </div>
     </footer>

--- a/src/components/tradition-map/tradition-map.tsx
+++ b/src/components/tradition-map/tradition-map.tsx
@@ -222,7 +222,7 @@ export function TraditionMap({ traditions, resourceMap = {} }: TraditionMapProps
       <div className="flex flex-col lg:flex-row gap-6">
         {/* Map column */}
         <div className="flex-1 min-w-0">
-          <div className="bg-[#eee9e3] rounded-lg border border-[#e2dbd3]">
+          <div className="bg-[#e8e3dc] rounded-lg">
             <svg
               ref={svgRef}
               className="w-full h-auto"


### PR DESCRIPTION
## Summary
- **Map background**: `#eee9e3` → `#e8e3dc` (a touch darker), border removed entirely
- **Footer**: Removed "Preserving the light of history." — just `© 2024 Lineage.guide.` now

## Test plan
- [ ] /map — map should sit in a slightly darker warm gray with no border, clearly distinct from the cream page
- [ ] Footer should be a single line with no wrapping

🤖 Generated with [Claude Code](https://claude.com/claude-code)