### PR TITLE
feat: refactor RecommendationFlow to recommend-first UX

### DIFF
--- a/src/components/__tests__/recommendation-flow.test.tsx
+++ b/src/components/__tests__/recommendation-flow.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
 
 const mockUser = { id: "u1", email: "test@example.com" };
 
@@ -17,16 +17,23 @@ vi.mock("../supabase-provider", () => ({
 }));
 
 vi.mock("@/lib/testimonies", () => ({
+  createRecommendation: vi.fn().mockResolvedValue({ id: "r1" }),
+  getUserRecommendation: vi.fn().mockResolvedValue(false),
+  getRecommendationCount: vi.fn().mockResolvedValue(5),
   createTestimony: vi.fn().mockResolvedValue({ id: "t1" }),
-  getUserTestimony: vi.fn().mockResolvedValue(null),
-  getProfile: vi.fn().mockResolvedValue({ traditions: [] }),
+  getProfile: vi.fn().mockResolvedValue({ traditions: ["Zen"] }),
   updateProfile: vi.fn().mockResolvedValue({}),
 }));
 
-import { createTestimony, getUserTestimony, getProfile } from "@/lib/testimonies";
+import {
+  createRecommendation,
+  getUserRecommendation,
+  getRecommendationCount,
+  createTestimony,
+  getProfile,
+} from "@/lib/testimonies";
 import { RecommendationFlow } from "../recommendation-flow";
 
-/** Set the URL search params for testing */
 function setUrlParams(params: string) {
   window.history.replaceState({}, "", params ? `/?${params}` : "/");
 }
@@ -34,222 +41,351 @@ function setUrlParams(params: string) {
 describe("RecommendationFlow", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
     currentUser = null;
     setUrlParams("");
-    // Restore default mock implementations after clearAllMocks
-    (getUserTestimony as ReturnType<typeof vi.fn>).mockResolvedValue(null);
-    (getProfile as ReturnType<typeof vi.fn>).mockResolvedValue({ traditions: [] });
-    (createTestimony as ReturnType<typeof vi.fn>).mockResolvedValue({ id: "t1" });
+    (getUserRecommendation as ReturnType<typeof vi.fn>).mockResolvedValue(
+      false
+    );
+    (getRecommendationCount as ReturnType<typeof vi.fn>).mockResolvedValue(5);
+    (createRecommendation as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: "r1",
+    });
+    (getProfile as ReturnType<typeof vi.fn>).mockResolvedValue({
+      traditions: ["Zen"],
+    });
+    (createTestimony as ReturnType<typeof vi.fn>).mockResolvedValue({
+      id: "t1",
+    });
   });
 
   afterEach(() => {
     setUrlParams("");
+    vi.useRealTimers();
   });
 
