### PR TITLE
Add taxonomy tagging: exemplars, script, and badges

### DIFF
--- a/data/resources/a-path-with-heart.json
+++ b/data/resources/a-path-with-heart.json
@@ -14,5 +14,8 @@
   "teachers": [
     "jack-kornfield"
   ],
-  "centers": []
+  "centers": [],
+  "experience_level": "beginner",
+  "topics": ["meditation-technique", "daily-life"],
+  "practice_context": ["new-to-practice"]
 }

--- a/data/resources/access-to-insight.json
+++ b/data/resources/access-to-insight.json
@@ -11,5 +11,8 @@
     "theravada"
   ],
   "teachers": [],
-  "centers": []
+  "centers": [],
+  "experience_level": "beginner",
+  "topics": ["meditation-technique", "philosophy", "ethics"],
+  "practice_context": ["new-to-practice", "deepening"]
 }

--- a/data/resources/almaas-the-unfolding-now.json
+++ b/data/resources/almaas-the-unfolding-now.json
@@ -15,5 +15,8 @@
   "teachers": [
     "ah-almaas"
   ],
-  "centers": []
+  "centers": [],
+  "experience_level": "intermediate",
+  "topics": ["meditation-technique", "nature-of-mind"],
+  "practice_context": ["deepening", "cross-tradition"]
 }

--- a/data/resources/awakening-buddha-within.json
+++ b/data/resources/awakening-buddha-within.json
@@ -16,5 +16,8 @@
   ],
   "centers": [
     "dzogchen-center"
-  ]
+  ],
+  "experience_level": "beginner",
+  "topics": ["meditation-technique", "philosophy", "daily-life"],
+  "practice_context": ["new-to-practice"]
 }

--- a/data/resources/batchelor-after-buddhism.json
+++ b/data/resources/batchelor-after-buddhism.json
@@ -14,5 +14,8 @@
   "teachers": [
     "stephen-batchelor"
   ],
-  "centers": []
+  "centers": [],
+  "experience_level": "intermediate",
+  "topics": ["philosophy", "ethics"],
+  "practice_context": ["academic", "secular", "cross-tradition"]
 }

--- a/data/resources/be-here-now.json
+++ b/data/resources/be-here-now.json
@@ -15,5 +15,8 @@
   "teachers": [
     "ram-dass"
   ],
-  "centers": []
+  "centers": [],
+  "experience_level": "beginner",
+  "topics": ["devotion", "daily-life", "philosophy"],
+  "practice_context": ["new-to-practice", "cross-tradition"]
 }

--- a/data/resources/bhagavad-gita.json
+++ b/data/resources/bhagavad-gita.json
@@ -13,5 +13,8 @@
     "classical-yoga"
   ],
   "teachers": [],
-  "centers": []
+  "centers": [],
+  "experience_level": "intermediate",
+  "topics": ["philosophy", "devotion", "ethics", "daily-life"],
+  "practice_context": ["deepening", "cross-tradition"]
 }

--- a/data/resources/cloud-of-unknowing.json
+++ b/data/resources/cloud-of-unknowing.json
@@ -11,5 +11,8 @@
     "christian-mysticism"
   ],
   "teachers": [],
-  "centers": []
+  "centers": [],
+  "experience_level": "intermediate",
+  "topics": ["meditation-technique", "nature-of-mind"],
+  "practice_context": ["deepening"]
 }

--- a/data/resources/dark-night-of-the-soul.json
+++ b/data/resources/dark-night-of-the-soul.json
@@ -11,5 +11,8 @@
   "teachers": [],
   "centers": [],
   "category": "primary_text",
-  "slug": "dark-night-of-the-soul"
+  "slug": "dark-night-of-the-soul",
+  "experience_level": "advanced",
+  "topics": ["nature-of-mind", "meditation-technique"],
+  "practice_context": ["deepening", "life-transition"]
 }

--- a/data/resources/kabbalah-very-short-introduction.json
+++ b/data/resources/kabbalah-very-short-introduction.json
@@ -11,5 +11,8 @@
     "kabbalah"
   ],
   "teachers": [],
