### PR TITLE
fix: normalize hyphens in search matching

### DIFF
--- a/src/components/home-search.tsx
+++ b/src/components/home-search.tsx
@@ -104,13 +104,15 @@ export function HomeSearch({
   }, [teachers, centers, resources, traditionNames]);
 
   const results = useMemo(() => {
-    const q = query.toLowerCase().trim();
+    const normalize = (s: string) =>
+      s.toLowerCase().replace(/-/g, " ").replace(/\s+/g, " ").trim();
+    const q = normalize(query);
     if (!q || q.length < 2) return [];
     return items
       .filter(
         (item) =>
-          item.name.toLowerCase().includes(q) ||
-          item.detail.toLowerCase().includes(q),
+          normalize(item.name).includes(q) ||
+          normalize(item.detail).includes(q),
       )
       .slice(0, 8);
   }, [query, items]);

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -13,9 +13,13 @@ export type SearchResult =
 /**
  * Case-insensitive substring match on name.
  */
+function normalize(s: string): string {
+  return s.toLowerCase().replace(/-/g, " ").replace(/\s+/g, " ").trim();
+}
+
 function matchesQuery(name: string, query: string): boolean {
   if (!query.trim()) return true;
-  return name.toLowerCase().includes(query.toLowerCase().trim());
+  return normalize(name).includes(normalize(query));
 }
 
 /**


### PR DESCRIPTION
## Summary
- Add `normalize()` function that replaces hyphens with spaces and collapses whitespace before search comparison
- Applied to both homepage search (`home-search.tsx`) and dedicated search page (`search.ts`)
- "non dual" now matches "non-dual" and vice versa

Closes #213

## Test plan
- [x] All 479 existing tests pass
- [ ] Search "non dual" on homepage — should show "non-dual" results
- [ ] Search "non-dual" on `/search` page — should match teachers/centers with "non dual" in name

🤖 Generated with [Claude Code](https://claude.com/claude-code)