### PR TITLE
feat: create TraditionListMobile component

### DIFF
--- a/src/components/tradition-map/__tests__/tradition-list-mobile.test.tsx
+++ b/src/components/tradition-map/__tests__/tradition-list-mobile.test.tsx
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { TraditionListMobile } from "../tradition-list-mobile";
+import type { TraditionGraph } from "@/lib/tradition-graph";
+import type { TraditionFamily } from "@/lib/types";
+
+const testGraph: TraditionGraph = {
+  nodes: [
+    { slug: "zen", name: "Zen", family: "Buddhist", summary: "A school of Mahayana Buddhism", originCentury: 6 },
+    { slug: "theravada", name: "Theravada", family: "Buddhist", summary: "The Way of the Elders", originCentury: -3 },
+    { slug: "advaita-vedanta", name: "Advaita Vedanta", family: "Vedic-Yogic", summary: "Non-dual philosophy", originCentury: 8 },
+  ],
+  edges: [
+    { source: "zen", target: "theravada", connectionType: "related_to", description: "Both emphasize meditation", strength: 1 },
+  ],
+};
+
+describe("TraditionListMobile", () => {
+  it("renders family sections for active families", () => {
+    const activeFamilies = new Set<TraditionFamily>(["Buddhist", "Vedic-Yogic"]);
+    render(
+      <TraditionListMobile graph={testGraph} activeFamilies={activeFamilies} onNodeClick={vi.fn()} />
+    );
+    expect(screen.getByText(/Buddhist/)).toBeInTheDocument();
+    expect(screen.getByText(/Vedic-Yogic/)).toBeInTheDocument();
+  });
+
+  it("hides inactive families", () => {
+    const activeFamilies = new Set<TraditionFamily>(["Buddhist"]);
+    render(
+      <TraditionListMobile graph={testGraph} activeFamilies={activeFamilies} onNodeClick={vi.fn()} />
+    );
+    expect(screen.getByText(/Buddhist/)).toBeInTheDocument();
+    expect(screen.queryByText(/Vedic-Yogic/)).not.toBeInTheDocument();
+  });
+
+  it("renders tradition names and summaries", () => {
+    const activeFamilies = new Set<TraditionFamily>(["Buddhist"]);
+    render(
+      <TraditionListMobile graph={testGraph} activeFamilies={activeFamilies} onNodeClick={vi.fn()} />
+    );
+    expect(screen.getAllByText("Zen").length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText("A school of Mahayana Buddhism")).toBeInTheDocument();
+    expect(screen.getAllByText("Theravada").length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("renders connection badges", () => {
+    const activeFamilies = new Set<TraditionFamily>(["Buddhist"]);
+    render(
+      <TraditionListMobile graph={testGraph} activeFamilies={activeFamilies} onNodeClick={vi.fn()} />
+    );
+    // Zen has a related_to connection to Theravada
+    expect(screen.getAllByText(/Related to:/).length).toBeGreaterThanOrEqual(1);
+  });
+
+  it("calls onNodeClick when tradition name tapped", () => {
+    const onNodeClick = vi.fn();
+    const activeFamilies = new Set<TraditionFamily>(["Buddhist"]);
+    render(
+      <TraditionListMobile graph={testGraph} activeFamilies={activeFamilies} onNodeClick={onNodeClick} />
+    );
+    // Get the tradition name button (not the badge button which has border-style)
+    const zenButtons = screen.getAllByText("Zen").filter((el) => el.tagName === "BUTTON");
+    // The tradition name button doesn't have inline border-style
+    const nameButton = zenButtons.find((el) => !el.style.borderStyle);
+    fireEvent.click(nameButton!);
+    expect(onNodeClick).toHaveBeenCalledWith("zen");
+  });
+
+  it("shows empty state when no families active", () => {
+    const activeFamilies = new Set<TraditionFamily>();
+    render(
+      <TraditionListMobile graph={testGraph} activeFamilies={activeFamilies} onNodeClick={vi.fn()} />
+    );
+    expect(screen.getByText(/Select a family above to explore traditions/)).toBeInTheDocument();
+  });
+});

--- a/src/components/tradition-map/tradition-list-mobile.tsx
+++ b/src/components/tradition-map/tradition-list-mobile.tsx
@@ -1,0 +1,172 @@
+"use client";
+
+import { useMemo, useCallback } from "react";
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from "@/components/ui/accordion";
+import { FAMILY_COLORS, type TraditionGraph } from "@/lib/tradition-graph";
+import type { TraditionFamily } from "@/lib/types";
+import { TraditionConnectionBadge } from "./tradition-connection-badge";
+
+interface TraditionListMobileProps {
+  graph: TraditionGraph;
+  activeFamilies: Set<TraditionFamily>;
+  onNodeClick: (slug: string) => void;
+}
+
+/**
+ * Family-grouped accordion list for mobile view of the tradition map.
+ *
+ * Groups traditions by family, shows connection badges, and supports
+ * scroll-to-target when a badge is tapped. Replaces the SVG map on
+ * small screens for better usability.
+ *
+ * Architecture note: This component consumes the same TraditionGraph
+ * as the desktop SVG map, demonstrating how a shared data model can
+ * drive multiple view representations — a common pattern in design
+ * systems where the same data feeds different device-optimized UIs.
+ */
+export function TraditionListMobile({
+  graph,
+  activeFamilies,
+  onNodeClick,
+}: TraditionListMobileProps) {
+  // Group nodes by family, filtered to active families
+  const familyGroups = useMemo(() => {
+    const groups = new Map<TraditionFamily, typeof graph.nodes>();
+    for (const node of graph.nodes) {
+      if (!activeFamilies.has(node.family)) continue;
+      const existing = groups.get(node.family) ?? [];
+      existing.push(node);
+      groups.set(node.family, existing);
+    }
+    return groups;
+  }, [graph, activeFamilies]);
+
+  // Build a quick lookup: slug → connections from that node
+  const connectionsBySlug = useMemo(() => {
+    const map = new Map<string, { connectionType: string; targetSlug: string; targetName: string }[]>();
+    const nameMap = new Map(graph.nodes.map((n) => [n.slug, n.name]));
+
+    for (const edge of graph.edges) {
+      // Add connection in both directions
+      const addConnection = (from: string, to: string) => {
+        const existing = map.get(from) ?? [];
+        const targetName = nameMap.get(to);
+        if (targetName) {
+          existing.push({
+            connectionType: edge.connectionType,
+            targetSlug: to,
+            targetName,
+          });
+          map.set(from, existing);
+        }
+      };
+      addConnection(edge.source, edge.target);
+      addConnection(edge.target, edge.source);
+    }
+    return map;
+  }, [graph]);
+
+  const handleBadgeClick = useCallback(
+    (slug: string) => {
+      const el = document.getElementById(`tradition-${slug}`);
+      if (el) {
+        el.scrollIntoView({ behavior: "smooth", block: "center" });
+        el.classList.add("tradition-highlight");
+        setTimeout(() => el.classList.remove("tradition-highlight"), 1500);
+      }
+    },
+    []
+  );
+
+  if (familyGroups.size === 0) {
+    return (
+      <div className="text-center py-12">
+        <p className="text-sm text-[#999] font-sans">
+          Select a family above to explore traditions
+        </p>
+      </div>
+    );
+  }
+
+  const familyEntries = Array.from(familyGroups.entries());
+
+  return (
+    <div>
+      {/* Highlight animation for scroll-to-target */}
+      <style>{`
+        @keyframes tradition-flash {
+          0% { background-color: rgba(180, 140, 100, 0.15); }
+          100% { background-color: transparent; }
+        }
+        .tradition-highlight {
+          animation: tradition-flash 1.5s ease-out;
+        }
+      `}</style>
+
+      <Accordion defaultValue={familyEntries.map(([f]) => f)}>
+        {familyEntries.map(([family, nodes]) => {
+          const colors = FAMILY_COLORS[family];
+          return (
+            <AccordionItem key={family} value={family}>
+              <AccordionTrigger className="px-2">
+                <span className="flex items-center gap-2 font-serif text-base">
+                  <span
+                    className="inline-block w-2.5 h-2.5 rounded-full"
+                    style={{ backgroundColor: colors.fill }}
+                  />
+                  {family}
+                  <span className="text-sm font-sans text-[#999] font-normal">
+                    ({nodes.length})
+                  </span>
+                </span>
+              </AccordionTrigger>
+              <AccordionContent>
+                <div className="space-y-3 px-2">
+                  {nodes.map((node) => {
+                    const connections = connectionsBySlug.get(node.slug) ?? [];
+                    return (
+                      <div
+                        key={node.slug}
+                        id={`tradition-${node.slug}`}
+                        className="rounded-lg border border-[#e8e4df] bg-white p-3 transition-colors"
+                      >
+                        <button
+                          onClick={() => onNodeClick(node.slug)}
+                          className="text-left font-serif text-[15px] font-medium hover:text-[#9e4a3a] transition-colors cursor-pointer"
+                          style={{ color: "#1a1a1a" }}
+                        >
+                          {node.name}
+                        </button>
+                        <p className="text-xs text-[#777] mt-1 leading-relaxed">
+                          {node.summary}
+                        </p>
+                        {connections.length > 0 && (
+                          <div className="flex flex-wrap gap-1.5 mt-2">
+                            {connections.map((conn) => (
+                              <TraditionConnectionBadge
+                                key={conn.targetSlug}
+                                connectionType={conn.connectionType as "branch_of" | "influenced_by" | "related_to"}
+                                targetName={conn.targetName}
+                                targetSlug={conn.targetSlug}
+                                onClick={handleBadgeClick}
+                              />
+                            ))}
+                          </div>
+                        )}
+                      </div>
+                    );
+                  })}
+                </div>
+              </AccordionContent>
+            </AccordionItem>
+          );
+        })}
+      </Accordion>
+    </div>
+  );
+}

--- a/src/components/ui/accordion.tsx
+++ b/src/components/ui/accordion.tsx
@@ -1,0 +1,74 @@
+"use client"
+
+import { Accordion as AccordionPrimitive } from "@base-ui/react/accordion"
+
+import { cn } from "@/lib/utils"
+import { ChevronDownIcon, ChevronUpIcon } from "lucide-react"
+
+function Accordion({ className, ...props }: AccordionPrimitive.Root.Props) {
+  return (
+    <AccordionPrimitive.Root
+      data-slot="accordion"
+      className={cn("flex w-full flex-col", className)}
+      {...props}
+    />
+  )
+}
+
+function AccordionItem({ className, ...props }: AccordionPrimitive.Item.Props) {
+  return (
+    <AccordionPrimitive.Item
+      data-slot="accordion-item"
+      className={cn("not-last:border-b", className)}
+      {...props}
+    />
+  )
+}
+
+function AccordionTrigger({
+  className,
+  children,
+  ...props
+}: AccordionPrimitive.Trigger.Props) {
+  return (
+    <AccordionPrimitive.Header className="flex">
+      <AccordionPrimitive.Trigger
+        data-slot="accordion-trigger"
+        className={cn(
+          "group/accordion-trigger relative flex flex-1 items-start justify-between rounded-lg border border-transparent py-2.5 text-left text-sm font-medium transition-all outline-none hover:underline focus-visible:border-ring focus-visible:ring-3 focus-visible:ring-ring/50 focus-visible:after:border-ring aria-disabled:pointer-events-none aria-disabled:opacity-50 **:data-[slot=accordion-trigger-icon]:ml-auto **:data-[slot=accordion-trigger-icon]:size-4 **:data-[slot=accordion-trigger-icon]:text-muted-foreground",
+          className
+        )}
+        {...props}
+      >
+        {children}
+        <ChevronDownIcon data-slot="accordion-trigger-icon" className="pointer-events-none shrink-0 group-aria-expanded/accordion-trigger:hidden" />
+        <ChevronUpIcon data-slot="accordion-trigger-icon" className="pointer-events-none hidden shrink-0 group-aria-expanded/accordion-trigger:inline" />
+      </AccordionPrimitive.Trigger>
+    </AccordionPrimitive.Header>
+  )
+}
+
+function AccordionContent({
+  className,
+  children,
+  ...props
+}: AccordionPrimitive.Panel.Props) {
+  return (
+    <AccordionPrimitive.Panel
+      data-slot="accordion-content"
+      className="overflow-hidden text-sm data-open:animate-accordion-down data-closed:animate-accordion-up"
+      {...props}
+    >
+      <div
+        className={cn(
+          "h-(--accordion-panel-height) pt-0 pb-2.5 data-ending-style:h-0 data-starting-style:h-0 [&_a]:underline [&_a]:underline-offset-3 [&_a]:hover:text-foreground [&_p:not(:last-child)]:mb-4",
+          className
+        )}
+      >
+        {children}
+      </div>
+    </AccordionPrimitive.Panel>
+  )
+}
+
+export { Accordion, AccordionItem, AccordionTrigger, AccordionContent }


### PR DESCRIPTION
## Summary
- New `TraditionListMobile` component: family-grouped accordion list for mobile
- Installs shadcn/ui Accordion (base-ui backed)
- Shows traditions grouped by family with colored dots, counts, summaries
- Connection badges with scroll-to-target and highlight animation
- Empty state when no families selected
- 6 tests covering rendering, filtering, clicks, and empty state

Closes #194

## Test plan
- [x] Family sections render for active families
- [x] Inactive families hidden
- [x] Tradition names, summaries, and badges render
- [x] onNodeClick fires correctly
- [x] Empty state displays when no families active

🤖 Generated with [Claude Code](https://claude.com/claude-code)