### PR TITLE
feat: recommendation count display with empty-state handling

### DIFF
--- a/src/components/__tests__/testimony-count.test.tsx
+++ b/src/components/__tests__/testimony-count.test.tsx
@@ -3,19 +3,25 @@ import { render, screen, waitFor } from "@testing-library/react";
 
 vi.mock("@/lib/testimonies", () => ({
   getTestimonyCounts: vi.fn(),
+  getRecommendationCount: vi.fn(),
 }));
 
-import { getTestimonyCounts } from "@/lib/testimonies";
-import { TestimonyCountProvider, TestimonyCountBadge } from "../testimony-count";
+import { getTestimonyCounts, getRecommendationCount } from "@/lib/testimonies";
+import {
+  TestimonyCountProvider,
+  TestimonyCountBadge,
+  RecommendationCount,
+} from "../testimony-count";
 
 const mockGetCounts = getTestimonyCounts as ReturnType<typeof vi.fn>;
+const mockGetRecommendationCount = getRecommendationCount as ReturnType<typeof vi.fn>;
 
 describe("TestimonyCountBadge", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("renders count for a resource with recommendations", async () => {
+  it("renders heart icon and count for a resource with recommendations", async () => {
     const counts = new Map([["book-a", 5]]);
     mockGetCounts.mockResolvedValue(counts);
 
@@ -26,8 +32,12 @@ describe("TestimonyCountBadge", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("5 recommended")).toBeInTheDocument();
+      expect(screen.getByText("5")).toBeInTheDocument();
     });
+
+    // Should have an SVG heart icon
+    const badge = screen.getByText("5").closest("span");
+    expect(badge?.querySelector("svg")).toBeTruthy();
   });
 
   it("renders nothing for a resource with zero recommendations", async () => {
@@ -62,8 +72,54 @@ describe("TestimonyCountBadge", () => {
     );
 
     await waitFor(() => {
-      expect(screen.getByText("3 recommended")).toBeInTheDocument();
-      expect(screen.getByText("7 recommended")).toBeInTheDocument();
+      expect(screen.getByText("3")).toBeInTheDocument();
+      expect(screen.getByText("7")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("RecommendationCount", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows loading skeleton while fetching", () => {
+    mockGetRecommendationCount.mockReturnValue(new Promise(() => {})); // Never resolves
+    render(<RecommendationCount resourceSlug="zen-mind" />);
+    expect(screen.getByLabelText("Loading recommendation count")).toBeInTheDocument();
+  });
+
+  it("renders nothing for zero recommendations", async () => {
+    mockGetRecommendationCount.mockResolvedValue(0);
+    const { container } = render(<RecommendationCount resourceSlug="zen-mind" />);
+    await waitFor(() => {
+      expect(container.querySelector("p")).toBeNull();
+      expect(container.querySelector(".animate-pulse")).toBeNull();
+    });
+  });
+
+  it("renders singular form for 1 recommendation", async () => {
+    mockGetRecommendationCount.mockResolvedValue(1);
+    render(<RecommendationCount resourceSlug="zen-mind" />);
+    await waitFor(() => {
+      expect(screen.getByText("1 recommendation")).toBeInTheDocument();
+    });
+  });
+
+  it("renders plural form for multiple recommendations", async () => {
+    mockGetRecommendationCount.mockResolvedValue(12);
+    render(<RecommendationCount resourceSlug="zen-mind" />);
+    await waitFor(() => {
+      expect(screen.getByText("12 recommendations")).toBeInTheDocument();
+    });
+  });
+
+  it("handles fetch errors gracefully by showing nothing", async () => {
+    mockGetRecommendationCount.mockRejectedValue(new Error("Network error"));
+    const { container } = render(<RecommendationCount resourceSlug="zen-mind" />);
+    await waitFor(() => {
+      expect(container.querySelector("p")).toBeNull();
+      expect(container.querySelector(".animate-pulse")).toBeNull();
     });
   });
 });

--- a/src/components/resource-list.tsx
+++ b/src/components/resource-list.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 import type { Resource, ResourceCategory, ResourceType } from "@/lib/types";
 import { ResourceListTestimonyCounts } from "./resource-list-testimony-counts";
+import { TestimonyCountBadge } from "./testimony-count";
 
 const CATEGORY_ORDER: ResourceCategory[] = [
   "primary_text",
@@ -93,9 +94,12 @@ export function ResourceList({ resources }: ResourceListProps) {
                             </span>
                           )}
                         </div>
-                        <p className="mt-1 font-sans text-sm leading-relaxed text-muted-foreground">
-                          {resource.description}
-                        </p>
+                        <div className="mt-1 flex items-center gap-3">
+                          <p className="font-sans text-sm leading-relaxed text-muted-foreground flex-1">
+                            {resource.description}
+                          </p>
+                          <TestimonyCountBadge slug={resource.slug} />
+                        </div>
                       </Link>
                     ))}
                   </div>

--- a/src/components/resource-testimonies.tsx
+++ b/src/components/resource-testimonies.tsx
@@ -2,6 +2,7 @@
 
 import { TestimonyDisplay } from "./testimony-display";
 import { RecommendationFlow } from "./recommendation-flow";
+import { RecommendationCount } from "./testimony-count";
 
 interface ResourceTestimoniesProps {
   resourceSlug: string;
@@ -11,9 +12,12 @@ interface ResourceTestimoniesProps {
 export function ResourceTestimonies({ resourceSlug, resourceTitle }: ResourceTestimoniesProps) {
   return (
     <section className="space-y-6">
-      <h2 className="font-serif text-xl font-semibold text-foreground">
-        Practitioner Recommendations
-      </h2>
+      <div className="space-y-1">
+        <h2 className="font-serif text-xl font-semibold text-foreground">
+          Practitioner Recommendations
+        </h2>
+        <RecommendationCount resourceSlug={resourceSlug} />
+      </div>
       <TestimonyDisplay resourceSlug={resourceSlug} />
       <RecommendationFlow resourceSlug={resourceSlug} resourceTitle={resourceTitle} />
     </section>

--- a/src/components/testimony-count.tsx
+++ b/src/components/testimony-count.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { createContext, useContext, useEffect, useMemo, useState } from "react";
-import { getTestimonyCounts } from "@/lib/testimonies";
+import { getTestimonyCounts, getRecommendationCount } from "@/lib/testimonies";
 
 interface TestimonyCountContextValue {
   counts: Map<string, number>;
@@ -48,6 +48,10 @@ export function useTestimonyCount(slug: string): number | null {
   return counts.get(slug) ?? 0;
 }
 
+/**
+ * Heart icon for list/card views.
+ * Shows: heart icon + number (no label). Hidden when count is 0 or loading.
+ */
 interface TestimonyCountBadgeProps {
   slug: string;
 }
@@ -59,9 +63,54 @@ export function TestimonyCountBadge({ slug }: TestimonyCountBadgeProps) {
   if (!count) return null;
 
   return (
-    <span className="inline-flex items-center gap-1 text-xs text-terracotta font-medium">
-      <span className="inline-block h-1.5 w-1.5 rounded-full bg-terracotta" />
-      {count} recommended
+    <span className="inline-flex items-center gap-1 text-xs font-medium" style={{ color: "#c9ad9e" }}>
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 20 20"
+        fill="currentColor"
+        className="h-3.5 w-3.5"
+        aria-hidden="true"
+      >
+        <path d="M9.653 16.915l-.005-.003-.019-.01a20.759 20.759 0 01-1.162-.682 22.045 22.045 0 01-2.765-2.033C3.981 12.695 2 10.577 2 7.75 2 5.478 3.791 3.5 6.05 3.5c1.278 0 2.435.592 3.2 1.52.017.02.033.04.05.06a4.19 4.19 0 01.05-.06C10.115 4.092 11.272 3.5 12.55 3.5 14.809 3.5 16.6 5.478 16.6 7.75c0 2.827-1.981 4.945-3.702 6.437a22.043 22.043 0 01-2.765 2.033 20.741 20.741 0 01-1.162.682l-.019.01-.005.003h-.002a.739.739 0 01-.69 0l-.003-.001z" />
+      </svg>
+      {count}
     </span>
+  );
+}
+
+/**
+ * Recommendation count display for resource detail pages.
+ * Fetches count client-side for a single resource slug.
+ *
+ * - 0 recommendations: renders nothing (empty-state prompt is in the CTA button)
+ * - 1+ recommendations: muted editorial count text
+ */
+interface RecommendationCountProps {
+  resourceSlug: string;
+}
+
+export function RecommendationCount({ resourceSlug }: RecommendationCountProps) {
+  const [count, setCount] = useState<number | null>(null);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    getRecommendationCount(resourceSlug)
+      .then(setCount)
+      .catch(() => setCount(0))
+      .finally(() => setLoading(false));
+  }, [resourceSlug]);
+
+  if (loading) {
+    return (
+      <div className="h-5 w-32 animate-pulse rounded bg-muted" aria-label="Loading recommendation count" />
+    );
+  }
+
+  if (!count) return null;
+
+  return (
+    <p className="text-sm font-serif" style={{ color: "#c9ad9e" }}>
+      {count} {count === 1 ? "recommendation" : "recommendations"}
+    </p>
   );
 }


### PR DESCRIPTION
## Summary

- Add `RecommendationCount` component for resource detail pages: fetches count client-side, shows loading skeleton, displays muted editorial count (e.g. "12 recommendations"), hides when zero
- Update `TestimonyCountBadge` for list/card views: heart icon + number only, warm muted color (#c9ad9e), hidden when zero
- Integrate count display into `ResourceTestimonies` section header
- Add badge to resource list cards in `ResourceList`
- Add 5 new tests for `RecommendationCount` (loading, zero, singular, plural, error handling)

Closes #255

## Test plan
- [x] `RecommendationCount` shows loading skeleton while fetching
- [x] Zero recommendations renders nothing (no "0 recommendations")
- [x] Singular "1 recommendation" / plural "N recommendations"
- [x] Error during fetch renders nothing gracefully
- [x] `TestimonyCountBadge` shows heart + number on list views
- [x] Badge hidden for zero-count resources

🤖 Generated with [Claude Code](https://claude.com/claude-code)