### PR TITLE
feat: add Formspree submission helper

### DIFF
--- a/src/lib/__tests__/feedback.test.ts
+++ b/src/lib/__tests__/feedback.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { submitFeedback, type FeedbackData } from "../feedback";
+
+const validData: FeedbackData = {
+  message: "Great site!",
+  name: "Test User",
+  email: "test@example.com",
+  pageUrl: "/traditions",
+};
+
+describe("submitFeedback", () => {
+  beforeEach(() => {
+    vi.restoreAllMocks();
+    vi.stubEnv("NEXT_PUBLIC_FORMSPREE_ID", "mbdpjqyb");
+  });
+
+  it("POSTs JSON to the Formspree endpoint and returns ok on success", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const result = await submitFeedback(validData);
+
+    expect(result).toEqual({ ok: true });
+    expect(mockFetch).toHaveBeenCalledWith(
+      "https://formspree.io/f/mbdpjqyb",
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json", Accept: "application/json" },
+        body: JSON.stringify(validData),
+      }
+    );
+  });
+
+  it("returns ok: false when the server responds with an error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: false }));
+
+    const result = await submitFeedback(validData);
+    expect(result).toEqual({ ok: false });
+  });
+
+  it("returns ok: false when fetch throws a network error", async () => {
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("Network error")));
+
+    const result = await submitFeedback(validData);
+    expect(result).toEqual({ ok: false });
+  });
+
+  it("returns ok: false when NEXT_PUBLIC_FORMSPREE_ID is not set", async () => {
+    vi.stubEnv("NEXT_PUBLIC_FORMSPREE_ID", "");
+
+    const result = await submitFeedback(validData);
+    expect(result).toEqual({ ok: false });
+  });
+
+  it("includes optional fields only when provided", async () => {
+    const mockFetch = vi.fn().mockResolvedValue({ ok: true });
+    vi.stubGlobal("fetch", mockFetch);
+
+    const minimalData: FeedbackData = { message: "Hi", pageUrl: "/" };
+    await submitFeedback(minimalData);
+
+    const body = JSON.parse(mockFetch.mock.calls[0][1].body);
+    expect(body).toEqual({ message: "Hi", pageUrl: "/" });
+    expect(body.name).toBeUndefined();
+    expect(body.email).toBeUndefined();
+  });
+});

--- a/src/lib/feedback.ts
+++ b/src/lib/feedback.ts
@@ -1,0 +1,27 @@
+export interface FeedbackData {
+  message: string;
+  name?: string;
+  email?: string;
+  pageUrl: string;
+}
+
+export async function submitFeedback(
+  data: FeedbackData
+): Promise<{ ok: boolean }> {
+  const formspreeId = process.env.NEXT_PUBLIC_FORMSPREE_ID;
+  if (!formspreeId) {
+    console.warn("NEXT_PUBLIC_FORMSPREE_ID is not set — feedback not submitted");
+    return { ok: false };
+  }
+
+  try {
+    const response = await fetch(`https://formspree.io/f/${formspreeId}`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json", Accept: "application/json" },
+      body: JSON.stringify(data),
+    });
+    return { ok: response.ok };
+  } catch {
+    return { ok: false };
+  }
+}


### PR DESCRIPTION
## Summary
- Creates `src/lib/feedback.ts` with `submitFeedback()` function that POSTs feedback data to Formspree
- Gracefully handles missing env var, server errors, and network failures (never throws)
- Includes 5 tests covering success, error, network failure, missing env var, and minimal payload

Closes #186

## Test plan
- [x] All 5 unit tests pass
- [x] Lint passes
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)