-  "centers": []
+  "centers": [],
+  "experience_level": "beginner",
+  "topics": ["philosophy"],
+  "practice_context": ["new-to-practice", "academic"]
 }

--- a/data/resources/know-yourself-balyani.json
+++ b/data/resources/know-yourself-balyani.json
@@ -14,5 +14,8 @@
   "teachers": [
     "rupert-spira"
   ],
-  "centers": []
+  "centers": [],
+  "experience_level": "advanced",
+  "topics": ["nature-of-mind", "philosophy"],
+  "practice_context": ["deepening", "cross-tradition"]
 }

--- a/data/resources/rumi-the-rumi-collection.json
+++ b/data/resources/rumi-the-rumi-collection.json
@@ -13,5 +13,8 @@
   "teachers": [
     "rumi"
   ],
-  "centers": []
+  "centers": [],
+  "experience_level": "beginner",
+  "topics": ["devotion", "nature-of-mind", "daily-life"],
+  "practice_context": ["new-to-practice", "cross-tradition"]
 }

--- a/data/resources/sacred-texts-taoism.json
+++ b/data/resources/sacred-texts-taoism.json
@@ -11,5 +11,8 @@
   "teachers": [],
   "centers": [],
   "category": "web_resource",
-  "slug": "sacred-texts-taoism"
+  "slug": "sacred-texts-taoism",
+  "experience_level": "intermediate",
+  "topics": ["philosophy"],
+  "practice_context": ["deepening", "academic"]
 }

--- a/data/resources/taoism-stanford-encyclopedia-of-philosophy.json
+++ b/data/resources/taoism-stanford-encyclopedia-of-philosophy.json
@@ -11,5 +11,8 @@
   "teachers": [],
   "centers": [],
   "category": "encyclopedia",
-  "slug": "taoism-stanford-encyclopedia-of-philosophy"
+  "slug": "taoism-stanford-encyclopedia-of-philosophy",
+  "experience_level": "intermediate",
+  "topics": ["philosophy"],
+  "practice_context": ["academic"]
 }

--- a/data/resources/the-essential-kabbalah.json
+++ b/data/resources/the-essential-kabbalah.json
@@ -11,5 +11,8 @@
     "kabbalah"
   ],
   "teachers": [],
-  "centers": []
+  "centers": [],
+  "experience_level": "beginner",
+  "topics": ["philosophy", "nature-of-mind"],
+  "practice_context": ["new-to-practice", "academic"]
 }

--- a/data/resources/the-tao-of-pooh.json
+++ b/data/resources/the-tao-of-pooh.json
@@ -11,5 +11,8 @@
     "taoism"
   ],
   "teachers": [],
-  "centers": []
+  "centers": [],
+  "experience_level": "beginner",
+  "topics": ["philosophy", "daily-life"],
+  "practice_context": ["new-to-practice", "secular"]
 }

--- a/data/resources/the-way-of-a-pilgrim.json
+++ b/data/resources/the-way-of-a-pilgrim.json
@@ -12,5 +12,8 @@
     "christian-mysticism"
   ],
   "teachers": [],
-  "centers": []
+  "centers": [],
+  "experience_level": "beginner",
+  "topics": ["meditation-technique", "devotion"],
+  "practice_context": ["new-to-practice", "retreat-prep"]
 }

--- a/data/resources/vipassana-research-institute.json
+++ b/data/resources/vipassana-research-institute.json
@@ -12,5 +12,8 @@
   "teachers": [],
   "centers": [],
   "category": "web_resource",
-  "slug": "vipassana-research-institute"
+  "slug": "vipassana-research-institute",
+  "experience_level": "beginner",
+  "topics": ["meditation-technique"],
+  "practice_context": ["new-to-practice", "retreat-prep"]
 }

--- a/data/resources/wisdom-masters-meister-eckhart.json
+++ b/data/resources/wisdom-masters-meister-eckhart.json
@@ -13,5 +13,8 @@
   "teachers": [
     "meister-eckhart"
   ],
-  "centers": []
+  "centers": [],
+  "experience_level": "intermediate",
+  "topics": ["nature-of-mind", "philosophy"],
+  "practice_context": ["deepening", "cross-tradition"]
 }