-  it("renders CTA when not signed in", () => {
-    render(<RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />);
-    expect(screen.getByText(/Have you read Zen Mind/)).toBeInTheDocument();
-    expect(screen.getByText("Share how it impacted your practice")).toBeInTheDocument();
+  it("renders recommend button with count", async () => {
+    render(
+      <RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Recommend")).toBeInTheDocument();
+      expect(screen.getByText("5 recommendations")).toBeInTheDocument();
+    });
   });
 
-  it("shows auth panel when CTA clicked and user not signed in", () => {
-    render(<RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />);
-    fireEvent.click(screen.getByText(/Have you read Zen Mind/));
-    expect(screen.getByText("Sign in to share your experience")).toBeInTheDocument();
+  it("shows singular 'recommendation' for count of 1", async () => {
+    (getRecommendationCount as ReturnType<typeof vi.fn>).mockResolvedValue(1);
+
+    render(
+      <RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("1 recommendation")).toBeInTheDocument();
+    });
   });
 
-  it("shows form directly when CTA clicked and user is signed in", async () => {
+  it("shows auth panel when recommend clicked and user not signed in", async () => {
+    render(
+      <RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Recommend")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText("Recommend"));
+    expect(
+      screen.getByText("Sign in to share your experience")
+    ).toBeInTheDocument();
+    expect(window.location.search).toContain("action=recommend");
+  });
+
+  it("calls createRecommendation when logged-in user clicks recommend", async () => {
     currentUser = mockUser;
-    (getProfile as ReturnType<typeof vi.fn>).mockResolvedValue({ traditions: ["Zen"] });
 
-    render(<RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />);
-    fireEvent.click(screen.getByText(/Have you read Zen Mind/));
+    render(
+      <RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />
+    );
 
     await waitFor(() => {
-      expect(screen.getByText("Recommend Zen Mind")).toBeInTheDocument();
+      expect(screen.getByText("Recommend")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Recommend"));
+    });
+
+    await waitFor(() => {
+      expect(createRecommendation).toHaveBeenCalledWith("u1", "zen-mind");
     });
   });
 
-  it("shows already-recommended message if user has existing testimony", async () => {
+  it("optimistically updates count and shows filled heart on recommend", async () => {
     currentUser = mockUser;
-    (getUserTestimony as ReturnType<typeof vi.fn>).mockResolvedValue({ id: "t1" });
 
-    render(<RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />);
-    fireEvent.click(screen.getByText(/Have you read Zen Mind/));
+    render(
+      <RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />
+    );
 
     await waitFor(() => {
-      expect(screen.getByText("You've already recommended this resource")).toBeInTheDocument();
+      expect(screen.getByText("5 recommendations")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Recommend"));
+    });
+
+    // Count bumped optimistically
+    await waitFor(() => {
+      expect(screen.getByText("6 recommendations")).toBeInTheDocument();
+      expect(screen.getByText("Recommended")).toBeInTheDocument();
     });
   });
 
-  it("renders all optional prompts in form", async () => {
+  it("rolls back optimistic update on error", async () => {
     currentUser = mockUser;
-    (getProfile as ReturnType<typeof vi.fn>).mockResolvedValue({ traditions: ["Zen"] });
+    (createRecommendation as ReturnType<typeof vi.fn>).mockRejectedValue(
+      new Error("Network error")
+    );
 
-    render(<RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />);
-    fireEvent.click(screen.getByText(/Have you read Zen Mind/));
+    render(
+      <RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />
+    );
 
     await waitFor(() => {
-      expect(screen.getByText("How did this resource impact you?")).toBeInTheDocument();
-      expect(screen.getByText("What were you going through at the time?")).toBeInTheDocument();
-      expect(screen.getByText("Who would benefit most from this?")).toBeInTheDocument();
-      expect(screen.getByText("Anything else you'd like to share?")).toBeInTheDocument();
+      expect(screen.getByText("5 recommendations")).toBeInTheDocument();
+    });
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Recommend"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText("5 recommendations")).toBeInTheDocument();
+      expect(screen.getByText("Recommend")).toBeInTheDocument();
+      expect(
+        screen.getByText("Something went wrong. Please try again.")
+      ).toBeInTheDocument();
     });
   });
 
-  it("shows textarea when prompt is toggled", async () => {
+  it("shows 'Want to say why?' after recommend with 300ms delay", async () => {
     currentUser = mockUser;
-    (getProfile as ReturnType<typeof vi.fn>).mockResolvedValue({ traditions: ["Zen"] });
 
-    render(<RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />);
-    fireEvent.click(screen.getByText(/Have you read Zen Mind/));
+    render(
+      <RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />
+    );
 
     await waitFor(() => {
-      expect(screen.getByText("How did this resource impact you?")).toBeInTheDocument();
+      expect(screen.getByText("Recommend")).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByText("How did this resource impact you?"));
-    expect(screen.getByPlaceholderText(/What shifted for you/)).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.click(screen.getByText("Recommend"));
+    });
+
+    // Wait for createRecommendation to resolve
+    await waitFor(() => {
+      expect(createRecommendation).toHaveBeenCalled();
+    });
+
+    // Not visible yet before 300ms
+    expect(screen.queryByText("Want to say why?")).not.toBeInTheDocument();
+
+    // Advance timer by 300ms
+    await act(async () => {
+      vi.advanceTimersByTime(300);
+    });
+
+    expect(screen.getByText("Want to say why?")).toBeInTheDocument();
   });
 
-  it("allows submitting with no prompts answered (bare recommendation)", async () => {
+  it("shows already-recommended state when user has existing recommendation", async () => {
     currentUser = mockUser;
-    (getProfile as ReturnType<typeof vi.fn>).mockResolvedValue({ traditions: ["Zen"] });
+    (getUserRecommendation as ReturnType<typeof vi.fn>).mockResolvedValue(true);
 
-    render(<RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />);
-    fireEvent.click(screen.getByText(/Have you read Zen Mind/));
-
-    await waitFor(() => {
-      expect(screen.getByText("Recommend this resource")).toBeInTheDocument();
-    });
-
-    fireEvent.click(screen.getByText("Recommend this resource"));
+    render(
+      <RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />
+    );
 
     await waitFor(() => {
-      expect(createTestimony).toHaveBeenCalledWith({
-        user_id: "u1",
-        resource_slug: "zen-mind",
-        impact: null,
-        context: null,
-        who_for: null,
-        freeform: null,
-      });
+      expect(screen.getByText("Recommended")).toBeInTheDocument();
     });
+
+    // Button should be disabled
+    const button = screen.getByLabelText("Recommended");
+    expect(button).toBeDisabled();
   });
 
-  it("shows success after submission when profile is complete", async () => {
+  it("disables recommend button after recommending", async () => {
     currentUser = mockUser;
-    (getProfile as ReturnType<typeof vi.fn>).mockResolvedValue({ traditions: ["Zen"] });
 
-    render(<RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />);
-    fireEvent.click(screen.getByText(/Have you read Zen Mind/));
+    render(
+      <RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />
+    );
 
     await waitFor(() => {
-      expect(screen.getByText("Recommend this resource")).toBeInTheDocument();
+      expect(screen.getByText("Recommend")).toBeInTheDocument();
     });
 
-    fireEvent.click(screen.getByText("Recommend this resource"));
-
-    await waitFor(() => {
-      expect(screen.getByText("Thank you for your recommendation")).toBeInTheDocument();
-    });
-  });
-
-  it("shows profile completion after submission when profile is empty", async () => {
-    currentUser = mockUser;
-    (getProfile as ReturnType<typeof vi.fn>).mockResolvedValue({ traditions: [] });
-
-    render(<RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />);
-    fireEvent.click(screen.getByText(/Have you read Zen Mind/));
-
-    await waitFor(() => {
-      expect(screen.getByText("Recommend this resource")).toBeInTheDocument();
+    await act(async () => {
+      fireEvent.click(screen.getByText("Recommend"));
     });
 
-    fireEvent.click(screen.getByText("Recommend this resource"));
-
     await waitFor(() => {
-      expect(screen.getByText("A little about you")).toBeInTheDocument();
+      const button = screen.getByLabelText("Recommended");
+      expect(button).toBeDisabled();
     });
   });
 
   describe("pending-action URL param", () => {
-    it("sets ?action=recommend in URL when unauthenticated user clicks CTA", () => {
-      render(<RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />);
-      fireEvent.click(screen.getByText(/Have you read Zen Mind/));
+    it("sets ?action=recommend when unauthenticated user clicks recommend", async () => {
+      render(
+        <RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />
+      );
 
+      await waitFor(() => {
+        expect(screen.getByText("Recommend")).toBeInTheDocument();
+      });
+
+      fireEvent.click(screen.getByText("Recommend"));
       expect(window.location.search).toContain("action=recommend");
     });
 
-    it("auto-advances to form when user is authenticated and ?action=recommend is present", async () => {
+    it("auto-fires recommend when user is authed and ?action=recommend is present", async () => {
       setUrlParams("action=recommend");
       currentUser = mockUser;
-      (getProfile as ReturnType<typeof vi.fn>).mockResolvedValue({ traditions: ["Zen"] });
 
-      render(<RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />);
+      render(
+        <RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />
+      );
 
       await waitFor(() => {
-        expect(screen.getByText("Recommend Zen Mind")).toBeInTheDocument();
+        expect(createRecommendation).toHaveBeenCalledWith("u1", "zen-mind");
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Recommended")).toBeInTheDocument();
       });
     });
 
-    it("shows already-recommended when param present but user has existing testimony", async () => {
+    it("clears ?action=recommend from URL after successful recommend", async () => {
       setUrlParams("action=recommend");
       currentUser = mockUser;
-      (getUserTestimony as ReturnType<typeof vi.fn>).mockResolvedValue({ id: "t1" });
 
-      render(<RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />);
+      render(
+        <RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />
+      );
 
       await waitFor(() => {
-        expect(screen.getByText("You've already recommended this resource")).toBeInTheDocument();
+        expect(createRecommendation).toHaveBeenCalled();
+      });
+
+      await waitFor(() => {
+        expect(window.location.search).not.toContain("action=recommend");
       });
     });
 
-    it("clears ?action=recommend from URL after successful submission", async () => {
-      setUrlParams("action=recommend");
+    it("does not auto-fire when param absent even if user is authenticated", async () => {
       currentUser = mockUser;
-      (getProfile as ReturnType<typeof vi.fn>).mockResolvedValue({ traditions: ["Zen"] });
 
-      render(<RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />);
-
-      await waitFor(() => {
-        expect(screen.getByText("Recommend this resource")).toBeInTheDocument();
-      });
-
-      fireEvent.click(screen.getByText("Recommend this resource"));
+      render(
+        <RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />
+      );
 
       await waitFor(() => {
-        expect(screen.getByText("Thank you for your recommendation")).toBeInTheDocument();
+        expect(screen.getByText("Recommend")).toBeInTheDocument();
       });
 
-      expect(window.location.search).not.toContain("action=recommend");
+      expect(createRecommendation).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("testimony form", () => {
+    it("allows submitting testimony after recommending", async () => {
+      currentUser = mockUser;
+
+      render(
+        <RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />
+      );
+
+      await waitFor(() => {
+        expect(screen.getByText("Recommend")).toBeInTheDocument();
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Recommend"));
+      });
+
+      await waitFor(() => {
+        expect(createRecommendation).toHaveBeenCalled();
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      expect(screen.getByText("Want to say why?")).toBeInTheDocument();
+
+      // Submit testimony without filling prompts
+      await act(async () => {
+        fireEvent.click(screen.getByText("Share your experience"));
+      });
+
+      await waitFor(() => {
+        expect(createTestimony).toHaveBeenCalledWith({
+          user_id: "u1",
+          resource_slug: "zen-mind",
+          impact: null,
+          context: null,
+          who_for: null,
+          freeform: null,
+        });
+      });
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Thank you for your recommendation")
+        ).toBeInTheDocument();
+      });
     });
 
-    it("shows error when auto-recommend fails (not silent failure)", async () => {
-      setUrlParams("action=recommend");
+    it("shows profile completion after testimony when profile is incomplete", async () => {
       currentUser = mockUser;
-      (getProfile as ReturnType<typeof vi.fn>).mockResolvedValue({ traditions: ["Zen"] });
-      (createTestimony as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("Network error"));
-
-      render(<RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />);
-
-      await waitFor(() => {
-        expect(screen.getByText("Recommend this resource")).toBeInTheDocument();
+      (getProfile as ReturnType<typeof vi.fn>).mockResolvedValue({
+        traditions: [],
       });
 
-      fireEvent.click(screen.getByText("Recommend this resource"));
+      render(
+        <RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />
+      );
 
       await waitFor(() => {
-        expect(screen.getByText("Something went wrong. Please try again.")).toBeInTheDocument();
+        expect(screen.getByText("Recommend")).toBeInTheDocument();
       });
-    });
 
-    it("does not auto-advance when param is absent even if user is authenticated", () => {
-      currentUser = mockUser;
-      render(<RecommendationFlow resourceSlug="zen-mind" resourceTitle="Zen Mind" />);
+      await act(async () => {
+        fireEvent.click(screen.getByText("Recommend"));
+      });
 
-      // Should stay on CTA step
-      expect(screen.getByText(/Have you read Zen Mind/)).toBeInTheDocument();
+      await waitFor(() => {
+        expect(createRecommendation).toHaveBeenCalled();
+      });
+
+      await act(async () => {
+        vi.advanceTimersByTime(300);
+      });
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Share your experience"));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("A little about you")).toBeInTheDocument();
+      });
     });
   });
 });

--- a/src/components/recommendation-flow.tsx
+++ b/src/components/recommendation-flow.tsx
@@ -1,12 +1,18 @@
 "use client";
 
-import { useState, useEffect, useCallback } from "react";
+import { useState, useEffect, useCallback, useRef } from "react";
 import { useSupabase } from "./supabase-provider";
 import { AuthPanel } from "./auth-panel";
 import { ProfileCompletion } from "./profile-completion";
-import { createTestimony, getUserTestimony, getProfile } from "@/lib/testimonies";
+import {
+  createRecommendation,
+  getUserRecommendation,
+  getRecommendationCount,
+  createTestimony,
+  getProfile,
+} from "@/lib/testimonies";
 
-type Step = "cta" | "auth" | "form" | "profile" | "success" | "already-recommended";
+type Step = "idle" | "auth" | "testimony" | "profile" | "success";
 
 const PROMPTS = [
   {
@@ -22,7 +28,8 @@ const PROMPTS = [
   {
     key: "who_for" as const,
     label: "Who would benefit most from this?",
-    placeholder: 'e.g. "Anyone starting a sitting practice" or "People dealing with grief"',
+    placeholder:
+      'e.g. "Anyone starting a sitting practice" or "People dealing with grief"',
   },
   {
     key: "freeform" as const,
@@ -36,61 +43,128 @@ interface RecommendationFlowProps {
   resourceTitle: string;
 }
 
-export function RecommendationFlow({ resourceSlug, resourceTitle }: RecommendationFlowProps) {
+export function RecommendationFlow({
+  resourceSlug,
+  resourceTitle,
+}: RecommendationFlowProps) {
   const { user, loading: authLoading } = useSupabase();
-  const [step, setStep] = useState<Step>("cta");
+  const [step, setStep] = useState<Step>("idle");
+  const [hasRecommended, setHasRecommended] = useState(false);
+  const [count, setCount] = useState(0);
+  const [recommending, setRecommending] = useState(false);
+  const [showTestimonyPrompt, setShowTestimonyPrompt] = useState(false);
   const [activePrompts, setActivePrompts] = useState<Set<string>>(new Set());
   const [values, setValues] = useState<Record<string, string>>({});
   const [submitting, setSubmitting] = useState(false);
   const [needsProfile, setNeedsProfile] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [animating, setAnimating] = useState(false);
+  const pendingActionFired = useRef(false);
 
-  const checkExisting = useCallback(async () => {
-    if (!user) return;
-    const existing = await getUserTestimony(user.id, resourceSlug);
-    if (existing) {
-      setStep("already-recommended");
-    } else {
+  // Fetch recommendation state and count on mount / auth change
+  useEffect(() => {
+    let cancelled = false;
+    async function load() {
+      const c = await getRecommendationCount(resourceSlug);
+      if (cancelled) return;
+      setCount(c);
+      if (user) {
+        const rec = await getUserRecommendation(user.id, resourceSlug);
+        if (cancelled) return;
+        if (rec) {
+          setHasRecommended(true);
+        }
+      }
+    }
+    if (!authLoading) load();
+    return () => {
+      cancelled = true;
+    };
+  }, [user, authLoading, resourceSlug]);
+
+  const doRecommend = useCallback(async () => {
+    if (!user || hasRecommended || recommending) return;
+    setRecommending(true);
+    setErrorMsg(null);
+
+    // Optimistic update
+    setHasRecommended(true);
+    setCount((prev) => prev + 1);
+    setAnimating(true);
+    setTimeout(() => setAnimating(false), 400);
+
+    try {
+      await createRecommendation(user.id, resourceSlug);
+      clearActionParam();
+
+      // Check profile for later testimony submission
       const profile = await getProfile(user.id);
       setNeedsProfile(!profile?.traditions?.length);
-      setStep("form");
-    }
-  }, [user, resourceSlug]);
 
-  // Check for pending-action URL param on mount/auth change
+      // Show testimony prompt after 300ms delay
+      setTimeout(() => {
+        setShowTestimonyPrompt(true);
+      }, 300);
+    } catch (err: unknown) {
+      // Rollback optimistic update
+      setHasRecommended(false);
+      setCount((prev) => prev - 1);
+      const msg = err instanceof Error ? err.message : String(err);
+      if (
+        msg.includes("banned") ||
+        msg.includes("violates row-level security")
+      ) {
+        setErrorMsg(
+          "Your account has been restricted. Please contact the site administrator."
+        );
+      } else {
+        setErrorMsg("Something went wrong. Please try again.");
+      }
+    } finally {
+      setRecommending(false);
+    }
+  }, [user, hasRecommended, recommending, resourceSlug]);
+
+  // Handle pending-action URL param: auto-fire recommend on auth
   useEffect(() => {
-    if (authLoading) return;
+    if (authLoading || pendingActionFired.current) return;
     const params = new URLSearchParams(window.location.search);
-    if (params.get("action") === "recommend" && user) {
-      checkExisting();
+    if (params.get("action") === "recommend" && user && !hasRecommended) {
+      pendingActionFired.current = true;
+      doRecommend();
     }
-  }, [user, authLoading, checkExisting]);
+  }, [user, authLoading, hasRecommended, doRecommend]);
 
-  // When user signs in (from auth step), advance to form
+  // When user signs in from auth step, go back to idle
   useEffect(() => {
     if (user && step === "auth") {
-      checkExisting();
+      setStep("idle");
+      // Check pending action
+      const params = new URLSearchParams(window.location.search);
+      if (params.get("action") === "recommend" && !pendingActionFired.current) {
+        pendingActionFired.current = true;
+        doRecommend();
+      }
     }
-  }, [user, step, checkExisting]);
+  }, [user, step, doRecommend]);
 
-  /** Remove ?action=recommend from URL without triggering navigation */
   function clearActionParam() {
     const url = new URL(window.location.href);
     url.searchParams.delete("action");
     window.history.replaceState({}, "", url.pathname + url.search);
   }
 
-  function handleCta() {
+  function handleRecommendClick() {
     if (authLoading) return;
-    if (user) {
-      checkExisting();
-    } else {
+    if (!user) {
       // Set pending-action param so intent survives the auth flow
       const url = new URL(window.location.href);
       url.searchParams.set("action", "recommend");
       window.history.replaceState({}, "", url.pathname + url.search);
       setStep("auth");
+      return;
     }
+    doRecommend();
   }
 
   function togglePrompt(key: string) {
@@ -98,7 +172,11 @@ export function RecommendationFlow({ resourceSlug, resourceTitle }: Recommendati
       const next = new Set(prev);
       if (next.has(key)) {
         next.delete(key);
-        setValues((v) => { const copy = { ...v }; delete copy[key]; return copy; });
+        setValues((v) => {
+          const copy = { ...v };
+          delete copy[key];
+          return copy;
+        });
       } else {
         next.add(key);
       }
@@ -110,7 +188,7 @@ export function RecommendationFlow({ resourceSlug, resourceTitle }: Recommendati
     setValues((prev) => ({ ...prev, [key]: value }));
   }
 
-  async function handleSubmit() {
+  async function handleTestimonySubmit() {
     setSubmitting(true);
     setErrorMsg(null);
     try {
@@ -126,8 +204,13 @@ export function RecommendationFlow({ resourceSlug, resourceTitle }: Recommendati
       setStep(needsProfile ? "profile" : "success");
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
-      if (msg.includes("banned") || msg.includes("violates row-level security")) {
-        setErrorMsg("Your account has been restricted. Please contact the site administrator.");
+      if (
+        msg.includes("banned") ||
+        msg.includes("violates row-level security")
+      ) {
+        setErrorMsg(
+          "Your account has been restricted. Please contact the site administrator."
+        );
       } else {
         setErrorMsg("Something went wrong. Please try again.");
       }
@@ -136,92 +219,8 @@ export function RecommendationFlow({ resourceSlug, resourceTitle }: Recommendati
     }
   }
 
-  if (step === "cta") {
-    return (
-      <button
-        onClick={handleCta}
-        className="w-full rounded-lg border-2 border-dashed border-terracotta/30 p-6 text-center hover:border-terracotta/60 transition-colors group"
-      >
-        <p className="font-serif text-lg font-medium text-foreground group-hover:text-terracotta transition-colors">
-          Have you read {resourceTitle}?
-        </p>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Share how it impacted your practice
-        </p>
-      </button>
-    );
-  }
-
   if (step === "auth") {
     return <AuthPanel />;
-  }
-
-  if (step === "already-recommended") {
-    return (
-      <div className="rounded-lg border border-border bg-card p-6 text-center">
-        <p className="font-serif text-lg font-medium text-foreground">
-          You&apos;ve already recommended this resource
-        </p>
-        <p className="mt-1 text-sm text-muted-foreground">
-          Thank you for sharing your experience
-        </p>
-      </div>
-    );
-  }
-
-  if (step === "form") {
-    return (
-      <div className="rounded-lg border border-border bg-card p-6 space-y-5">
-        <div>
-          <p className="font-serif text-lg font-medium text-foreground">
-            Recommend {resourceTitle}
-          </p>
-          <p className="mt-1 text-sm text-muted-foreground">
-            Choose any prompts that feel relevant — or just submit to recommend it
-          </p>
-        </div>
-
-        <div className="space-y-3">
-          {PROMPTS.map(({ key, label, placeholder }) => (
-            <div key={key}>
-              <button
-                type="button"
-                onClick={() => togglePrompt(key)}
-                className={`w-full text-left rounded-md border px-4 py-3 text-sm transition-colors ${
-                  activePrompts.has(key)
-                    ? "border-terracotta/50 bg-terracotta-light"
-                    : "border-border hover:border-foreground/30"
-                }`}
-              >
-                <span className={activePrompts.has(key) ? "text-foreground font-medium" : "text-muted-foreground"}>
-                  {label}
-                </span>
-              </button>
-              {activePrompts.has(key) && (
-                <textarea
-                  value={values[key] ?? ""}
-                  onChange={(e) => updateValue(key, e.target.value)}
-                  placeholder={placeholder}
-                  rows={3}
-                  maxLength={2000}
-                  className="mt-2 w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-terracotta/40"
-                />
-              )}
-            </div>
-          ))}
-        </div>
-
-        {errorMsg && <p className="text-sm text-destructive">{errorMsg}</p>}
-
-        <button
-          onClick={handleSubmit}
-          disabled={submitting}
-          className="rounded-md bg-terracotta px-5 py-2 text-sm font-medium text-white hover:bg-terracotta/90 disabled:opacity-50 transition-colors"
-        >
-          {submitting ? "Submitting…" : "Recommend this resource"}
-        </button>
-      </div>
-    );
   }
 
   if (step === "profile") {
@@ -233,15 +232,119 @@ export function RecommendationFlow({ resourceSlug, resourceTitle }: Recommendati
     );
   }
 
-  // success
+  if (step === "success") {
+    return (
+      <div className="rounded-lg border border-border bg-card p-6 text-center">
+        <p className="font-serif text-lg font-medium text-foreground">
+          Thank you for your recommendation
+        </p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Your experience helps others find resources that matter
+        </p>
+      </div>
+    );
+  }
+
+  // -- Main recommend-first UI (step === "idle") --
+
   return (
-    <div className="rounded-lg border border-border bg-card p-6 text-center">
-      <p className="font-serif text-lg font-medium text-foreground">
-        Thank you for your recommendation
-      </p>
-      <p className="mt-1 text-sm text-muted-foreground">
-        Your experience helps others find resources that matter
-      </p>
+    <div className="space-y-4">
+      {/* Recommend button with heart + count */}
+      <div className="flex items-center gap-3">
+        <button
+          onClick={handleRecommendClick}
+          disabled={hasRecommended || recommending}
+          aria-label={hasRecommended ? "Recommended" : "Recommend"}
+          className={`inline-flex items-center gap-2 rounded-lg px-4 py-2 text-sm font-medium transition-colors ${
+            hasRecommended
+              ? "bg-terracotta-light text-terracotta cursor-default"
+              : "border border-terracotta/30 text-foreground hover:border-terracotta hover:text-terracotta"
+          } disabled:opacity-100`}
+        >
+          {/* Heart icon */}
+          <svg
+            viewBox="0 0 24 24"
+            className={`h-5 w-5 transition-all duration-300 ${
+              hasRecommended ? "text-terracotta" : "text-muted-foreground"
+            } ${animating ? "scale-125" : "scale-100"}`}
+            fill={hasRecommended ? "currentColor" : "none"}
+            stroke="currentColor"
+            strokeWidth={hasRecommended ? 0 : 2}
+          >
+            <path d="M20.84 4.61a5.5 5.5 0 0 0-7.78 0L12 5.67l-1.06-1.06a5.5 5.5 0 0 0-7.78 7.78l1.06 1.06L12 21.23l7.78-7.78 1.06-1.06a5.5 5.5 0 0 0 0-7.78z" />
+          </svg>
+          <span>{hasRecommended ? "Recommended" : "Recommend"}</span>
+        </button>
+
+        <span
+          className="text-sm text-muted-foreground"
+          data-testid="recommend-count"
+        >
+          {count} {count === 1 ? "recommendation" : "recommendations"}
+        </span>
+      </div>
+
+      {errorMsg && <p className="text-sm text-destructive">{errorMsg}</p>}
+
+      {/* "Want to say why?" testimony prompt */}
+      {hasRecommended && showTestimonyPrompt && step === "idle" && (
+        <div className="rounded-lg border border-border bg-card p-6 space-y-5 animate-in slide-in-from-top-2 duration-300">
+          <div>
+            <p className="font-serif text-lg font-medium text-foreground">
+              Want to say why?
+            </p>
+            <p className="mt-1 text-sm text-muted-foreground">
+              Share what made {resourceTitle} meaningful to you
+            </p>
+          </div>
+
+          <div className="space-y-3">
+            {PROMPTS.map(({ key, label, placeholder }) => (
+              <div key={key}>
+                <button
+                  type="button"
+                  onClick={() => togglePrompt(key)}
+                  className={`w-full text-left rounded-md border px-4 py-3 text-sm transition-colors ${
+                    activePrompts.has(key)
+                      ? "border-terracotta/50 bg-terracotta-light"
+                      : "border-border hover:border-foreground/30"
+                  }`}
+                >
+                  <span
+                    className={
+                      activePrompts.has(key)
+                        ? "text-foreground font-medium"
+                        : "text-muted-foreground"
+                    }
+                  >
+                    {label}
+                  </span>
+                </button>
+                {activePrompts.has(key) && (
+                  <textarea
+                    value={values[key] ?? ""}
+                    onChange={(e) => updateValue(key, e.target.value)}
+                    placeholder={placeholder}
+                    rows={3}
+                    maxLength={2000}
+                    className="mt-2 w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-terracotta/40"
+                  />
+                )}
+              </div>
+            ))}
+          </div>
+
+          {errorMsg && <p className="text-sm text-destructive">{errorMsg}</p>}
+
+          <button
+            onClick={handleTestimonySubmit}
+            disabled={submitting}
+            className="rounded-md bg-terracotta px-5 py-2 text-sm font-medium text-white hover:bg-terracotta/90 disabled:opacity-50 transition-colors"
+          >
+            {submitting ? "Submitting..." : "Share your experience"}
+          </button>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary

- Refactors `RecommendationFlow` from testimony-first to recommend-first UX: one-click heart button with count, optimistic UI, terracotta fill animation
- After recommending, "Want to say why?" testimony form slides in after 300ms delay
- Already-recommended state shows filled heart + disabled button
- Integrates with `?action=recommend` pending-action param for post-auth auto-recommend
- Rollback on error: count reverts, heart unfills, error message shown

Closes #253

## Test plan
- [x] 15 tests covering: button render with count, click fires createRecommendation, optimistic count + rollback, 300ms testimony prompt delay, already-recommended state, pending-action auto-fire, testimony submission, profile completion flow
- [x] Full test suite passes (551/551, pre-existing tradition-map failure unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)