### PR TITLE
Replace four-field testimony form with single textarea

### DIFF
--- a/src/components/__tests__/recommendation-flow.test.tsx
+++ b/src/components/__tests__/recommendation-flow.test.tsx
@@ -305,7 +305,7 @@ describe("RecommendationFlow", () => {
   });
 
   describe("testimony form", () => {
-    it("allows submitting testimony after recommending", async () => {
+    async function openTestimonyForm() {
       currentUser = mockUser;
 
       render(
@@ -329,8 +329,78 @@ describe("RecommendationFlow", () => {
       });
 
       expect(screen.getByText("Want to say why?")).toBeInTheDocument();
+    }
 
-      // Submit testimony without filling prompts
+    it("shows single textarea with placeholder", async () => {
+      await openTestimonyForm();
+
+      const textarea = screen.getByPlaceholderText(
+        "What impact has this had on your practice?"
+      );
+      expect(textarea).toBeInTheDocument();
+      expect(textarea).toHaveAttribute("maxLength", "2000");
+    });
+
+    it("shows character count", async () => {
+      await openTestimonyForm();
+
+      expect(screen.getByText("0/2000")).toBeInTheDocument();
+
+      const textarea = screen.getByPlaceholderText(
+        "What impact has this had on your practice?"
+      );
+      fireEvent.change(textarea, { target: { value: "Great book" } });
+
+      expect(screen.getByText("10/2000")).toBeInTheDocument();
+    });
+
+    it("toggles scaffolding prompts on 'Need help getting started?' click", async () => {
+      await openTestimonyForm();
+
+      // Prompts not visible initially
+      expect(
+        screen.queryByText("How did this resource impact your practice?")
+      ).not.toBeInTheDocument();
+
+      // Click to show
+      fireEvent.click(screen.getByText("Need help getting started?"));
+      expect(
+        screen.getByText("How did this resource impact your practice?")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("What were you going through when you found it?")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Who would benefit most from this?")
+      ).toBeInTheDocument();
+      expect(
+        screen.getByText("Anything else you'd like to share?")
+      ).toBeInTheDocument();
+
+      // Click again to hide
+      fireEvent.click(screen.getByText("Need help getting started?"));
+      expect(
+        screen.queryByText("How did this resource impact your practice?")
+      ).not.toBeInTheDocument();
+    });
+
+    it("disables submit button when textarea is empty", async () => {
+      await openTestimonyForm();
+
+      const submitButton = screen.getByText("Share your experience");
+      expect(submitButton).toBeDisabled();
+    });
+
+    it("submits testimony with single content field", async () => {
+      await openTestimonyForm();
+
+      const textarea = screen.getByPlaceholderText(
+        "What impact has this had on your practice?"
+      );
+      fireEvent.change(textarea, {
+        target: { value: "This book changed my practice deeply." },
+      });
+
       await act(async () => {
         fireEvent.click(screen.getByText("Share your experience"));
       });
@@ -339,10 +409,7 @@ describe("RecommendationFlow", () => {
         expect(createTestimony).toHaveBeenCalledWith({
           user_id: "u1",
           resource_slug: "zen-mind",
-          impact: null,
-          context: null,
-          who_for: null,
-          freeform: null,
+          content: "This book changed my practice deeply.",
         });
       });
 
@@ -377,6 +444,13 @@ describe("RecommendationFlow", () => {
 
       await act(async () => {
         vi.advanceTimersByTime(300);
+      });
+
+      const textarea = screen.getByPlaceholderText(
+        "What impact has this had on your practice?"
+      );
+      fireEvent.change(textarea, {
+        target: { value: "Meaningful experience" },
       });
 
       await act(async () => {

--- a/src/components/recommendation-flow.tsx
+++ b/src/components/recommendation-flow.tsx
@@ -14,29 +14,14 @@ import {
 
 type Step = "idle" | "auth" | "testimony" | "profile" | "success";
 
-const PROMPTS = [
-  {
-    key: "impact" as const,
-    label: "How did this resource impact you?",
-    placeholder: "What shifted for you? What did you understand differently?",
-  },
-  {
-    key: "context" as const,
-    label: "What were you going through at the time?",
-    placeholder: "Helps others in similar situations find this",
-  },
-  {
-    key: "who_for" as const,
-    label: "Who would benefit most from this?",
-    placeholder:
-      'e.g. "Anyone starting a sitting practice" or "People dealing with grief"',
-  },
-  {
-    key: "freeform" as const,
-    label: "Anything else you'd like to share?",
-    placeholder: "An open space for whatever feels relevant",
-  },
+const SCAFFOLD_PROMPTS = [
+  "How did this resource impact your practice?",
+  "What were you going through when you found it?",
+  "Who would benefit most from this?",
+  "Anything else you'd like to share?",
 ];
+
+const MAX_CHARS = 2000;
 
 interface RecommendationFlowProps {
   resourceSlug: string;
@@ -53,8 +38,8 @@ export function RecommendationFlow({
   const [count, setCount] = useState(0);
   const [recommending, setRecommending] = useState(false);
   const [showTestimonyPrompt, setShowTestimonyPrompt] = useState(false);
-  const [activePrompts, setActivePrompts] = useState<Set<string>>(new Set());
-  const [values, setValues] = useState<Record<string, string>>({});
+  const [showScaffolding, setShowScaffolding] = useState(false);
+  const [content, setContent] = useState("");
   const [submitting, setSubmitting] = useState(false);
   const [needsProfile, setNeedsProfile] = useState(false);
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
@@ -167,38 +152,15 @@ export function RecommendationFlow({
     doRecommend();
   }
 
-  function togglePrompt(key: string) {
-    setActivePrompts((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) {
-        next.delete(key);
-        setValues((v) => {
-          const copy = { ...v };
-          delete copy[key];
-          return copy;
-        });
-      } else {
-        next.add(key);
-      }
-      return next;
-    });
-  }
-
-  function updateValue(key: string, value: string) {
-    setValues((prev) => ({ ...prev, [key]: value }));
-  }
-
   async function handleTestimonySubmit() {
+    if (!content.trim()) return;
     setSubmitting(true);
     setErrorMsg(null);
     try {
       await createTestimony({
         user_id: user!.id,
         resource_slug: resourceSlug,
-        impact: values.impact || null,
-        context: values.context || null,
-        who_for: values.who_for || null,
-        freeform: values.freeform || null,
+        content: content.trim(),
       });
       clearActionParam();
       setStep(needsProfile ? "profile" : "success");
@@ -298,47 +260,42 @@ export function RecommendationFlow({
             </p>
           </div>
 
-          <div className="space-y-3">
-            {PROMPTS.map(({ key, label, placeholder }) => (
-              <div key={key}>
-                <button
-                  type="button"
-                  onClick={() => togglePrompt(key)}
-                  className={`w-full text-left rounded-md border px-4 py-3 text-sm transition-colors ${
-                    activePrompts.has(key)
-                      ? "border-terracotta/50 bg-terracotta-light"
-                      : "border-border hover:border-foreground/30"
-                  }`}
-                >
-                  <span
-                    className={
-                      activePrompts.has(key)
-                        ? "text-foreground font-medium"
-                        : "text-muted-foreground"
-                    }
-                  >
-                    {label}
-                  </span>
-                </button>
-                {activePrompts.has(key) && (
-                  <textarea
-                    value={values[key] ?? ""}
-                    onChange={(e) => updateValue(key, e.target.value)}
-                    placeholder={placeholder}
-                    rows={3}
-                    maxLength={2000}
-                    className="mt-2 w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-terracotta/40"
-                  />
-                )}
-              </div>
-            ))}
+          <div className="space-y-2">
+            <textarea
+              value={content}
+              onChange={(e) => setContent(e.target.value.slice(0, MAX_CHARS))}
+              placeholder="What impact has this had on your practice?"
+              rows={5}
+              maxLength={MAX_CHARS}
+              className="w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-terracotta/40 resize-y"
+            />
+            <div className="flex items-center justify-between">
+              <button
+                type="button"
+                onClick={() => setShowScaffolding((prev) => !prev)}
+                className="text-xs text-muted-foreground/70 hover:text-muted-foreground transition-colors underline decoration-dotted underline-offset-2"
+              >
+                Need help getting started?
+              </button>
+              <span className="text-xs text-muted-foreground/60 tabular-nums">
+                {content.length}/{MAX_CHARS}
+              </span>
+            </div>
           </div>
+
+          {showScaffolding && (
+            <ul className="space-y-1 pl-4 text-xs text-muted-foreground/70 italic list-disc animate-in fade-in duration-200">
+              {SCAFFOLD_PROMPTS.map((prompt) => (
+                <li key={prompt}>{prompt}</li>
+              ))}
+            </ul>
+          )}
 
           {errorMsg && <p className="text-sm text-destructive">{errorMsg}</p>}
 
           <button
             onClick={handleTestimonySubmit}
-            disabled={submitting}
+            disabled={submitting || !content.trim()}
             className="rounded-md bg-terracotta px-5 py-2 text-sm font-medium text-white hover:bg-terracotta/90 disabled:opacity-50 transition-colors"
           >
             {submitting ? "Submitting..." : "Share your experience"}

--- a/src/lib/__tests__/testimonies.test.ts
+++ b/src/lib/__tests__/testimonies.test.ts
@@ -202,7 +202,7 @@ describe("testimonies", () => {
   });
 
   describe("createTestimony", () => {
-    it("updates an existing recommendation row with testimony text", async () => {
+    it("updates an existing recommendation row with testimony content", async () => {
       const testimony = {
         id: "t1",
         user_id: "u1",
@@ -217,11 +217,11 @@ describe("testimonies", () => {
       const result = await createTestimony({
         user_id: "u1",
         resource_slug: "zen-mind",
-        impact: "Life-changing",
+        content: "Life-changing",
       });
 
       expect(mockFrom).toHaveBeenCalledWith("testimonies");
-      expect(chain.update).toHaveBeenCalledWith({ impact: "Life-changing" });
+      expect(chain.update).toHaveBeenCalledWith({ impact: "Life-changing", context: null, who_for: null, freeform: null });
       expect(chain.eq).toHaveBeenCalledWith("user_id", "u1");
       expect(chain.eq).toHaveBeenCalledWith("resource_slug", "zen-mind");
       expect(result).toEqual(testimony);
@@ -232,7 +232,7 @@ describe("testimonies", () => {
       mockFrom.mockReturnValue(chain);
 
       await expect(
-        createTestimony({ user_id: "u1", resource_slug: "zen-mind", impact: "test" })
+        createTestimony({ user_id: "u1", resource_slug: "zen-mind", content: "test" })
       ).rejects.toEqual({ message: "No rows found" });
     });
   });

--- a/src/lib/testimonies.ts
+++ b/src/lib/testimonies.ts
@@ -78,15 +78,12 @@ export async function getRecommendationCount(
 export async function createTestimony(testimony: {
   user_id: string;
   resource_slug: string;
-  impact?: string | null;
-  context?: string | null;
-  who_for?: string | null;
-  freeform?: string | null;
+  content: string;
 }): Promise<Testimony> {
-  const { user_id, resource_slug, ...fields } = testimony;
+  const { user_id, resource_slug, content } = testimony;
   const { data, error } = await supabase
     .from("testimonies")
-    .update(fields)
+    .update({ impact: content, context: null, who_for: null, freeform: null })
     .eq("user_id", user_id)
     .eq("resource_slug", resource_slug)
     .select()


### PR DESCRIPTION
## Summary
- Replaces four separate text fields (impact, context, who_for, freeform) with a single `<textarea>` with 2000-char limit and character count display
- Adds "Need help getting started?" toggle that reveals four bullet-point prompts as writing inspiration (not form fields)
- Updates `createTestimony()` to accept a single `content` string, stored in the `impact` column (pragmatic — no schema change needed for the spike)

Closes #254

## Test plan
- [x] Single textarea renders with correct placeholder
- [x] Character count displays and updates
- [x] "Need help getting started?" toggles scaffolding prompts
- [x] Submit disabled when textarea is empty
- [x] Submit sends single content field to createTestimony
- [x] Profile completion still triggers when profile incomplete
- [x] All 39 tests in changed files pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)