### PR TITLE
fix: subtle drop shadow on map container

### DIFF
--- a/src/components/tradition-map/tradition-map.tsx
+++ b/src/components/tradition-map/tradition-map.tsx
@@ -222,7 +222,7 @@ export function TraditionMap({ traditions, resourceMap = {} }: TraditionMapProps
       <div className="flex flex-col lg:flex-row gap-6">
         {/* Map column */}
         <div className="flex-1 min-w-0">
-          <div className="bg-white rounded-lg">
+          <div className="bg-white rounded-lg shadow-sm">
             <svg
               ref={svgRef}
               className="w-full h-auto"


### PR DESCRIPTION
## Summary
Adds `shadow-sm` to the map container for a gentle lift off the cream page background.

## Test plan
- [ ] /map — map should have a faint, tasteful shadow

🤖 Generated with [Claude Code](https://claude.com/claude-code)