### PR TITLE
fix: show real map on mobile with smart zoom + pan

### DIFF
--- a/src/components/tradition-map/__tests__/tradition-map.test.tsx
+++ b/src/components/tradition-map/__tests__/tradition-map.test.tsx
@@ -135,14 +135,10 @@ describe("TraditionMap", () => {
     expect(map).toBeInTheDocument();
   });
 
-  it("renders both desktop SVG map and mobile accordion list", () => {
+  it("renders SVG map on all screen sizes", () => {
     const { container } = render(<TraditionMap traditions={sampleTraditions} />);
-    // Desktop SVG map (hidden on mobile via CSS)
     const svgMap = container.querySelector("[role='img'][aria-label='Interactive map of contemplative traditions']");
     expect(svgMap).toBeInTheDocument();
-    // Mobile accordion list (hidden on desktop via CSS)
-    const mobileList = container.querySelector(".lg\\:hidden");
-    expect(mobileList).toBeInTheDocument();
   });
 
   it("renders nodes as keyboard-accessible links", () => {

--- a/src/components/tradition-map/tradition-map.tsx
+++ b/src/components/tradition-map/tradition-map.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { useRef, useMemo, useState, useCallback, useEffect } from "react";
-import { useRouter } from "next/navigation";
 import {
   buildTraditionGraph,
   getFamilies,
@@ -14,7 +13,6 @@ import { FamilyFilter } from "./family-filter";
 import { MapCanvas } from "./map-canvas";
 import { useMapZoom } from "./use-map-zoom";
 import { useMapInteraction } from "./use-map-interaction";
-import { TraditionListMobile } from "./tradition-list-mobile";
 
 // Import pre-computed layout (generated at build time by `npm run prebuild`)
 import layoutData from "@/generated/map-layout.json";
@@ -49,7 +47,6 @@ function computeViewBox(layout: LayoutMap) {
 }
 
 export function TraditionMap({ traditions, resourceMap = {} }: TraditionMapProps) {
-  const router = useRouter();
   const svgRef = useRef<SVGSVGElement>(null);
   const layout = layoutData as LayoutMap;
   const [isTouchDevice, setIsTouchDevice] = useState(false);
@@ -127,14 +124,6 @@ export function TraditionMap({ traditions, resourceMap = {} }: TraditionMapProps
     [isTouchDevice, selectedSlug, handleNodeClick, handleNodeSelect]
   );
 
-  // Mobile list: tap tradition → navigate to its page
-  const handleMobileNodeClick = useCallback(
-    (slug: string) => {
-      router.push(`/traditions/${slug}`);
-    },
-    [router]
-  );
-
   // Background click deselects on all devices
   const handleSvgClick = useCallback(
     (e: React.MouseEvent<SVGSVGElement>) => {
@@ -202,6 +191,13 @@ export function TraditionMap({ traditions, resourceMap = {} }: TraditionMapProps
         .map-edge-entrance {
           animation: map-edge-draw-in 0.3s ease-out both;
         }
+        @keyframes fade-out-delayed {
+          0%, 70% { opacity: 1; }
+          100% { opacity: 0; }
+        }
+        .animate-fade-out-delayed {
+          animation: fade-out-delayed 4s ease-out forwards;
+        }
       `}</style>
 
       {/* Filters */}
@@ -213,8 +209,8 @@ export function TraditionMap({ traditions, resourceMap = {} }: TraditionMapProps
         />
       </div>
 
-      {/* Legend — desktop only, between filters and map */}
-      <div className="mb-6 hidden lg:flex items-center justify-center gap-6 text-sm text-[#888] font-sans">
+      {/* Legend */}
+      <div className="mb-6 flex items-center justify-center gap-6 text-sm text-[#888] font-sans">
         <span className="flex items-center gap-2">
           <svg width="40" height="2">
             <line x1="0" y1="1" x2="40" y2="1" stroke="#b48c64" strokeWidth="2" />
@@ -231,15 +227,14 @@ export function TraditionMap({ traditions, resourceMap = {} }: TraditionMapProps
 
       {/* Two-column layout: map + sources sidebar */}
       <div className="flex flex-col lg:flex-row gap-6">
-        {/* Map column — desktop: SVG map, mobile: accordion list */}
+        {/* Map column */}
         <div className="flex-1 min-w-0">
-          {/* Desktop SVG map */}
-          <div className="hidden lg:block bg-white rounded-lg shadow-sm">
+          <div className="relative bg-white rounded-lg shadow-sm">
             <svg
               ref={svgRef}
               className="w-full h-auto"
               viewBox={`${viewBox.x} ${viewBox.y} ${viewBox.width} ${viewBox.height}`}
-              style={{ maxHeight: "70vh", touchAction: "none" }}
+              style={{ maxHeight: "80vh", minHeight: "60vh", touchAction: "none" }}
               aria-label="Interactive map of contemplative traditions"
               role="img"
               onClick={handleSvgClick}
@@ -269,15 +264,16 @@ export function TraditionMap({ traditions, resourceMap = {} }: TraditionMapProps
                 />
               </g>
             </svg>
-          </div>
-
-          {/* Mobile accordion list */}
-          <div className="lg:hidden">
-            <TraditionListMobile
-              graph={graph}
-              activeFamilies={activeFamilies}
-              onNodeClick={handleMobileNodeClick}
-            />
+            {/* Mobile hint — fades out after first interaction */}
+            {isTouchDevice && (
+              <div
+                className="absolute bottom-3 left-1/2 -translate-x-1/2 pointer-events-none
+                  bg-black/60 text-white text-xs px-3 py-1.5 rounded-full font-sans
+                  animate-fade-out-delayed"
+              >
+                Pinch to zoom &middot; Drag to explore
+              </div>
+            )}
           </div>
         </div>
 

--- a/src/components/tradition-map/use-map-zoom.ts
+++ b/src/components/tradition-map/use-map-zoom.ts
@@ -26,7 +26,7 @@ export function useMapZoom(
   svgRef: React.RefObject<SVGSVGElement | null>,
   options: { minZoom?: number; maxZoom?: number } = {}
 ) {
-  const { minZoom = 1, maxZoom = 4 } = options;
+  const { minZoom = 0.5, maxZoom = 5 } = options;
   const [transform, setTransform] = useState<MapTransform>(INITIAL_TRANSFORM);
   const zoomBehaviorRef = useRef<ZoomBehavior<SVGSVGElement, unknown> | null>(null);
 
@@ -43,6 +43,21 @@ export function useMapZoom(
 
     zoomBehaviorRef.current = zoomBehavior;
     select(svg).call(zoomBehavior);
+
+    // On mobile, start zoomed into the center of the map so labels are readable.
+    // Center point is roughly where Buddhist/Vedic traditions cluster (~500 CE).
+    const isMobile = typeof window !== "undefined"
+      && window.matchMedia?.("(max-width: 768px)").matches;
+    if (isMobile) {
+      const rect = svg.getBoundingClientRect();
+      const scale = 2.2;
+      // Center on the middle of the map (x~450, y~500 in SVG coords)
+      // Transform formula: translate = screenCenter - svgCenter * scale
+      const tx = rect.width / 2 - 450 * scale;
+      const ty = rect.height / 2 - 500 * scale;
+      const initialTransform = zoomIdentity.translate(tx, ty).scale(scale);
+      select(svg).call(zoomBehavior.transform, initialTransform);
+    }
 
     return () => {
       select(svg).on(".zoom", null);


### PR DESCRIPTION
## Summary
- Reverts the list-view-on-mobile approach — shows the actual SVG map on all screen sizes
- On mobile, starts zoomed in at 2.2x centered on the Buddhist/Vedic cluster so labels are readable
- Adds a "Pinch to zoom · Drag to explore" hint overlay that fades after 4 seconds (touch devices only)
- Zoom range expanded to 0.5x–5x so users can zoom out to see the full picture or zoom in on details
- Legend now visible on mobile too
- Map min-height set to 60vh so it has presence on mobile

## Test plan
- [ ] On mobile: map loads zoomed into the center, labels are readable
- [ ] On mobile: "Pinch to zoom" hint appears and fades after ~4s
- [ ] On mobile: pinch-to-zoom and drag-to-pan work smoothly
- [ ] On desktop: map loads at 1x zoom as before (no change)
- [ ] All 478 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)