### PR TITLE
chore: remove mobile zoom hack and stale GitHub links

### DIFF
--- a/src/components/tradition-map/tradition-map.tsx
+++ b/src/components/tradition-map/tradition-map.tsx
@@ -328,15 +328,9 @@ export function TraditionMap({ traditions, resourceMap = {} }: TraditionMapProps
                     <p className="text-sm text-[#999] mb-2">
                       No sources yet for {selectedTraditionName}.
                     </p>
-                    <a
-                      href="https://github.com/meninoebom/lineage/issues"
-                      target="_blank"
-                      rel="noopener noreferrer"
-                      className="text-sm hover:underline"
-                      style={{ color: "#c0553a" }}
-                    >
-                      Help us add some
-                    </a>
+                    <p className="text-sm" style={{ color: "#c0553a" }}>
+                      Use the feedback button to suggest sources
+                    </p>
                   </div>
                 )}
                 {filteredResources.map((r) => (
@@ -381,20 +375,10 @@ export function TraditionMap({ traditions, resourceMap = {} }: TraditionMapProps
                 ))}
               </div>
               <div className="text-center pt-4 mt-4 border-t border-[#e8e4df]">
-                <p className="text-sm text-[#999] mb-2">
-                  This map is a living document. We&apos;re building it in the open
-                  and inviting anyone to contribute sources, corrections, or new
-                  connections.
+                <p className="text-sm text-[#999]">
+                  This map is a living document. Use the feedback button to
+                  suggest sources, corrections, or new connections.
                 </p>
-                <a
-                  href="https://github.com/meninoebom/lineage/issues"
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-sm hover:underline"
-                  style={{ color: "#c0553a" }}
-                >
-                  Suggest an Edit
-                </a>
               </div>
             </div>
           </aside>

--- a/src/components/tradition-map/use-map-zoom.ts
+++ b/src/components/tradition-map/use-map-zoom.ts
@@ -26,7 +26,7 @@ export function useMapZoom(
   svgRef: React.RefObject<SVGSVGElement | null>,
   options: { minZoom?: number; maxZoom?: number } = {}
 ) {
-  const { minZoom = 0.8, maxZoom = 4 } = options;
+  const { minZoom = 1, maxZoom = 4 } = options;
   const [transform, setTransform] = useState<MapTransform>(INITIAL_TRANSFORM);
   const zoomBehaviorRef = useRef<ZoomBehavior<SVGSVGElement, unknown> | null>(null);
 
@@ -43,13 +43,6 @@ export function useMapZoom(
 
     zoomBehaviorRef.current = zoomBehavior;
     select(svg).call(zoomBehavior);
-
-    // On mobile, start zoomed in so labels are readable
-    const isMobile = typeof window !== "undefined"
-      && window.matchMedia?.("(max-width: 640px)").matches;
-    if (isMobile) {
-      select(svg).call(zoomBehavior.transform, zoomIdentity.scale(1.8));
-    }
 
     return () => {
       select(svg).on(".zoom", null);


### PR DESCRIPTION
## Summary
- Removed mobile zoom hack (matchMedia + zoomIdentity.scale(1.8)) from use-map-zoom.ts — no longer needed since mobile uses accordion list
- Restored minZoom default from 0.8 to 1
- Replaced two GitHub Issues links in sources sidebar with feedback widget references

Closes #196

## Test plan
- [x] All 478 existing tests pass
- [x] No lint errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)