--- a/data/resources/zen-buddhism-stanford-encyclopedia-of-philosophy.json
+++ b/data/resources/zen-buddhism-stanford-encyclopedia-of-philosophy.json
@@ -11,5 +11,8 @@
   "teachers": [],
   "centers": [],
   "category": "encyclopedia",
-  "slug": "zen-buddhism-stanford-encyclopedia-of-philosophy"
+  "slug": "zen-buddhism-stanford-encyclopedia-of-philosophy",
+  "experience_level": "intermediate",
+  "topics": ["philosophy"],
+  "practice_context": ["academic"]
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,6 +26,7 @@
         "tw-animate-css": "^1.4.0"
       },
       "devDependencies": {
+        "@anthropic-ai/sdk": "^0.87.0",
         "@tailwindcss/postcss": "^4",
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
@@ -93,6 +94,27 @@
         "nr": "bin/nr.mjs",
         "nun": "bin/nun.mjs",
         "nup": "bin/nup.mjs"
+      }
+    },
+    "node_modules/@anthropic-ai/sdk": {
+      "version": "0.87.0",
+      "resolved": "https://registry.npmjs.org/@anthropic-ai/sdk/-/sdk-0.87.0.tgz",
+      "integrity": "sha512-ZvBWT5VkPTW6b8LIpugpuAkpcYPSLOXdWTcgQrpUqf4IeJ5ZrH5rT8sTsUDvxPCHAlRG3nF4VIWfjw6uLhJ18g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "json-schema-to-ts": "^3.1.1"
+      },
+      "bin": {
+        "anthropic-ai-sdk": "bin/cli"
+      },
+      "peerDependencies": {
+        "zod": "^3.25.0 || ^4.0.0"
+      },
+      "peerDependenciesMeta": {
+        "zod": {
+          "optional": true
+        }
       }
     },
     "node_modules/@asamuzakjp/css-color": {
@@ -9021,6 +9043,20 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/json-schema-to-ts": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/json-schema-to-ts/-/json-schema-to-ts-3.1.1.tgz",
+      "integrity": "sha512-+DWg8jCJG2TEnpy7kOm/7/AxaYoaRbjVB4LFZLySZlWn8exGs3A4OLJR966cVvU26N7X9TWxl+Jsw7dzAqKT6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.18.3",
+        "ts-algebra": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
@@ -13162,6 +13198,13 @@
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
       }
