### PR TITLE
feat: create TraditionConnectionBadge component

### DIFF
--- a/src/components/tradition-map/__tests__/tradition-connection-badge.test.tsx
+++ b/src/components/tradition-map/__tests__/tradition-connection-badge.test.tsx
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TraditionConnectionBadge } from "../tradition-connection-badge";
+
+describe("TraditionConnectionBadge", () => {
+  it("renders 'Branch of:' prefix for branch_of type", () => {
+    render(
+      <TraditionConnectionBadge
+        connectionType="branch_of"
+        targetName="Theravada"
+        targetSlug="theravada"
+        onClick={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/Branch of:/)).toBeInTheDocument();
+    expect(screen.getByText(/Theravada/)).toBeInTheDocument();
+  });
+
+  it("renders 'Influenced by:' prefix for influenced_by type", () => {
+    render(
+      <TraditionConnectionBadge
+        connectionType="influenced_by"
+        targetName="Zen"
+        targetSlug="zen"
+        onClick={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/Influenced by:/)).toBeInTheDocument();
+  });
+
+  it("renders 'Related to:' prefix for related_to type", () => {
+    render(
+      <TraditionConnectionBadge
+        connectionType="related_to"
+        targetName="Sufism"
+        targetSlug="sufism"
+        onClick={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/Related to:/)).toBeInTheDocument();
+  });
+
+  it("calls onClick with targetSlug when clicked", () => {
+    const onClick = vi.fn();
+    render(
+      <TraditionConnectionBadge
+        connectionType="branch_of"
+        targetName="Theravada"
+        targetSlug="theravada"
+        onClick={onClick}
+      />
+    );
+    fireEvent.click(screen.getByRole("button"));
+    expect(onClick).toHaveBeenCalledWith("theravada");
+  });
+
+  it("applies solid border for branch_of", () => {
+    const { container } = render(
+      <TraditionConnectionBadge
+        connectionType="branch_of"
+        targetName="Theravada"
+        targetSlug="theravada"
+        onClick={vi.fn()}
+      />
+    );
+    const button = container.querySelector("button");
+    expect(button?.style.borderStyle).toBe("solid");
+  });
+
+  it("applies dashed border for influenced_by", () => {
+    const { container } = render(
+      <TraditionConnectionBadge
+        connectionType="influenced_by"
+        targetName="Zen"
+        targetSlug="zen"
+        onClick={vi.fn()}
+      />
+    );
+    const button = container.querySelector("button");
+    expect(button?.style.borderStyle).toBe("dashed");
+  });
+
+  it("applies dotted border for related_to", () => {
+    const { container } = render(
+      <TraditionConnectionBadge
+        connectionType="related_to"
+        targetName="Sufism"
+        targetSlug="sufism"
+        onClick={vi.fn()}
+      />
+    );
+    const button = container.querySelector("button");
+    expect(button?.style.borderStyle).toBe("dotted");
+  });
+});

--- a/src/components/tradition-map/tradition-connection-badge.tsx
+++ b/src/components/tradition-map/tradition-connection-badge.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import type { ConnectionType } from "@/lib/types";
+
+const TYPE_LABELS: Record<ConnectionType, string> = {
+  branch_of: "Branch of:",
+  influenced_by: "Influenced by:",
+  related_to: "Related to:",
+  diverged_from: "Diverged from:",
+};
+
+const BORDER_STYLES: Record<ConnectionType, string> = {
+  branch_of: "solid",
+  influenced_by: "dashed",
+  related_to: "dotted",
+  diverged_from: "solid",
+};
+
+interface TraditionConnectionBadgeProps {
+  connectionType: ConnectionType;
+  targetName: string;
+  targetSlug: string;
+  onClick: (slug: string) => void;
+}
+
+/**
+ * Pill-shaped badge showing a tradition connection.
+ *
+ * Border style encodes the connection type visually:
+ * - solid → branch_of (direct lineage)
+ * - dashed → influenced_by (indirect influence)
+ * - dotted → related_to (thematic similarity)
+ *
+ * Min 44px touch target for mobile accessibility.
+ */
+export function TraditionConnectionBadge({
+  connectionType,
+  targetName,
+  targetSlug,
+  onClick,
+}: TraditionConnectionBadgeProps) {
+  return (
+    <button
+      onClick={() => onClick(targetSlug)}
+      className="inline-flex items-center gap-1 px-2.5 min-h-[44px] rounded-full text-xs font-sans border border-[#d5d0c8] bg-[#faf8f5] text-[#6b6459] hover:bg-[#f0ece6] hover:text-[#9e4a3a] transition-colors cursor-pointer"
+      style={{ borderStyle: BORDER_STYLES[connectionType] }}
+    >
+      <span className="text-[#999]">{TYPE_LABELS[connectionType]}</span>
+      <span>{targetName}</span>
+    </button>
+  );
+}


### PR DESCRIPTION
## Summary
- New `TraditionConnectionBadge` pill-shaped component for displaying tradition connections
- Border style varies by connection type: solid (branch_of), dashed (influenced_by), dotted (related_to)
- 44px min touch target, Lapham's editorial palette colors
- 7 tests covering rendering, click handling, and border styles

Closes #193

## Test plan
- [x] Tests pass for all connection types
- [x] Click handler fires with correct slug
- [x] Border styles verified per type

🤖 Generated with [Claude Code](https://claude.com/claude-code)