### PR TITLE
fix: improve mobile map UX — scrollable chips + zoom

### DIFF
--- a/src/components/tradition-map/family-filter.tsx
+++ b/src/components/tradition-map/family-filter.tsx
@@ -22,7 +22,7 @@ export function FamilyFilter({
 }: FamilyFilterProps) {
   return (
     <div
-      className="flex gap-2 justify-center overflow-x-auto pb-2 sm:flex-wrap sm:overflow-x-visible sm:pb-0 scrollbar-thin"
+      className="flex gap-2 justify-start px-4 overflow-x-auto pb-2 snap-x snap-mandatory sm:justify-center sm:px-0 sm:flex-wrap sm:overflow-x-visible sm:pb-0 sm:snap-none scrollbar-thin [-webkit-overflow-scrolling:touch] [mask-image:linear-gradient(to_right,transparent,black_16px,black_calc(100%-16px),transparent)] sm:[mask-image:none]"
       role="group"
       aria-label="Filter by tradition family"
     >
@@ -34,7 +34,7 @@ export function FamilyFilter({
             key={family}
             onClick={() => onToggle(family)}
             className={`
-              inline-flex items-center gap-1.5 px-3 py-1 shrink-0
+              inline-flex items-center gap-1.5 px-3 py-1 shrink-0 snap-start
               font-sans text-sm whitespace-nowrap
               border rounded-full transition-all duration-200
               ${

--- a/src/components/tradition-map/use-map-zoom.ts
+++ b/src/components/tradition-map/use-map-zoom.ts
@@ -26,7 +26,7 @@ export function useMapZoom(
   svgRef: React.RefObject<SVGSVGElement | null>,
   options: { minZoom?: number; maxZoom?: number } = {}
 ) {
-  const { minZoom = 1, maxZoom = 3 } = options;
+  const { minZoom = 0.8, maxZoom = 4 } = options;
   const [transform, setTransform] = useState<MapTransform>(INITIAL_TRANSFORM);
   const zoomBehaviorRef = useRef<ZoomBehavior<SVGSVGElement, unknown> | null>(null);
 
@@ -43,6 +43,13 @@ export function useMapZoom(
 
     zoomBehaviorRef.current = zoomBehavior;
     select(svg).call(zoomBehavior);
+
+    // On mobile, start zoomed in so labels are readable
+    const isMobile = typeof window !== "undefined"
+      && window.matchMedia?.("(max-width: 640px)").matches;
+    if (isMobile) {
+      select(svg).call(zoomBehavior.transform, zoomIdentity.scale(1.8));
+    }
 
     return () => {
       select(svg).on(".zoom", null);


### PR DESCRIPTION
## Summary
- Filter chips now scroll horizontally on mobile with snap points and fade-edge mask hints
- Map starts at 1.8x zoom on mobile so tradition labels are readable without pinch-zooming
- Zoom range expanded (0.8–4x) to give mobile users more room to explore

## Test plan
- [ ] On mobile: filter chips scroll left/right with momentum, fade edges visible
- [ ] On mobile: map loads zoomed in, text is readable
- [ ] On desktop: filter chips wrap as before, map loads at 1x zoom
- [ ] All 464 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)