### PR TITLE
feat: add recommendation query functions for two-tier model

### DIFF
--- a/src/lib/__tests__/testimonies.test.ts
+++ b/src/lib/__tests__/testimonies.test.ts
@@ -43,6 +43,9 @@ import { supabase } from "../supabase";
 import {
   getTestimonies,
   getTestimonyCounts,
+  createRecommendation,
+  getUserRecommendation,
+  getRecommendationCount,
   createTestimony,
   getUserTestimony,
   updateProfile,
@@ -119,13 +122,93 @@ describe("testimonies", () => {
     });
   });
 
+  describe("createRecommendation", () => {
+    it("inserts a bare recommendation and returns it", async () => {
+      const recommendation = {
+        id: "t1",
+        user_id: "u1",
+        resource_slug: "zen-mind",
+        recommended_at: "2026-04-21T00:00:00.000Z",
+      };
+
+      const chain = chainable({ single: vi.fn().mockResolvedValue({ data: recommendation, error: null }) });
+      mockFrom.mockReturnValue(chain);
+
+      const result = await createRecommendation("u1", "zen-mind");
+
+      expect(mockFrom).toHaveBeenCalledWith("testimonies");
+      expect(chain.insert).toHaveBeenCalled();
+      expect(result).toEqual(recommendation);
+    });
+
+    it("throws on supabase error", async () => {
+      const chain = chainable({ single: vi.fn().mockResolvedValue({ data: null, error: { message: "duplicate" } }) });
+      mockFrom.mockReturnValue(chain);
+
+      await expect(createRecommendation("u1", "zen-mind")).rejects.toEqual({ message: "duplicate" });
+    });
+  });
+
+  describe("getUserRecommendation", () => {
+    it("returns true when user has recommended", async () => {
+      const chain = chainable({ maybeSingle: vi.fn().mockResolvedValue({ data: { id: "t1" }, error: null }) });
+      mockFrom.mockReturnValue(chain);
+
+      const result = await getUserRecommendation("u1", "zen-mind");
+      expect(result).toBe(true);
+    });
+
+    it("returns false when user has not recommended", async () => {
+      const chain = chainable({ maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) });
+      mockFrom.mockReturnValue(chain);
+
+      const result = await getUserRecommendation("u1", "zen-mind");
+      expect(result).toBe(false);
+    });
+
+    it("throws on supabase error", async () => {
+      const chain = chainable({ maybeSingle: vi.fn().mockResolvedValue({ data: null, error: { message: "fail" } }) });
+      mockFrom.mockReturnValue(chain);
+
+      await expect(getUserRecommendation("u1", "zen-mind")).rejects.toEqual({ message: "fail" });
+    });
+  });
+
+  describe("getRecommendationCount", () => {
+    it("returns count for a resource", async () => {
+      const chain = chainable({ maybeSingle: vi.fn().mockResolvedValue({ data: { count: 7 }, error: null }) });
+      mockFrom.mockReturnValue(chain);
+
+      const result = await getRecommendationCount("zen-mind");
+      expect(mockFrom).toHaveBeenCalledWith("testimony_counts");
+      expect(chain.eq).toHaveBeenCalledWith("resource_slug", "zen-mind");
+      expect(result).toBe(7);
+    });
+
+    it("returns 0 when no recommendations exist", async () => {
+      const chain = chainable({ maybeSingle: vi.fn().mockResolvedValue({ data: null, error: null }) });
+      mockFrom.mockReturnValue(chain);
+
+      const result = await getRecommendationCount("unknown-book");
+      expect(result).toBe(0);
+    });
+
+    it("throws on supabase error", async () => {
+      const chain = chainable({ maybeSingle: vi.fn().mockResolvedValue({ data: null, error: { message: "fail" } }) });
+      mockFrom.mockReturnValue(chain);
+
+      await expect(getRecommendationCount("zen-mind")).rejects.toEqual({ message: "fail" });
+    });
+  });
+
   describe("createTestimony", () => {
-    it("inserts a testimony and returns it", async () => {
+    it("updates an existing recommendation row with testimony text", async () => {
       const testimony = {
         id: "t1",
         user_id: "u1",
         resource_slug: "zen-mind",
         impact: "Life-changing",
+        recommended_at: "2026-04-21T00:00:00.000Z",
       };
 
       const chain = chainable({ single: vi.fn().mockResolvedValue({ data: testimony, error: null }) });
@@ -138,8 +221,19 @@ describe("testimonies", () => {
       });
 
       expect(mockFrom).toHaveBeenCalledWith("testimonies");
-      expect(chain.insert).toHaveBeenCalled();
+      expect(chain.update).toHaveBeenCalledWith({ impact: "Life-changing" });
+      expect(chain.eq).toHaveBeenCalledWith("user_id", "u1");
+      expect(chain.eq).toHaveBeenCalledWith("resource_slug", "zen-mind");
       expect(result).toEqual(testimony);
+    });
+
+    it("throws when no recommendation exists to update", async () => {
+      const chain = chainable({ single: vi.fn().mockResolvedValue({ data: null, error: { message: "No rows found" } }) });
+      mockFrom.mockReturnValue(chain);
+
+      await expect(
+        createTestimony({ user_id: "u1", resource_slug: "zen-mind", impact: "test" })
+      ).rejects.toEqual({ message: "No rows found" });
     });
   });
 

--- a/src/lib/testimonies.ts
+++ b/src/lib/testimonies.ts
@@ -29,6 +29,52 @@ export async function getTestimonyCounts(slugs: string[]): Promise<Map<string, n
   return counts;
 }
 
+export async function createRecommendation(
+  userId: string,
+  resourceSlug: string
+): Promise<Testimony> {
+  const { data, error } = await supabase
+    .from("testimonies")
+    .insert({
+      user_id: userId,
+      resource_slug: resourceSlug,
+      recommended_at: new Date().toISOString(),
+    })
+    .select()
+    .single();
+
+  if (error) throw error;
+  return data as Testimony;
+}
+
+export async function getUserRecommendation(
+  userId: string,
+  resourceSlug: string
+): Promise<boolean> {
+  const { data, error } = await supabase
+    .from("testimonies")
+    .select("id")
+    .eq("user_id", userId)
+    .eq("resource_slug", resourceSlug)
+    .maybeSingle();
+
+  if (error) throw error;
+  return data !== null;
+}
+
+export async function getRecommendationCount(
+  resourceSlug: string
+): Promise<number> {
+  const { data, error } = await supabase
+    .from("testimony_counts")
+    .select("count")
+    .eq("resource_slug", resourceSlug)
+    .maybeSingle();
+
+  if (error) throw error;
+  return (data as { count: number } | null)?.count ?? 0;
+}
+
 export async function createTestimony(testimony: {
   user_id: string;
   resource_slug: string;
@@ -37,9 +83,12 @@ export async function createTestimony(testimony: {
   who_for?: string | null;
   freeform?: string | null;
 }): Promise<Testimony> {
+  const { user_id, resource_slug, ...fields } = testimony;
   const { data, error } = await supabase
     .from("testimonies")
-    .insert(testimony)
+    .update(fields)
+    .eq("user_id", user_id)
+    .eq("resource_slug", resource_slug)
     .select()
     .single();
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -120,6 +120,7 @@ export interface Testimony {
   context: string | null;
   who_for: string | null;
   freeform: string | null;
+  recommended_at: string;
   created_at: string;
   profiles?: Pick<Profile, "display_name" | "traditions" | "years_of_practice">;
 }


### PR DESCRIPTION
## Summary

- Adds `recommended_at` field to the `Testimony` TypeScript type
- Adds `createRecommendation()` — inserts a bare recommendation row (no text fields)
- Adds `getUserRecommendation()` — returns boolean for whether a user has recommended a resource
- Adds `getRecommendationCount()` — returns total recommendation count for a resource via the `testimony_counts` view
- Changes `createTestimony()` to UPDATE an existing recommendation row rather than INSERT, supporting the two-tier recommend-then-testify model

Closes #251

## Test plan

- [x] All 20 testimony tests pass (including 9 new tests for the 3 new functions + updated createTestimony)
- [x] Existing tests updated to reflect new `createTestimony` semantics (update vs insert)
- [x] Error paths tested for all new functions

🤖 Generated with [Claude Code](https://claude.com/claude-code)