### PR TITLE
feat: add recommended_at column to testimonies schema

### DIFF
--- a/supabase/schema.sql
+++ b/supabase/schema.sql
@@ -22,9 +22,19 @@ create table public.testimonies (
   context text check (char_length(context) <= 2000),
   who_for text check (char_length(who_for) <= 2000),
   freeform text check (char_length(freeform) <= 2000),
+  recommended_at timestamptz not null default now(),
   created_at timestamptz default now(),
   unique(user_id, resource_slug)
 );
+
+-- Backfill migration for existing rows:
+-- Run this against a live database that already has the testimonies table:
+--
+--   ALTER TABLE testimonies ADD COLUMN recommended_at timestamptz;
+--   UPDATE testimonies SET recommended_at = created_at WHERE recommended_at IS NULL;
+--   ALTER TABLE testimonies ALTER COLUMN recommended_at SET NOT NULL;
+--   ALTER TABLE testimonies ALTER COLUMN recommended_at SET DEFAULT now();
+--
 
 -- Indexes
 create index testimonies_resource_slug_idx on public.testimonies (resource_slug);


### PR DESCRIPTION
## Summary

- Adds `recommended_at timestamptz NOT NULL DEFAULT now()` to the `testimonies` table in `supabase/schema.sql`
- Includes commented backfill migration for existing rows (sets `recommended_at = created_at`)
- RLS policies and `testimony_counts` view are unaffected (row-level auth, view only uses `resource_slug` and `count`)

## Context

Foundation for the recommend-first flow. A bare recommendation is a testimony row with `recommended_at` set but all text fields null. This distinguishes recommendations from full testimonies.

TypeScript types and query functions will be updated in #251.

## Test plan

- [x] All 531 existing tests pass (1 pre-existing unrelated failure in tradition-map due to missing generated file)
- [x] `testimony_counts` view unchanged -- only references `resource_slug` and `count(*)`
- [x] RLS policies unchanged -- row-level checks on `user_id`/`auth.uid()`, not column-specific
- [x] New column has `NOT NULL DEFAULT now()` so existing insert paths work without modification

Closes #250

🤖 Generated with [Claude Code](https://claude.com/claude-code)