+    },
+    "node_modules/ts-algebra": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ts-algebra/-/ts-algebra-2.0.0.tgz",
+      "integrity": "sha512-FPAhNPFMrkwz76P7cdjdmiShwMynZYN6SgOujD1urY4oNm80Ou9oMdmbR45LotcKOXoy7wSmHkRFE6Mxbrhefw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/ts-api-utils": {
       "version": "2.4.0",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "tw-animate-css": "^1.4.0"
   },
   "devDependencies": {
+    "@anthropic-ai/sdk": "^0.87.0",
     "@tailwindcss/postcss": "^4",
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",

--- a/scripts/tag-resources.ts
+++ b/scripts/tag-resources.ts
@@ -1,0 +1,386 @@
+#!/usr/bin/env npx tsx
+/**
+ * Claude-assisted taxonomy tagging for resources.
+ *
+ * Uses hand-tagged exemplars as few-shot examples to tag remaining resources
+ * with experience_level, topics, and practice_context.
+ *
+ * Usage:
+ *   npx tsx scripts/tag-resources.ts              # dry run (default)
+ *   npx tsx scripts/tag-resources.ts --write       # write changes to files
+ *   npx tsx scripts/tag-resources.ts --limit 10    # process only 10 resources
+ */
+
+import Anthropic from "@anthropic-ai/sdk";
+import { readdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
+// -- Types --
+
+interface Resource {
+  title: string;
+  slug: string;
+  type: string;
+  category: string;
+  description: string;
+  traditions: string[];
+  author: string | null;
+  experience_level?: string;
+  topics?: string[];
+  practice_context?: string[];
+  [key: string]: unknown;
+}
+
+interface TagResult {
+  experience_level: string;
+  topics: string[];
+  practice_context: string[];
+}
+
+interface ProcessedResource {
+  slug: string;
+  title: string;
+  tags: TagResult;
+  confidence: "high" | "medium" | "low";
+}
+
+// -- Config --
+
+const DATA_DIR = join(process.cwd(), "data");
+const RESOURCES_DIR = join(DATA_DIR, "resources");
+const TAXONOMY_PATH = join(DATA_DIR, "taxonomy.json");
+
+const BATCH_SIZE = 10;
+const RATE_LIMIT_DELAY_MS = 500;
+
+// -- Parse args --
+
+const args = process.argv.slice(2);
+const dryRun = !args.includes("--write");
+const limitIdx = args.indexOf("--limit");
+const limit = limitIdx !== -1 ? parseInt(args[limitIdx + 1], 10) : Infinity;
+
+// -- Load data --
+
+function loadTaxonomy() {
+  return JSON.parse(readFileSync(TAXONOMY_PATH, "utf-8"));
+}
+
+function loadAllResources(): Resource[] {
+  return readdirSync(RESOURCES_DIR)
+    .filter((f) => f.endsWith(".json"))
+    .map((f) => JSON.parse(readFileSync(join(RESOURCES_DIR, f), "utf-8")));
+}
+
+function getExemplars(resources: Resource[]): Resource[] {
+  return resources.filter(
+    (r) => r.experience_level && r.topics?.length && r.practice_context?.length
+  );
+}
+
+function getUntagged(resources: Resource[]): Resource[] {
+  return resources.filter((r) => !r.experience_level);
+}
+
+// -- Prompt construction --
+
+function buildSystemPrompt(
+  taxonomy: Record<string, unknown>,
+  exemplars: Resource[]
+): string {
+  const exemplarText = exemplars
+    .map(
+      (e) =>
+        `Title: ${e.title}
+Type: ${e.type} | Category: ${e.category}
+Traditions: ${e.traditions.join(", ")}
+Description: ${e.description.slice(0, 200)}
+→ experience_level: ${e.experience_level}
+→ topics: ${JSON.stringify(e.topics)}
+→ practice_context: ${JSON.stringify(e.practice_context)}`
+    )
+    .join("\n\n");
+
+  return `You are a taxonomy tagger for a contemplative traditions directory. Tag each resource with:
+
+TAXONOMY SCHEMA:
+${JSON.stringify(taxonomy, null, 2)}
+
+RULES:
+- experience_level: exactly one value. "beginner" = accessible to newcomers, "intermediate" = assumes some practice/study, "advanced" = requires significant background.
+- topics: 1-4 values from the topics list. Pick what the resource is primarily ABOUT.
+- practice_context: 1-3 values from the practice_context list. Pick WHO or WHEN this resource is for.
+- For encyclopedia/academic articles, lean toward "academic" practice_context and "intermediate" experience_level.
+- For primary texts, consider the original difficulty, not modern translations.
+- When unsure, pick the more accessible level.
+
+TAGGED EXAMPLES:
+${exemplarText}
+
+RESPONSE FORMAT:
+Respond with ONLY valid JSON. For each resource, output:
+{
+  "results": [
+    {
+      "slug": "resource-slug",
+      "experience_level": "beginner|intermediate|advanced",
+      "topics": ["topic1", "topic2"],
+      "practice_context": ["context1"],
+      "confidence": "high|medium|low"
+    }
+  ]
+}
+
+Set confidence to "low" if the description is too short or vague to tag reliably.`;
+}
+
+function buildUserPrompt(batch: Resource[]): string {
+  return (
+    "Tag these resources:\n\n" +
+    batch
+      .map(
+        (r) =>
+          `slug: ${r.slug}
+title: ${r.title}
+type: ${r.type} | category: ${r.category}
+traditions: ${r.traditions.join(", ")}
+author: ${r.author ?? "unknown"}
+description: ${r.description.slice(0, 300)}`
+      )
+      .join("\n---\n")
+  );
+}
+
+// -- API call --
+
+async function tagBatch(
+  client: Anthropic,
+  systemPrompt: string,
+  batch: Resource[]
+): Promise<ProcessedResource[]> {
+  const response = await client.messages.create({
+    model: "claude-haiku-4-5-20251001",
+    max_tokens: 4096,
+    system: systemPrompt,
+    messages: [{ role: "user", content: buildUserPrompt(batch) }],
+  });
+
+  const text =
+    response.content[0].type === "text" ? response.content[0].text : "";
+
+  // Extract JSON from response (handle markdown code blocks)
+  const jsonMatch = text.match(/\{[\s\S]*\}/);
+  if (!jsonMatch) {
+    console.error("Failed to parse response:", text.slice(0, 200));
+    return [];
+  }
+
+  const parsed = JSON.parse(jsonMatch[0]);
+  return parsed.results.map(
+    (r: {
+      slug: string;
+      experience_level: string;
+      topics: string[];
+      practice_context: string[];
+      confidence: string;
+    }) => ({
+      slug: r.slug,
+      title: batch.find((b) => b.slug === r.slug)?.title ?? r.slug,
+      tags: {
+        experience_level: r.experience_level,
+        topics: r.topics,
+        practice_context: r.practice_context,
+      },
+      confidence: r.confidence as "high" | "medium" | "low",
+    })
+  );
+}
+
+// -- Validation --
+
+function validateTags(
+  result: ProcessedResource,
+  taxonomy: Record<string, { values: string[] }>
+): string[] {
+  const errors: string[] = [];
+
+  if (!taxonomy.experience_level.values.includes(result.tags.experience_level)) {
+    errors.push(
+      `Invalid experience_level "${result.tags.experience_level}" for ${result.slug}`
+    );
+  }
+
+  for (const t of result.tags.topics) {
+    if (!taxonomy.topics.values.includes(t)) {
+      errors.push(`Invalid topic "${t}" for ${result.slug}`);
+    }
+  }
+
+  for (const c of result.tags.practice_context) {
+    if (!taxonomy.practice_context.values.includes(c)) {
+      errors.push(`Invalid practice_context "${c}" for ${result.slug}`);
+    }
+  }
+
+  if (result.tags.topics.length === 0) {
+    errors.push(`No topics for ${result.slug}`);
+  }
+
+  if (result.tags.practice_context.length === 0) {
+    errors.push(`No practice_context for ${result.slug}`);
+  }
+
+  return errors;
+}
+
+// -- Write back --
+
+function writeResource(slug: string, tags: TagResult): void {
+  const filePath = join(RESOURCES_DIR, `${slug}.json`);
+  const resource = JSON.parse(readFileSync(filePath, "utf-8"));
+  resource.experience_level = tags.experience_level;
+  resource.topics = tags.topics;
+  resource.practice_context = tags.practice_context;
+  writeFileSync(filePath, JSON.stringify(resource, null, 2) + "\n");
+}
+
+// -- Main --
+
+async function main() {
+  console.log(`Mode: ${dryRun ? "DRY RUN" : "WRITE"}`);
+  console.log();
+
+  const taxonomy = loadTaxonomy();
+  const allResources = loadAllResources();
+  const exemplars = getExemplars(allResources);
+  const untagged = getUntagged(allResources).slice(0, limit);
+
+  console.log(`Total resources: ${allResources.length}`);
+  console.log(`Already tagged (exemplars): ${exemplars.length}`);
+  console.log(`To process: ${untagged.length}`);
+  console.log();
+
+  if (untagged.length === 0) {
+    console.log("Nothing to tag!");
+    return;
+  }
+
+  const client = new Anthropic();
+  const systemPrompt = buildSystemPrompt(taxonomy, exemplars);
+
+  const allResults: ProcessedResource[] = [];
+  const allErrors: string[] = [];
+  let lowConfidenceCount = 0;
+
+  // Process in batches
+  for (let i = 0; i < untagged.length; i += BATCH_SIZE) {
+    const batch = untagged.slice(i, i + BATCH_SIZE);
+    const batchNum = Math.floor(i / BATCH_SIZE) + 1;
+    const totalBatches = Math.ceil(untagged.length / BATCH_SIZE);
+
+    console.log(
+      `Batch ${batchNum}/${totalBatches} (${batch.length} resources)...`
+    );
+
+    try {
+      const results = await tagBatch(client, systemPrompt, batch);
+
+      for (const result of results) {
+        const errors = validateTags(result, taxonomy);
+        if (errors.length > 0) {
+          allErrors.push(...errors);
+          continue;
+        }
+
+        allResults.push(result);
+
+        if (result.confidence === "low") {
+          lowConfidenceCount++;
+        }
+
+        if (!dryRun) {
+          writeResource(result.slug, result.tags);
+        }
+      }
+
+      // Check for resources that weren't returned
+      const returnedSlugs = new Set(results.map((r) => r.slug));
+      for (const r of batch) {
+        if (!returnedSlugs.has(r.slug)) {
+          allErrors.push(`Missing from response: ${r.slug}`);
+        }
+      }
+    } catch (err) {
+      console.error(`  Error processing batch: ${err}`);
+      allErrors.push(`Batch ${batchNum} failed: ${err}`);
+    }
+
+    // Rate limiting between batches
+    if (i + BATCH_SIZE < untagged.length) {
+      await new Promise((resolve) => setTimeout(resolve, RATE_LIMIT_DELAY_MS));
+    }
+  }
+
+  // -- Coverage report --
+
+  console.log("\n========== COVERAGE REPORT ==========\n");
+
+  const totalProcessed = allResults.length + exemplars.length;
+  const totalResources = allResources.length;
+
+  // Experience level coverage
+  const withLevel = allResults.filter((r) => r.tags.experience_level).length + exemplars.length;
+  console.log(
+    `experience_level: ${withLevel}/${totalResources} (${((withLevel / totalResources) * 100).toFixed(1)}%)`
+  );
+
+  // Topics coverage
+  const withTopics = allResults.filter((r) => r.tags.topics.length > 0).length + exemplars.length;
+  console.log(
+    `topics:           ${withTopics}/${totalResources} (${((withTopics / totalResources) * 100).toFixed(1)}%)`
+  );
+
+  // Practice context coverage
+  const withContext =
+    allResults.filter((r) => r.tags.practice_context.length > 0).length + exemplars.length;
+  console.log(
+    `practice_context: ${withContext}/${totalResources} (${((withContext / totalResources) * 100).toFixed(1)}%)`
+  );
+
+  console.log(`\nTotal processed: ${totalProcessed}/${totalResources}`);
+  console.log(`Low confidence: ${lowConfidenceCount}`);
+
+  if (lowConfidenceCount > 0) {
+    console.log("\n--- Low confidence resources (review manually) ---");
+    for (const r of allResults.filter((r) => r.confidence === "low")) {
+      console.log(`  ${r.slug}: ${JSON.stringify(r.tags)}`);
+    }
+  }
+
+  if (allErrors.length > 0) {
+    console.log(`\n--- Errors (${allErrors.length}) ---`);
+    for (const e of allErrors) {
+      console.log(`  ${e}`);
+    }
+  }
+
+  if (dryRun) {
+    console.log("\n[DRY RUN] No files were modified. Use --write to apply.");
+
+    // Show sample of what would be written
+    console.log("\n--- Sample tagged resources ---");
+    for (const r of allResults.slice(0, 5)) {
+      console.log(`  ${r.title}`);
+      console.log(`    level: ${r.tags.experience_level} | confidence: ${r.confidence}`);
+      console.log(`    topics: ${r.tags.topics.join(", ")}`);
+      console.log(`    context: ${r.tags.practice_context.join(", ")}`);
+    }
+  } else {
+    console.log(`\n[WRITE] Updated ${allResults.length} resource files.`);
+  }
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/src/app/resources/[slug]/page.tsx
+++ b/src/app/resources/[slug]/page.tsx
@@ -6,6 +6,7 @@ import { Badge } from "@/components/ui/badge";
 import { getAllResources, getResource, getAllTraditions, getAllTeachers } from "@/lib/data";
 import { bookshopAffiliateUrl } from "@/lib/affiliate";
 import { ResourceTestimonies } from "@/components/resource-testimonies";
+import { TaxonomyBadges } from "@/components/taxonomy-badges";
 import { SITE_URL } from "@/lib/seo";
 
 export function generateStaticParams() {
@@ -73,11 +74,25 @@ export default async function ResourcePage({ params }: { params: Promise<{ slug:
           {resource.year && (
             <p className="text-sm text-muted-foreground mt-1">{resource.year}</p>
           )}
+          {resource.experience_level && (
+            <div className="mt-3">
+              <TaxonomyBadges experienceLevel={resource.experience_level} />
+            </div>
+          )}
         </header>
 
-        <p className="text-foreground/80 leading-relaxed mb-8">
+        <p className="text-foreground/80 leading-relaxed mb-6">
           {resource.description}
         </p>
+
+        {(resource.topics?.length || resource.practice_context?.length) && (
+          <div className="mb-8">
+            <TaxonomyBadges
+              topics={resource.topics}
+              practiceContext={resource.practice_context}
+            />
+          </div>
+        )}
 
         {/* External link */}
         <div className="mb-10">

--- a/src/app/resources/[slug]/page.tsx
+++ b/src/app/resources/[slug]/page.tsx
@@ -85,7 +85,7 @@ export default async function ResourcePage({ params }: { params: Promise<{ slug:
           {resource.description}
         </p>
 
-        {(resource.topics?.length || resource.practice_context?.length) && (
+        {(resource.topics?.length ?? 0) + (resource.practice_context?.length ?? 0) > 0 && (
           <div className="mb-8">
             <TaxonomyBadges
               topics={resource.topics}

--- a/src/components/__tests__/taxonomy-badges.test.tsx
+++ b/src/components/__tests__/taxonomy-badges.test.tsx
@@ -1,0 +1,67 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { TaxonomyBadges } from "../taxonomy-badges";
+
+describe("TaxonomyBadges", () => {
+  it("renders nothing when no taxonomy fields provided", () => {
+    const { container } = render(<TaxonomyBadges />);
+    expect(container.innerHTML).toBe("");
+  });
+
+  it("renders experience level badge", () => {
+    render(<TaxonomyBadges experienceLevel="beginner" />);
+    expect(screen.getByText("Beginner")).toBeInTheDocument();
+  });
+
+  it("renders all three experience levels with distinct styles", () => {
+    const { rerender } = render(
+      <TaxonomyBadges experienceLevel="beginner" />
+    );
+    const beginner = screen.getByText("Beginner");
+    expect(beginner.className).toContain("bg-[#eaf2ea]");
+
+    rerender(<TaxonomyBadges experienceLevel="intermediate" />);
+    const intermediate = screen.getByText("Intermediate");
+    expect(intermediate.className).toContain("bg-[#f3e8e5]");
+
+    rerender(<TaxonomyBadges experienceLevel="advanced" />);
+    const advanced = screen.getByText("Advanced");
+    expect(advanced.className).toContain("bg-[#1a1a1a]/10");
+  });
+
+  it("renders topic badges", () => {
+    render(
+      <TaxonomyBadges topics={["meditation-technique", "daily-life"]} />
+    );
+    expect(screen.getByText("Meditation Technique")).toBeInTheDocument();
+    expect(screen.getByText("Daily Life")).toBeInTheDocument();
+  });
+
+  it("renders practice context badges with dashed border", () => {
+    render(
+      <TaxonomyBadges practiceContext={["new-to-practice", "retreat-prep"]} />
+    );
+    const badge = screen.getByText("New To Practice");
+    expect(badge.className).toContain("border-dashed");
+  });
+
+  it("renders all fields together", () => {
+    render(
+      <TaxonomyBadges
+        experienceLevel="intermediate"
+        topics={["philosophy"]}
+        practiceContext={["academic"]}
+      />
+    );
+    expect(screen.getByText("Intermediate")).toBeInTheDocument();
+    expect(screen.getByText("Philosophy")).toBeInTheDocument();
+    expect(screen.getByText("Academic")).toBeInTheDocument();
+  });
+
+  it("handles empty arrays gracefully", () => {
+    const { container } = render(
+      <TaxonomyBadges topics={[]} practiceContext={[]} />
+    );
+    expect(container.innerHTML).toBe("");
+  });
+});

--- a/src/components/taxonomy-badges.tsx
+++ b/src/components/taxonomy-badges.tsx
@@ -1,0 +1,77 @@
+import { Badge } from "@/components/ui/badge";
+import type { ExperienceLevel } from "@/lib/types";
+
+interface TaxonomyBadgesProps {
+  experienceLevel?: ExperienceLevel;
+  topics?: string[];
+  practiceContext?: string[];
+}
+
+const LEVEL_STYLES: Record<ExperienceLevel, string> = {
+  beginner:
+    "bg-[#eaf2ea] text-[#3d6b3d] border-[#3d6b3d]/20",
+  intermediate:
+    "bg-[#f3e8e5] text-[#9e4a3a] border-[#9e4a3a]/20",
+  advanced:
+    "bg-[#1a1a1a]/10 text-[#1a1a1a] border-[#1a1a1a]/20",
+};
+
+const LEVEL_LABELS: Record<ExperienceLevel, string> = {
+  beginner: "Beginner",
+  intermediate: "Intermediate",
+  advanced: "Advanced",
+};
+
+function formatLabel(slug: string): string {
+  return slug
+    .split("-")
+    .map((w) => w.charAt(0).toUpperCase() + w.slice(1))
+    .join(" ");
+}
+
+export function TaxonomyBadges({
+  experienceLevel,
+  topics,
+  practiceContext,
+}: TaxonomyBadgesProps) {
+  const hasTopics = topics && topics.length > 0;
+  const hasContext = practiceContext && practiceContext.length > 0;
+
+  if (!experienceLevel && !hasTopics && !hasContext) return null;
+
+  return (
+    <div className="space-y-3">
+      {experienceLevel && (
+        <div>
+          <span
+            className={`inline-flex items-center rounded-full border px-2.5 py-0.5 font-serif text-xs font-medium ${LEVEL_STYLES[experienceLevel]}`}
+          >
+            {LEVEL_LABELS[experienceLevel]}
+          </span>
+        </div>
+      )}
+      {(hasTopics || hasContext) && (
+        <div className="flex flex-wrap gap-1.5">
+          {topics?.map((topic) => (
+            <Badge
+              key={topic}
+              variant="outline"
+              className="font-serif text-[11px]"
+            >
+              {formatLabel(topic)}
+            </Badge>
+          ))}
+          {practiceContext?.map((ctx) => (
+            <Badge
+              key={ctx}
+              variant="outline"
+              className="font-serif text-[11px] border-dashed"
+            >
+              {formatLabel(ctx)}
+            </Badge>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

- **Hand-tag 20 exemplar resources** with `experience_level`, `topics`, `practice_context` covering 17 traditions, 4 resource types, all 3 experience levels (#231)
- **Build Claude-assisted tagging script** (`scripts/tag-resources.ts`) with dry-run mode, few-shot exemplars, validation, rate limiting, and coverage reporting (#232)
- **Add TaxonomyBadges component** to resource detail pages — experience level badge near title, topics/context badges below description with editorial styling (#233)

## Tagging rationale

Exemplars selected for diversity across:
- **Experience levels**: 10 beginner, 8 intermediate, 2 advanced
- **Traditions**: 17 traditions including Buddhist, Vedic, Taoist, Christian, Islamic, Jewish, and secular
- **Types**: book, article, website, video
- **Topics**: 6 of 10 taxonomy topics used (meditation-technique, philosophy, daily-life, devotion, nature-of-mind, ethics)
- **Contexts**: all 7 practice contexts used

## Test plan

- [x] All 536 tests pass (7 new for TaxonomyBadges)
- [x] Build succeeds
- [x] Badges render correctly when taxonomy fields present
- [x] No empty badge rows when taxonomy fields missing
- [x] Tagging script loads and validates in dry-run mode
- [ ] Run `npx tsx scripts/tag-resources.ts` with API key to tag remaining resources

Closes #231, closes #232, closes #233

🤖 Generated with [Claude Code](https://claude.com/claude-code)