### PR TITLE
fix: handle empty location and transparent hover

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -108,7 +108,7 @@ export default function Home() {
             <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
               {sections.map((section) => (
                 <Link key={section.href} href={section.href} className="group">
-                  <div className="h-full rounded-lg bg-card p-6 border border-border/50 shadow-lg transition-colors group-hover:bg-accent/50 text-center">
+                  <div className="h-full rounded-lg bg-card p-6 border border-border/50 shadow-lg transition-colors group-hover:bg-accent text-center">
                     <div className="text-muted-foreground mb-4 flex justify-center">{section.icon}</div>
                     <h3 className="font-serif text-lg font-medium mb-2 group-hover:text-primary transition-colors">
                       {section.title}

--- a/src/app/teachers/[slug]/page.tsx
+++ b/src/app/teachers/[slug]/page.tsx
@@ -25,9 +25,11 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
   const { slug } = await params;
   const teacher = getTeacher(slug);
   if (!teacher) return {};
+  const location = [teacher.city, teacher.state].filter(Boolean).join(", ");
+  const locationSuffix = location ? ` in ${location}` : "";
   const description = teacher.traditions.length > 0
-    ? `${teacher.name} — ${teacher.traditions.join(", ")} teacher in ${teacher.city}, ${teacher.state}.`
-    : `${teacher.name} — contemplative teacher in ${teacher.city}, ${teacher.state}.`;
+    ? `${teacher.name} — ${teacher.traditions.join(", ")} teacher${locationSuffix}.`
+    : `${teacher.name} — contemplative teacher${locationSuffix}.`;
   return {
     title: teacher.name,
     description,
@@ -86,10 +88,12 @@ export default async function TeacherPage({ params }: { params: Promise<{ slug: 
               </span>
             )}
           </h1>
-          <p className="font-sans text-sm text-muted-foreground mb-4">
-            {teacher.city}, {teacher.state}
-            {teacher.country !== "US" && ` · ${teacher.country}`}
-          </p>
+          {(teacher.city || teacher.state) && (
+            <p className="font-sans text-sm text-muted-foreground mb-4">
+              {[teacher.city, teacher.state].filter(Boolean).join(", ")}
+              {teacher.country && teacher.country !== "US" && ` · ${teacher.country}`}
+            </p>
+          )}
           <div className="flex flex-wrap gap-2 mb-6">
             {traditions.map((t) => (
               <Link key={t.slug} href={`/traditions/${t.slug}`}>


### PR DESCRIPTION
## Summary
- **Teacher detail page**: No longer renders hanging `, ` when city/state are empty (e.g. Mirabai Starr)
- **Home feature cards**: Hover state uses solid `bg-accent` instead of transparent `bg-accent/50` which looked washed out over the hero image

## Test plan
- [ ] Visit `/teachers/mirabai-starr` — no hanging comma below the name
- [ ] Hover over feature cards on homepage — solid background, no transparency

🤖 Generated with [Claude Code](https://claude.com/claude-code)