### PR TITLE
feat: content manifest + /lookup for agent workflows

### DIFF
--- a/.claude/commands/lookup.md
+++ b/.claude/commands/lookup.md
@@ -1,0 +1,19 @@
+Look up whether a person, tradition, practice, concept, or text exists on lineage.guide.
+
+Read `data/manifest.json` and search across all entity types for "$ARGUMENTS".
+
+Search these fields:
+- **traditions**: name, alternate_names, key_figures, key_texts, related_practices
+- **teachers**: name
+- **centers**: name
+- **resources**: title, author
+- **paths**: title
+
+Use case-insensitive substring matching. Report:
+1. **Exact matches** — entities whose name/title matches the query
+2. **Mentioned in** — entities that reference the query in related fields (key_figures, key_texts, etc.)
+3. **Not found** — if nothing matches, say so and suggest whether to add it
+
+For each match, show: entity type, slug, name, and the file path (`data/{type}/{slug}.json` or `.mdx`).
+
+If manifest.json is missing or stale, run `npx tsx scripts/generate-manifest.ts` first.

--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,0 +1,17854 @@
+{
+  "generated_at": "2026-04-22T21:30:25.028Z",
+  "counts": {
+    "traditions": 29,
+    "teachers": 137,
+    "centers": 80,
+    "resources": 1156,
+    "paths": 11
+  },
+  "traditions": [
+    {
+      "slug": "advaita-vedanta",
+      "name": "Advaita Vedanta",
+      "family": "Vedic-Yogic",
+      "alternate_names": [
+        "Non-dual Vedanta",
+        "Advaita"
+      ],
+      "key_figures": [
+        "Adi Shankara (788–820 CE)",
+        "Ramana Maharshi (1879–1950)",
+        "Nisargadatta Maharaj (1897–1981)"
+      ],
+      "key_texts": [
+        "Upanishads",
+        "Brahma Sutras",
+        "Bhagavad Gita",
+        "Vivekachudamani",
+        "Ashtavakra Gita"
+      ],
+      "related_practices": [
+        "self-inquiry (atma vichara)",
+        "shravana (hearing)",
+        "manana (reflection)",
+        "nididhyasana (contemplative meditation)",
+        "three states analysis"
+      ],
+      "connected_traditions": [
+        "vedanta",
+        "kashmir-shaivism",
+        "dzogchen",
+        "modern-non-dual",
+        "bhakti",
+        "classical-yoga"
+      ]
+    },
+    {
+      "slug": "bhakti",
+      "name": "Bhakti",
+      "family": "Vedic-Yogic",
+      "alternate_names": [
+        "Bhakti Yoga",
+        "Devotional Hinduism"
+      ],
+      "key_figures": [
+        "The Alvars (Tamil Vishnu poet-saints)",
+        "The Nayanars (Tamil Shiva poet-saints)",
+        "Ramanuja (11th c.)",
+        "Kabir (15th c.)",
+        "Mirabai (16th c.)",
+        "Tukaram (17th c.)"
+      ],
+      "key_texts": [
+        "Bhagavad Gita",
+        "Narada Bhakti Sutras"
+      ],
+      "related_practices": [
+        "kirtan (devotional chanting)",
+        "japa (repetitive prayer)",
+        "puja (worship)",
+        "bhajan (devotional singing)",
+        "pilgrimage"
+      ],
+      "connected_traditions": [
+        "advaita-vedanta",
+        "sufism"
+      ]
+    },
+    {
+      "slug": "chan-buddhism",
+      "name": "Chan Buddhism",
+      "family": "Buddhist",
+      "alternate_names": [
+        "Chán",
+        "Seon (Korean)",
+        "Thien (Vietnamese)"
+      ],
+      "key_figures": [
+        "Bodhidharma (5th–6th c. CE)",
+        "Huineng (638–713)",
+        "Mazu Daoyi (709–788)",
+        "Linji Yixuan (d. 866)"
+      ],
+      "key_texts": [
+        "Platform Sutra of the Sixth Patriarch"
+      ],
+      "related_practices": [
+        "zuochan (seated meditation)",
+        "gongan (koan) practice",
+        "walking meditation",
+        "mindful work"
+      ],
+      "connected_traditions": [
+        "zen",
+        "mahayana",
+        "theravada",
+        "taoism"
+      ]
+    },
+    {
+      "slug": "christian-mysticism",
+      "name": "Christian Mysticism",
+      "family": "Christian Contemplative",
+      "alternate_names": [
+        "Contemplative Christianity"
+      ],
+      "key_figures": [
+        "Evagrius Ponticus (4th c.)",
+        "Pseudo-Dionysius (5th–6th c.)",
+        "Meister Eckhart (13th–14th c.)",
+        "Teresa of Avila (1515–1582)",
+        "John of the Cross (1542–1591)",
+        "Thomas Keating (1923–2018)"
+      ],
+      "key_texts": [
+        "The Cloud of Unknowing (14th c.)",
+        "Interior Castle (Teresa of Avila)",
+        "Dark Night of the Soul (John of the Cross)"
+      ],
+      "related_practices": [
+        "centering prayer",
+        "lectio divina",
+        "contemplative prayer",
+        "apophatic meditation"
+      ],
+      "connected_traditions": [
+        "hesychasm",
+        "quaker-inner-light",
+        "gnosticism"
+      ]
+    },
+    {
+      "slug": "classical-yoga",
+      "name": "Classical Yoga (Patanjali)",
+      "family": "Vedic-Yogic",
+      "alternate_names": [
+        "Raja Yoga",
+        "Ashtanga Yoga (eight-limbed)",
+        "Patanjali's Yoga"
+      ],
+      "key_figures": [
+        "Patanjali (c. 2nd century BCE)"
+      ],
+      "key_texts": [
+        "Yoga Sutras of Patanjali"
+      ],
+      "related_practices": [
+        "asana (posture)",
+        "pranayama (breath control)",
+        "dharana (concentration)",
+        "dhyana (meditation)",
+        "samadhi (absorption)",
+        "pratyahara (sense withdrawal)"
+      ],
+      "connected_traditions": [
+        "advaita-vedanta",
+        "theravada"
+      ]
+    },
+    {
+      "slug": "dzogchen",
+      "name": "Dzogchen",
+      "family": "Buddhist",
+      "alternate_names": [
+        "Great Perfection",
+        "Atiyoga"
+      ],
+      "key_figures": [
+        "Garab Dorje",
+        "Padmasambhava (Guru Rinpoche, 8th c.)",
+        "Vimalamitra (8th c.)",
+        "Longchenpa (1308–1364)",
+        "Jigme Lingpa (1730–1798)"
+      ],
+      "key_texts": [
+        "Seven Treasuries (Longchenpa)",
+        "Longchen Nyingtik (Jigme Lingpa)"
+      ],
+      "related_practices": [
+        "trekchö (cutting through)",
+        "tögal (direct crossing)",
+        "rigpa recognition",
+        "pointing-out instruction (ngo sprod)"
+      ],
+      "connected_traditions": [
+        "zen",
+        "advaita-vedanta",
+        "tantra",
+        "tibetan-buddhism-nyingma",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-gelug"
+      ]
+    },
+    {
+      "slug": "early-buddhism",
+      "name": "Early Buddhism",
+      "family": "Buddhist",
+      "alternate_names": [
+        "Original Buddhism",
+        "Pre-sectarian Buddhism"
+      ],
+      "key_figures": [
+        "Siddhartha Gautama (the Buddha, c. 5th century BCE)"
+      ],
+      "key_texts": [
+        "Pali Canon (Tipitaka)"
+      ],
+      "related_practices": [
+        "mindfulness (satipatthana)",
+        "breath meditation (anapanasati)",
+        "ethical conduct (sila)",
+        "walking meditation"
+      ],
+      "connected_traditions": [
+        "theravada",
+        "mahayana",
+        "jainism",
+        "classical-yoga"
+      ]
+    },
+    {
+      "slug": "gnosticism",
+      "name": "Gnosticism",
+      "family": "Other",
+      "alternate_names": [
+        "Gnostic traditions"
+      ],
+      "key_figures": [
+        "Valentinus (2nd c. CE)",
+        "Basilides (2nd c. CE)"
+      ],
+      "key_texts": [
+        "Gospel of Thomas",
+        "Gospel of Philip",
+        "Apocryphon of John",
+        "Nag Hammadi Library"
+      ],
+      "related_practices": [
+        "contemplative visualization",
+        "soul ascent meditation",
+        "baptism",
+        "sacred meals"
+      ],
+      "connected_traditions": [
+        "christian-mysticism",
+        "kabbalah",
+        "neoplatonism"
+      ]
+    },
+    {
+      "slug": "hesychasm",
+      "name": "Hesychasm",
+      "family": "Christian Contemplative",
+      "alternate_names": [
+        "Hesychast tradition"
+      ],
+      "key_figures": [
+        "Evagrius Ponticus (4th c.)",
+        "John Climacus (7th c.)",
+        "Symeon the New Theologian (10th–11th c.)",
+        "Gregory Palamas (14th c.)"
+      ],
+      "key_texts": [
+        "Philokalia"
+      ],
+      "related_practices": [
+        "Jesus Prayer",
+        "nepsis (watchful attention)",
+        "prayer of the heart",
+        "breath-synchronized prayer"
+      ],
+      "connected_traditions": [
+        "christian-mysticism"
+      ]
+    },
+    {
+      "slug": "jainism",
+      "name": "Jainism",
+      "family": "Other",
+      "alternate_names": [
+        "Jain Dharma"
+      ],
+      "key_figures": [
+        "Mahavira (c. 599–527 BCE)"
+      ],
+      "key_texts": [
+        "Tattvartha Sutra",
+        "Jain Agamas"
+      ],
+      "related_practices": [
+        "dhyana (meditation)",
+        "svadhyaya (self-study)",
+        "ahimsa (non-violence practice)",
+        "ascetic discipline",
+        "kayotsarga (body abandonment meditation)"
+      ],
+      "connected_traditions": [
+        "theravada",
+        "classical-yoga"
+      ]
+    },
+    {
+      "slug": "kabbalah",
+      "name": "Kabbalah",
+      "family": "Other",
+      "alternate_names": [
+        "Jewish Mysticism",
+        "Qabalah"
+      ],
+      "key_figures": [
+        "Moses de Leon (13th c.)",
+        "Rabbi Shimon bar Yochai (2nd c., traditional)",
+        "Isaac Luria (1534–1572)"
+      ],
+      "key_texts": [
+        "Zohar (Book of Splendor)",
+        "Sefer Yetzirah (Book of Creation)"
+      ],
+      "related_practices": [
+        "meditation on the sefirot",
+        "contemplative prayer with kavvanot",
+        "sacred text study",
+        "Tree of Life contemplation"
+      ],
+      "connected_traditions": [
+        "gnosticism",
+        "sufism"
+      ]
+    },
+    {
+      "slug": "kashmir-shaivism",
+      "name": "Kashmir Shaivism",
+      "family": "Vedic-Yogic",
+      "alternate_names": [
+        "Trika Shaivism",
+        "Pratyabhijna (Recognition school)"
+      ],
+      "key_figures": [
+        "Vasugupta (c. 9th c.)",
+        "Somananda",
+        "Utpaladeva",
+        "Abhinavagupta (c. 950–1020 CE)",
+        "Swami Lakshman Joo (1907–1991)"
+      ],
+      "key_texts": [
+        "Shiva Sutras",
+        "Tantraloka (Abhinavagupta)",
+        "Vijnana Bhairava Tantra",
+        "Spanda Karikas"
+      ],
+      "related_practices": [
+        "centering practices (112 meditations)",
+        "mantra",
+        "spanda (vibration awareness)",
+        "pratyabhijna (recognition)",
+        "contemplation of Shiva Sutras"
+      ],
+      "connected_traditions": [
+        "advaita-vedanta",
+        "tantra"
+      ]
+    },
+    {
+      "slug": "mahayana",
+      "name": "Mahayana Buddhism",
+      "family": "Buddhist",
+      "alternate_names": [
+        "Great Vehicle"
+      ],
+      "key_figures": [
+        "Nagarjuna (c. 150–250 CE)"
+      ],
+      "key_texts": [
+        "Heart Sutra",
+        "Lotus Sutra",
+        "Prajnaparamita Sutras"
+      ],
+      "related_practices": [
+        "bodhisattva vows",
+        "sutra study",
+        "devotional practice"
+      ],
+      "connected_traditions": [
+        "early-buddhism",
+        "theravada",
+        "chan-buddhism",
+        "tibetan-buddhism-nyingma",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-gelug",
+        "vajrayana",
+        "zen",
+        "dzogchen"
+      ]
+    },
+    {
+      "slug": "modern-non-dual",
+      "name": "Modern Non-Dual",
+      "family": "Modern Secular",
+      "alternate_names": [
+        "Neo-Advaita",
+        "Direct Path"
+      ],
+      "key_figures": [
+        "Ramana Maharshi (1879–1950)",
+        "Nisargadatta Maharaj (1897–1981)",
+        "Jiddu Krishnamurti (1895–1986)"
+      ],
+      "key_texts": [
+        "I Am That (Nisargadatta Maharaj)",
+        "Be As You Are (David Godman on Ramana Maharshi)"
+      ],
+      "related_practices": [
+        "self-inquiry",
+        "guided meditation on awareness",
+        "direct pointing",
+        "dialogic inquiry (satsang)"
+      ],
+      "connected_traditions": [
+        "advaita-vedanta",
+        "zen",
+        "dzogchen"
+      ]
+    },
+    {
+      "slug": "neoplatonism",
+      "name": "Neoplatonism",
+      "family": "Other",
+      "alternate_names": [
+        "Platonic mysticism"
+      ],
+      "key_figures": [
+        "Plotinus (204–270 CE)",
+        "Porphyry (234–305 CE)",
+        "Pseudo-Dionysius the Areopagite (5th–6th c.)"
+      ],
+      "key_texts": [
+        "Enneads (Plotinus)"
+      ],
+      "related_practices": [
+        "contemplative ascent",
+        "henosis (union with the One)",
+        "philosophical meditation"
+      ],
+      "connected_traditions": [
+        "gnosticism",
+        "christian-mysticism",
+        "sufism",
+        "kabbalah",
+        "hesychasm"
+      ]
+    },
+    {
+      "slug": "quaker-inner-light",
+      "name": "Quaker Inner Light",
+      "family": "Christian Contemplative",
+      "alternate_names": [
+        "Religious Society of Friends",
+        "Quakerism"
+      ],
+      "key_figures": [
+        "George Fox (1624–1691)",
+        "William Penn (1644–1718)"
+      ],
+      "key_texts": [],
+      "related_practices": [
+        "silent worship (Meeting for Worship)",
+        "corporate silence",
+        "waiting for the Spirit"
+      ],
+      "connected_traditions": [
+        "christian-mysticism"
+      ]
+    },
+    {
+      "slug": "secular-mindfulness",
+      "name": "Secular Mindfulness (MBSR)",
+      "family": "Modern Secular",
+      "alternate_names": [
+        "MBSR",
+        "Mindfulness-Based Stress Reduction"
+      ],
+      "key_figures": [
+        "Jon Kabat-Zinn (b. 1944)"
+      ],
+      "key_texts": [
+        "Full Catastrophe Living (Jon Kabat-Zinn)"
+      ],
+      "related_practices": [
+        "body scan meditation",
+        "sitting meditation",
+        "mindful movement",
+        "informal mindfulness",
+        "MBCT (Mindfulness-Based Cognitive Therapy)"
+      ],
+      "connected_traditions": [
+        "theravada",
+        "vipassana-movement",
+        "zen",
+        "classical-yoga"
+      ]
+    },
+    {
+      "slug": "sufism",
+      "name": "Sufism",
+      "family": "Islamic Contemplative",
+      "alternate_names": [
+        "Tasawwuf",
+        "Islamic Mysticism"
+      ],
+      "key_figures": [
+        "Hasan al-Basri (d. 728)",
+        "Rabia al-Adawiyya (d. 801)",
+        "Junayd of Baghdad (d. 910)",
+        "al-Ghazali (1058–1111)",
+        "Ibn Arabi (1165–1240)",
+        "Rumi (1207–1273)",
+        "Awhad al-Din Balyani (13th c.)"
+      ],
+      "key_texts": [
+        "Revival of the Religious Sciences (al-Ghazali)",
+        "Masnavi (Rumi)",
+        "Fusus al-Hikam (Ibn Arabi)",
+        "Know Yourself (Awhad al-Din Balyani)"
+      ],
+      "related_practices": [
+        "dhikr (remembrance of God)",
+        "sama (spiritual listening/whirling)",
+        "muraqaba (meditation)",
+        "devotional poetry"
+      ],
+      "connected_traditions": [
+        "bhakti",
+        "christian-mysticism",
+        "kabbalah",
+        "neoplatonism"
+      ]
+    },
+    {
+      "slug": "tai-chi-qigong",
+      "name": "Tai Chi/Qigong",
+      "family": "Taoist",
+      "alternate_names": [
+        "Taijiquan",
+        "T'ai Chi Ch'uan"
+      ],
+      "key_figures": [
+        "Zhang Sanfeng (traditionally 12th–13th c.)"
+      ],
+      "key_texts": [],
+      "related_practices": [
+        "tai chi forms",
+        "qigong",
+        "breath cultivation",
+        "slow movement meditation"
+      ],
+      "connected_traditions": [
+        "taoism",
+        "classical-yoga"
+      ]
+    },
+    {
+      "slug": "tantra",
+      "name": "Tantra",
+      "family": "Vedic-Yogic",
+      "alternate_names": [
+        "Tantric traditions",
+        "Tantrism"
+      ],
+      "key_figures": [
+        "Abhinavagupta (c. 950–1020 CE)",
+        "Matsyendranath"
+      ],
+      "key_texts": [
+        "Vijñāna Bhairava Tantra",
+        "Kularnava Tantra"
+      ],
+      "related_practices": [
+        "mantra",
+        "yantra and mandala",
+        "mudra",
+        "deity visualization",
+        "subtle body practices (chakras, nadis, kundalini)",
+        "diksha (initiation)"
+      ],
+      "connected_traditions": [
+        "kashmir-shaivism",
+        "dzogchen",
+        "classical-yoga"
+      ]
+    },
+    {
+      "slug": "taoism",
+      "name": "Taoism",
+      "family": "Taoist",
+      "alternate_names": [
+        "Daoism"
+      ],
+      "key_figures": [
+        "Laozi (traditionally 6th c. BCE)",
+        "Zhuangzi (4th c. BCE)"
+      ],
+      "key_texts": [
+        "Tao Te Ching (Laozi)",
+        "Zhuangzi"
+      ],
+      "related_practices": [
+        "zuowang (sitting and forgetting)",
+        "qigong (breath cultivation)",
+        "neidan (internal alchemy)",
+        "meditation"
+      ],
+      "connected_traditions": [
+        "chan-buddhism",
+        "zen",
+        "tai-chi-qigong"
+      ]
+    },
+    {
+      "slug": "theravada",
+      "name": "Theravada Buddhism",
+      "family": "Buddhist",
+      "alternate_names": [
+        "Way of the Elders",
+        "Southern Buddhism",
+        "Pali Buddhism"
+      ],
+      "key_figures": [
+        "Buddhaghosa (5th c. CE)",
+        "Mahinda (3rd c. BCE)",
+        "Ledi Sayadaw (1846–1923)",
+        "Mahasi Sayadaw (1904–1982)"
+      ],
+      "key_texts": [
+        "Pali Canon (Tipitaka)",
+        "Visuddhimagga (Path of Purification)"
+      ],
+      "related_practices": [
+        "vipassana (insight meditation)",
+        "samatha (calm abiding)",
+        "jhana (meditative absorption)",
+        "metta (loving-kindness meditation)",
+        "walking meditation"
+      ],
+      "connected_traditions": [
+        "zen",
+        "vipassana-movement",
+        "secular-mindfulness",
+        "mahayana",
+        "early-buddhism",
+        "jainism"
+      ]
+    },
+    {
+      "slug": "tibetan-buddhism-gelug",
+      "name": "Tibetan Buddhism (Gelug)",
+      "family": "Buddhist",
+      "alternate_names": [
+        "Gelugpa",
+        "Yellow Hat School"
+      ],
+      "key_figures": [
+        "Tsongkhapa (1357–1419)"
+      ],
+      "key_texts": [
+        "Lamrim Chenmo (Great Treatise on the Stages of the Path)"
+      ],
+      "related_practices": [
+        "lamrim (graduated path meditation)",
+        "analytical meditation",
+        "philosophical debate",
+        "Vajrayana deity yoga"
+      ],
+      "connected_traditions": [
+        "mahayana",
+        "vajrayana",
+        "theravada",
+        "dzogchen",
+        "tibetan-buddhism-nyingma",
+        "tibetan-buddhism-kagyu",
+        "classical-yoga"
+      ]
+    },
+    {
+      "slug": "tibetan-buddhism-kagyu",
+      "name": "Tibetan Buddhism (Kagyu)",
+      "family": "Buddhist",
+      "alternate_names": [
+        "Kagyupa",
+        "Oral Lineage",
+        "Whispered Transmission"
+      ],
+      "key_figures": [
+        "Tilopa (988–1069)",
+        "Naropa (1016–1100)",
+        "Marpa (1012–1097)",
+        "Milarepa (1052–1135)",
+        "Gampopa (1079–1153)",
+        "First Karmapa, Düsum Khyenpa (1110–1193)"
+      ],
+      "key_texts": [
+        "Songs of Milarepa",
+        "Jewel Ornament of Liberation (Gampopa)",
+        "Ocean of Definitive Meaning (Ninth Karmapa)"
+      ],
+      "related_practices": [
+        "Mahamudra",
+        "Six Yogas of Naropa (tummo, illusory body, dream yoga, clear light, bardo, phowa)",
+        "guru yoga",
+        "ngöndro (preliminary practices)"
+      ],
+      "connected_traditions": [
+        "mahayana",
+        "vajrayana",
+        "tibetan-buddhism-nyingma",
+        "tibetan-buddhism-gelug",
+        "dzogchen"
+      ]
+    },
+    {
+      "slug": "tibetan-buddhism-nyingma",
+      "name": "Tibetan Buddhism (Nyingma)",
+      "family": "Buddhist",
+      "alternate_names": [
+        "Nyingmapa",
+        "Ancient Ones",
+        "Old Translation School"
+      ],
+      "key_figures": [
+        "Padmasambhava (Guru Rinpoche, 8th c.)",
+        "Vimalamitra (8th c.)",
+        "Yeshe Tsogyal (8th c.)",
+        "Longchenpa (1308–1364)",
+        "Jigme Lingpa (1730–1798)",
+        "Patrul Rinpoche (1808–1887)"
+      ],
+      "key_texts": [
+        "Longchen Nyingtik (Jigme Lingpa)",
+        "Seven Treasuries (Longchenpa)",
+        "Treasury of Precious Qualities (Jigme Lingpa)",
+        "Words of My Perfect Teacher (Patrul Rinpoche)"
+      ],
+      "related_practices": [
+        "Dzogchen (trekchö and tögal)",
+        "deity yoga",
+        "terma (treasure-teaching) revelation",
+        "ngöndro (preliminary practices)",
+        "guru yoga (especially Guru Rinpoche)"
+      ],
+      "connected_traditions": [
+        "mahayana",
+        "vajrayana",
+        "dzogchen",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-gelug",
+        "tantra"
+      ]
+    },
+    {
+      "slug": "vajrayana",
+      "name": "Vajrayana Buddhism",
+      "family": "Buddhist",
+      "alternate_names": [
+        "Diamond Vehicle",
+        "Thunderbolt Vehicle",
+        "Tantric Buddhism"
+      ],
+      "key_figures": [
+        "Tilopa (988–1069)",
+        "Naropa (1016–1100)",
+        "Padmasambhava (8th c.)"
+      ],
+      "key_texts": [
+        "Guhyasamaja Tantra",
+        "Hevajra Tantra"
+      ],
+      "related_practices": [
+        "deity yoga (visualization)",
+        "mantra recitation",
+        "mandala offering",
+        "subtle body practices",
+        "guru yoga"
+      ],
+      "connected_traditions": [
+        "mahayana",
+        "tibetan-buddhism-nyingma",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-gelug",
+        "dzogchen",
+        "tantra",
+        "kashmir-shaivism"
+      ]
+    },
+    {
+      "slug": "vedanta",
+      "name": "Vedanta",
+      "family": "Vedic-Yogic",
+      "alternate_names": [
+        "Uttara Mimamsa"
+      ],
+      "key_figures": [
+        "Shankara (788–820 CE)",
+        "Ramanuja (11th c.)",
+        "Madhva (13th c.)",
+        "Vivekananda (1863–1902)"
+      ],
+      "key_texts": [
+        "Upanishads",
+        "Brahma Sutras",
+        "Bhagavad Gita"
+      ],
+      "related_practices": [
+        "scriptural study",
+        "philosophical inquiry",
+        "meditation on Brahman"
+      ],
+      "connected_traditions": [
+        "advaita-vedanta",
+        "bhakti",
+        "classical-yoga",
+        "kashmir-shaivism",
+        "modern-non-dual",
+        "jainism"
+      ]
+    },
+    {
+      "slug": "vipassana-movement",
+      "name": "Vipassana Movement",
+      "family": "Buddhist",
+      "alternate_names": [
+        "Insight Meditation Movement",
+        "American Vipassana"
+      ],
+      "key_figures": [
+        "Ledi Sayadaw (1846–1923)",
+        "Mahasi Sayadaw (1904–1982)",
+        "S.N. Goenka (1924–2013)",
+        "Joseph Goldstein",
+        "Jack Kornfield",
+        "Sharon Salzberg"
+      ],
+      "key_texts": [
+        "Satipatthana Sutta"
+      ],
+      "related_practices": [
+        "vipassana (insight meditation)",
+        "body scanning",
+        "noting practice",
+        "silent retreat",
+        "walking meditation"
+      ],
+      "connected_traditions": [
+        "theravada",
+        "secular-mindfulness"
+      ]
+    },
+    {
+      "slug": "zen",
+      "name": "Zen",
+      "family": "Buddhist",
+      "alternate_names": [
+        "Chan (Chinese)",
+        "Seon (Korean)",
+        "Thien (Vietnamese)"
+      ],
+      "key_figures": [
+        "Bodhidharma (5th–6th c. CE)",
+        "Huineng (638–713)",
+        "Dogen (1200–1253)",
+        "Eisai (1141–1215)",
+        "Hakuin (1686–1769)",
+        "Shunryu Suzuki (1904–1971)"
+      ],
+      "key_texts": [
+        "Platform Sutra of the Sixth Patriarch",
+        "The Gateless Gate (Mumonkan)",
+        "Blue Cliff Record (Hekiganroku)",
+        "Shobogenzo"
+      ],
+      "related_practices": [
+        "zazen (seated meditation)",
+        "koan practice",
+        "kinhin (walking meditation)",
+        "sesshin (intensive retreat)",
+        "samu (mindful work)",
+        "oryoki (formal eating)"
+      ],
+      "connected_traditions": [
+        "theravada",
+        "dzogchen",
+        "chan-buddhism",
+        "taoism"
+      ]
+    }
+  ],
+  "teachers": [
+    {
+      "slug": "adyashanti",
+      "name": "Adyashanti",
+      "traditions": [
+        "zen",
+        "modern-non-dual",
+        "advaita-vedanta"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "San Jose, California, US"
+    },
+    {
+      "slug": "ah-almaas",
+      "name": "A.H. Almaas",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual",
+        "sufism"
+      ],
+      "centers": [],
+      "living": true,
+      "location": ""
+    },
+    {
+      "slug": "ajahn-chah",
+      "name": "Ajahn Chah",
+      "traditions": [
+        "theravada"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Ubon Ratchathani, Ubon Ratchathani, TH"
+    },
+    {
+      "slug": "ajahn-lee",
+      "name": "Ajahn Lee",
+      "traditions": [
+        "theravada"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Bangkok, Bangkok, TH"
+    },
+    {
+      "slug": "ajahn-pasanno",
+      "name": "Ajahn Pasanno",
+      "traditions": [
+        "theravada"
+      ],
+      "centers": [
+        "abhayagiri-buddhist-monastery"
+      ],
+      "living": true,
+      "location": "Redwood Valley, California, US"
+    },
+    {
+      "slug": "ajahn-sumedho",
+      "name": "Ajahn Sumedho",
+      "traditions": [
+        "theravada"
+      ],
+      "centers": [
+        "abhayagiri-buddhist-monastery"
+      ],
+      "living": true,
+      "location": "Hemel Hempstead, England, UK"
+    },
+    {
+      "slug": "anam-thubten",
+      "name": "Anam Thubten",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "centers": [],
+      "living": true,
+      "location": ""
+    },
+    {
+      "slug": "andrew-holecek",
+      "name": "Andrew Holecek",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "Colorado, US"
+    },
+    {
+      "slug": "angel-kyodo-williams",
+      "name": "angel Kyodo williams",
+      "traditions": [
+        "zen"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "Berkeley, California, US"
+    },
+    {
+      "slug": "anna-douglas",
+      "name": "Anna Douglas",
+      "traditions": [
+        "early-buddhism",
+        "theravada",
+        "vipassana-movement"
+      ],
+      "centers": [
+        "spirit-rock"
+      ],
+      "living": true,
+      "location": ""
+    },
+    {
+      "slug": "annamalai-swami",
+      "name": "Annamalai Swami",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Tiruvannamalai, Tamil Nadu, IN"
+    },
+    {
+      "slug": "anthony-de-mello",
+      "name": "Anthony de Mello",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Pune, Maharashtra, India"
+    },
+    {
+      "slug": "artur-appazov",
+      "name": "Artur Appazov",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "US"
+    },
+    {
+      "slug": "av-neryah",
+      "name": "Av Neryah",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "Unknown, Unknown, US"
+    },
+    {
+      "slug": "ayu-khandro",
+      "name": "Ayu Khandro",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Lhasa, Central Tibet, CN"
+    },
+    {
+      "slug": "ayya-khema",
+      "name": "Ayya Khema",
+      "traditions": [
+        "theravada"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "DE"
+    },
+    {
+      "slug": "b-alan-wallace",
+      "name": "B. Alan Wallace",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "Santa Barbara, California, US"
+    },
+    {
+      "slug": "baizhang-huaihai",
+      "name": "Baizhang Huaihai",
+      "traditions": [
+        "zen",
+        "chan-buddhism"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Nanchang, Jiangxi, CN"
+    },
+    {
+      "slug": "bassui",
+      "name": "Bassui Tokushō",
+      "traditions": [
+        "zen"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Enzan, Yamanashi, JP"
+    },
+    {
+      "slug": "bernie-glassman",
+      "name": "Bernie Glassman",
+      "traditions": [
+        "zen"
+      ],
+      "centers": [
+        "zen-peacemakers"
+      ],
+      "living": false,
+      "location": "Montague, Massachusetts, US"
+    },
+    {
+      "slug": "bhikkhu-bodhi",
+      "name": "Bhikkhu Bodhi",
+      "traditions": [
+        "theravada",
+        "early-buddhism"
+      ],
+      "centers": [
+        "chuang-yen-monastery"
+      ],
+      "living": true,
+      "location": "Carmel, New York, US"
+    },
+    {
+      "slug": "bks-iyengar",
+      "name": "BKS Iyengar",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Pune, Maharashtra, IN"
+    },
+    {
+      "slug": "brother-david-steindl-rast",
+      "name": "Brother David Steindl-Rast",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "centers": [],
+      "living": true,
+      "location": ""
+    },
+    {
+      "slug": "caverly-morgan",
+      "name": "Caverly Morgan",
+      "traditions": [
+        "zen"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "Portland, Oregon, US"
+    },
+    {
+      "slug": "christiane-wolf",
+      "name": "Christiane Wolf",
+      "traditions": [
+        "vipassana-movement",
+        "secular-mindfulness"
+      ],
+      "centers": [
+        "insightla"
+      ],
+      "living": true,
+      "location": "Los Angeles, California, US"
+    },
+    {
+      "slug": "christopher-hareesh-wallis",
+      "name": "Christopher 'Hareesh' Wallis",
+      "traditions": [
+        "tantra",
+        "kashmir-shaivism"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "San Francisco, California, US"
+    },
+    {
+      "slug": "cynthia-bourgeault",
+      "name": "Cynthia Bourgeault",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "centers": [
+        "center-for-action-and-contemplation"
+      ],
+      "living": true,
+      "location": "Eagle Island, Maine, US"
+    },
+    {
+      "slug": "dan-harris",
+      "name": "Dan Harris",
+      "traditions": [
+        "secular-mindfulness",
+        "vipassana-movement"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "New York, New York, US"
+    },
+    {
+      "slug": "daniel-brown",
+      "name": "Daniel P. Brown",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Newton, Massachusetts, US"
+    },
+    {
+      "slug": "david-nichtern",
+      "name": "David Nichtern",
+      "traditions": [
+        "vajrayana"
+      ],
+      "centers": [
+        "shambhala-mountain-center"
+      ],
+      "living": true,
+      "location": "New York, New York, US"
+    },
+    {
+      "slug": "diane-musho-hamilton",
+      "name": "Diane Musho Hamilton",
+      "traditions": [
+        "zen"
+      ],
+      "centers": [],
+      "living": true,
+      "location": ""
+    },
+    {
+      "slug": "dilgo-khyentse-rinpoche",
+      "name": "Dilgo Khyentse Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Thimphu, Thimphu, BT"
+    },
+    {
+      "slug": "donald-rothberg",
+      "name": "Donald Rothberg",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "centers": [
+        "spirit-rock"
+      ],
+      "living": true,
+      "location": "Woodacre, California, US"
+    },
+    {
+      "slug": "dudjom-rinpoche",
+      "name": "Dudjom Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Boudhanath, Bagmati, NP"
+    },
+    {
+      "slug": "dzigar-kongtrul-rinpoche",
+      "name": "Dzigar Kongtrul Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "centers": [
+        "naropa-university"
+      ],
+      "living": true,
+      "location": "Crestone, Colorado, US"
+    },
+    {
+      "slug": "eckhart-tolle",
+      "name": "Eckhart Tolle",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "centers": [],
+      "living": true,
+      "location": ""
+    },
+    {
+      "slug": "eshwar-segobind",
+      "name": "Eshwar Segobind",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "US"
+    },
+    {
+      "slug": "father-thomas-keating",
+      "name": "Thomas Keating",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "centers": [
+        "st-benedicts-monastery-snowmass",
+        "st-josephs-abbey"
+      ],
+      "living": false,
+      "location": "Snowmass, Colorado, US"
+    },
+    {
+      "slug": "fleet-maull",
+      "name": "Fleet Maull",
+      "traditions": [
+        "zen"
+      ],
+      "centers": [],
+      "living": true,
+      "location": ""
+    },
+    {
+      "slug": "gabor-mate",
+      "name": "Gabor Maté",
+      "traditions": [
+        "secular-mindfulness"
+      ],
+      "centers": [
+        "upaya-zen-center"
+      ],
+      "living": true,
+      "location": "Vancouver, British Columbia, CA"
+    },
+    {
+      "slug": "gangaji",
+      "name": "Gangaji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "Ashland, Oregon, US"
+    },
+    {
+      "slug": "geoffrey-shugen-arnold",
+      "name": "Geoffrey Shugen Arnold",
+      "traditions": [
+        "zen"
+      ],
+      "centers": [
+        "zen-mountain-monastery"
+      ],
+      "living": true,
+      "location": "Mt Tremper, New York, US"
+    },
+    {
+      "slug": "george-mumford",
+      "name": "George Mumford",
+      "traditions": [
+        "vipassana-movement",
+        "secular-mindfulness"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "Boston, Massachusetts, US"
+    },
+    {
+      "slug": "gil-fronsdal",
+      "name": "Gil Fronsdal",
+      "traditions": [
+        "theravada",
+        "zen"
+      ],
+      "centers": [
+        "insight-meditation-center"
+      ],
+      "living": true,
+      "location": "Redwood City, California, US"
+    },
+    {
+      "slug": "hafiz",
+      "name": "Hafiz",
+      "traditions": [
+        "sufism"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Shiraz, Fars, IR"
+    },
+    {
+      "slug": "hazrat-inayat-khan",
+      "name": "Hazrat Inayat Khan",
+      "traditions": [
+        "sufism"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Baroda, Gujarat, IN"
+    },
+    {
+      "slug": "hongzhi",
+      "name": "Hongzhi Zhengjue",
+      "traditions": [
+        "zen",
+        "chan-buddhism"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Ningbo, Zhejiang, CN"
+    },
+    {
+      "slug": "ilie-cioara",
+      "name": "Ilie Cioara",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Bucharest, Bucharest, RO"
+    },
+    {
+      "slug": "jack-engler",
+      "name": "Jack Engler",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "centers": [
+        "insight-meditation-society"
+      ],
+      "living": false,
+      "location": "Cambridge, Massachusetts, US"
+    },
+    {
+      "slug": "jack-kornfield",
+      "name": "Jack Kornfield",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "centers": [
+        "spirit-rock",
+        "insight-meditation-society"
+      ],
+      "living": true,
+      "location": "Woodacre, California, US"
+    },
+    {
+      "slug": "james-finley",
+      "name": "James Finley",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "centers": [
+        "center-for-action-and-contemplation",
+        "abbey-of-gethsemani"
+      ],
+      "living": true,
+      "location": "Santa Monica, California, US"
+    },
+    {
+      "slug": "jan-chozen-bays",
+      "name": "Jan Chozen Bays",
+      "traditions": [
+        "zen"
+      ],
+      "centers": [
+        "great-vow-zen-monastery"
+      ],
+      "living": true,
+      "location": "Clatskanie, Oregon, US"
+    },
+    {
+      "slug": "jean-klein",
+      "name": "Jean Klein",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Santa Barbara, California, US"
+    },
+    {
+      "slug": "jody-hojin-kimmel",
+      "name": "Jody Hojin Kimmel",
+      "traditions": [
+        "zen"
+      ],
+      "centers": [
+        "zen-mountain-monastery"
+      ],
+      "living": true,
+      "location": "Mt Tremper, New York, US"
+    },
+    {
+      "slug": "jon-kabat-zinn",
+      "name": "Jon Kabat-Zinn",
+      "traditions": [
+        "secular-mindfulness",
+        "vipassana-movement",
+        "zen"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "Lexington, Massachusetts, US"
+    },
+    {
+      "slug": "joseph-goldstein",
+      "name": "Joseph Goldstein",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "centers": [
+        "insight-meditation-society"
+      ],
+      "living": true,
+      "location": "Barre, Massachusetts, US"
+    },
+    {
+      "slug": "judith-blackstone",
+      "name": "Judith Blackstone",
+      "traditions": [
+        "modern-non-dual",
+        "advaita-vedanta",
+        "kashmir-shaivism",
+        "zen"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "US"
+    },
+    {
+      "slug": "kabir-helminski",
+      "name": "Kabir Helminski",
+      "traditions": [
+        "sufism"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "Watsonville, California, US"
+    },
+    {
+      "slug": "kaira-jewel-lingo",
+      "name": "Kaira Jewel Lingo",
+      "traditions": [
+        "vipassana-movement",
+        "zen"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "Durham, North Carolina, US"
+    },
+    {
+      "slug": "kavitha-chinnaiyan",
+      "name": "Kavitha Chinnaiyan",
+      "traditions": [
+        "tantra",
+        "kashmir-shaivism",
+        "vedanta"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "Rochester, Michigan, US"
+    },
+    {
+      "slug": "kiran-trace",
+      "name": "Kiran Trace",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "US"
+    },
+    {
+      "slug": "krishna-das",
+      "name": "Krishna Das",
+      "traditions": [
+        "bhakti"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "New York, New York, US"
+    },
+    {
+      "slug": "lama-rod-owens",
+      "name": "Lama Rod Owens",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "Atlanta, Georgia, US"
+    },
+    {
+      "slug": "lama-shabkar",
+      "name": "Lama Shabkar",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Rebkong, Amdo, CN"
+    },
+    {
+      "slug": "lama-surya-das",
+      "name": "Lama Surya Das",
+      "traditions": [
+        "dzogchen"
+      ],
+      "centers": [
+        "dzogchen-center"
+      ],
+      "living": true,
+      "location": "Cambridge, Massachusetts, US"
+    },
+    {
+      "slug": "lama-tsultrim-allione",
+      "name": "Lama Tsultrim Allione",
+      "traditions": [
+        "tibetan-buddhism-nyingma",
+        "tibetan-buddhism-kagyu",
+        "vajrayana"
+      ],
+      "centers": [
+        "tara-mandala"
+      ],
+      "living": true,
+      "location": ""
+    },
+    {
+      "slug": "larry-rosenberg",
+      "name": "Larry Rosenberg",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "centers": [
+        "cambridge-insight-meditation-center",
+        "insight-meditation-society",
+        "insight-meditation-center"
+      ],
+      "living": true,
+      "location": "Cambridge, Massachusetts, US"
+    },
+    {
+      "slug": "llewellyn-vaughan-lee",
+      "name": "Llewellyn Vaughan-Lee",
+      "traditions": [
+        "sufism"
+      ],
+      "centers": [],
+      "living": true,
+      "location": ""
+    },
+    {
+      "slug": "loch-kelly",
+      "name": "Loch Kelly",
+      "traditions": [
+        "dzogchen",
+        "modern-non-dual"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "New York, New York, US"
+    },
+    {
+      "slug": "longchenpa",
+      "name": "Longchenpa",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Gangri Thokar, Central Tibet, CN"
+    },
+    {
+      "slug": "madeline-klyne",
+      "name": "Madeline Klyne",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "centers": [
+        "cambridge-insight-meditation-center",
+        "insight-meditation-center"
+      ],
+      "living": true,
+      "location": "Cambridge, Massachusetts, US"
+    },
+    {
+      "slug": "matthew-fox",
+      "name": "Matthew Fox",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "centers": [],
+      "living": true,
+      "location": ""
+    },
+    {
+      "slug": "meister-eckhart",
+      "name": "Meister Eckhart",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Cologne, North Rhine-Westphalia, DE"
+    },
+    {
+      "slug": "michael-singer",
+      "name": "Michael Singer",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "centers": [
+        "temple-of-the-universe"
+      ],
+      "living": true,
+      "location": "Alachua, Florida, US"
+    },
+    {
+      "slug": "michael-taft",
+      "name": "Michael Taft",
+      "traditions": [
+        "modern-non-dual",
+        "zen",
+        "tantra"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "Berkeley, California, US"
+    },
+    {
+      "slug": "mingyur-rinpoche",
+      "name": "Yongey Mingyur Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma"
+      ],
+      "centers": [
+        "tergar-meditation-community"
+      ],
+      "living": true,
+      "location": "Minneapolis, Minnesota, US"
+    },
+    {
+      "slug": "mirabai-starr",
+      "name": "Mirabai Starr",
+      "traditions": [
+        "christian-mysticism",
+        "sufism"
+      ],
+      "centers": [],
+      "living": true,
+      "location": ""
+    },
+    {
+      "slug": "monshin-nannette-overley",
+      "name": "Monshin Nannette Overley",
+      "traditions": [
+        "zen"
+      ],
+      "centers": [
+        "upaya-zen-center"
+      ],
+      "living": true,
+      "location": "Santa Fe, New Mexico, US"
+    },
+    {
+      "slug": "mooji",
+      "name": "Mooji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "Monte Sahaja, Alentejo, Portugal"
+    },
+    {
+      "slug": "narayan-helen-liebenson",
+      "name": "Narayan Helen Liebenson",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "centers": [
+        "cambridge-insight-meditation-center",
+        "insight-meditation-center",
+        "insight-meditation-society"
+      ],
+      "living": true,
+      "location": "Cambridge, Massachusetts, US"
+    },
+    {
+      "slug": "naropa",
+      "name": "Naropa",
+      "traditions": [
+        "vajrayana"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Nalanda, Bihar, IN"
+    },
+    {
+      "slug": "nisargadatta-maharaj",
+      "name": "Nisargadatta Maharaj",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Mumbai, Maharashtra, IN"
+    },
+    {
+      "slug": "noah-levine",
+      "name": "Noah Levine",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "Los Angeles, California, US"
+    },
+    {
+      "slug": "norman-fischer",
+      "name": "Norman Fischer",
+      "traditions": [
+        "zen"
+      ],
+      "centers": [
+        "san-francisco-zen-center",
+        "green-gulch-farm"
+      ],
+      "living": true,
+      "location": "Muir Beach, California, US"
+    },
+    {
+      "slug": "oren-jay-sofer",
+      "name": "Oren Jay Sofer",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "San Francisco, California, US"
+    },
+    {
+      "slug": "pablo-das",
+      "name": "Pablo Das",
+      "traditions": [
+        "vipassana-movement"
+      ],
+      "centers": [
+        "insightla"
+      ],
+      "living": true,
+      "location": "Los Angeles, California, US"
+    },
+    {
+      "slug": "padmasambhava",
+      "name": "Padmasambhava",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Samye, Central Tibet, CN"
+    },
+    {
+      "slug": "patanjali",
+      "name": "Patanjali",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Unknown, Northern India, IN"
+    },
+    {
+      "slug": "patrul-rinpoche",
+      "name": "Patrul Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Dzachuka, Kham, CN"
+    },
+    {
+      "slug": "pema-chodron",
+      "name": "Pema Chödrön",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu"
+      ],
+      "centers": [
+        "gampo-abbey"
+      ],
+      "living": true,
+      "location": "Pleasant Bay, Nova Scotia, CA"
+    },
+    {
+      "slug": "phillip-moffitt",
+      "name": "Phillip Moffitt",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "centers": [
+        "spirit-rock"
+      ],
+      "living": true,
+      "location": "Marin County, California, US"
+    },
+    {
+      "slug": "ponlop-rinpoche",
+      "name": "Ponlop Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "centers": [],
+      "living": true,
+      "location": ""
+    },
+    {
+      "slug": "ram-dass",
+      "name": "Ram Dass",
+      "traditions": [
+        "bhakti",
+        "vedanta"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Maui, Hawaii, US"
+    },
+    {
+      "slug": "ramana-maharshi",
+      "name": "Ramana Maharshi",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Tiruvannamalai, Tamil Nadu, IN"
+    },
+    {
+      "slug": "ravi-shankar",
+      "name": "Ravi Shankar",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "centers": [],
+      "living": true,
+      "location": ""
+    },
+    {
+      "slug": "richard-rohr",
+      "name": "Richard Rohr",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "centers": [
+        "center-for-action-and-contemplation"
+      ],
+      "living": true,
+      "location": "Albuquerque, New Mexico, US"
+    },
+    {
+      "slug": "rob-burbea",
+      "name": "Rob Burbea",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "centers": [
+        "insight-meditation-society"
+      ],
+      "living": false,
+      "location": "GB"
+    },
+    {
+      "slug": "robert-svoboda",
+      "name": "Robert Svoboda",
+      "traditions": [
+        "tantra",
+        "classical-yoga"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "Albuquerque, New Mexico, US"
+    },
+    {
+      "slug": "robert-thurman",
+      "name": "Robert Thurman",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-gelug"
+      ],
+      "centers": [
+        "tibet-house-us"
+      ],
+      "living": true,
+      "location": "New York, New York, US"
+    },
+    {
+      "slug": "rodney-smith",
+      "name": "Rodney Smith",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "centers": [
+        "seattle-insight-meditation-society",
+        "insight-meditation-society"
+      ],
+      "living": true,
+      "location": "Seattle, Washington, US"
+    },
+    {
+      "slug": "rolf-gates",
+      "name": "Rolf Gates",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "centers": [
+        "kripalu-center"
+      ],
+      "living": true,
+      "location": "Santa Cruz, California, US"
+    },
+    {
+      "slug": "roshi-enkyo-ohara",
+      "name": "Roshi Pat Enkyo O'Hara",
+      "traditions": [
+        "zen"
+      ],
+      "centers": [
+        "village-zendo"
+      ],
+      "living": true,
+      "location": "New York, New York, US"
+    },
+    {
+      "slug": "roshi-joan-halifax",
+      "name": "Roshi Joan Halifax",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "centers": [
+        "upaya-zen-center"
+      ],
+      "living": true,
+      "location": "Santa Fe, New Mexico, US"
+    },
+    {
+      "slug": "roshi-robert-kennedy",
+      "name": "Roshi Robert Kennedy",
+      "traditions": [
+        "zen",
+        "christian-mysticism"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "Jersey City, New Jersey, US"
+    },
+    {
+      "slug": "rumi",
+      "name": "Rumi",
+      "traditions": [
+        "sufism"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Konya, Konya, TR"
+    },
+    {
+      "slug": "rupert-spira",
+      "name": "Rupert Spira",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "Oxford, Oxfordshire, UK"
+    },
+    {
+      "slug": "ryokan",
+      "name": "Ryōkan",
+      "traditions": [
+        "zen"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Izumozaki, Niigata, JP"
+    },
+    {
+      "slug": "sadhguru",
+      "name": "Sadhguru",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "centers": [
+        "isha-institute-of-inner-sciences"
+      ],
+      "living": true,
+      "location": "Coimbatore, Tamil Nadu, IN"
+    },
+    {
+      "slug": "sakyong-mipham",
+      "name": "Sakyong Mipham",
+      "traditions": [
+        "vajrayana"
+      ],
+      "centers": [
+        "shambhala-mountain-center"
+      ],
+      "living": true,
+      "location": "Halifax, Nova Scotia, CA"
+    },
+    {
+      "slug": "sally-kempton",
+      "name": "Sally Kempton",
+      "traditions": [
+        "kashmir-shaivism"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Carmel Valley, California, US"
+    },
+    {
+      "slug": "seng-tsan",
+      "name": "Seng T'san",
+      "traditions": [
+        "zen",
+        "chan-buddhism"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Mount Wangong, Anhui, CN"
+    },
+    {
+      "slug": "sharon-salzberg",
+      "name": "Sharon Salzberg",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "centers": [
+        "insight-meditation-society"
+      ],
+      "living": true,
+      "location": "New York, New York, US"
+    },
+    {
+      "slug": "shinzen-young",
+      "name": "Shinzen Young",
+      "traditions": [
+        "vipassana-movement",
+        "secular-mindfulness",
+        "zen"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "Burlington, Vermont, US"
+    },
+    {
+      "slug": "shunryu-suzuki",
+      "name": "Shunryu Suzuki",
+      "traditions": [
+        "zen"
+      ],
+      "centers": [
+        "san-francisco-zen-center",
+        "tassajara-zen-mountain-center"
+      ],
+      "living": false,
+      "location": "San Francisco, California, US"
+    },
+    {
+      "slug": "spring-washam",
+      "name": "Spring Washam",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "centers": [
+        "east-bay-meditation-center",
+        "spirit-rock"
+      ],
+      "living": true,
+      "location": "Oakland, California, US"
+    },
+    {
+      "slug": "st-teresa-of-avila",
+      "name": "St. Teresa of Avila",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Avila, Castile and León, ES"
+    },
+    {
+      "slug": "stephen-batchelor",
+      "name": "Stephen Batchelor",
+      "traditions": [
+        "secular-mindfulness",
+        "early-buddhism"
+      ],
+      "centers": [
+        "barre-center-for-buddhist-studies"
+      ],
+      "living": true,
+      "location": "Aquitaine, Nouvelle-Aquitaine, France"
+    },
+    {
+      "slug": "swami-sivananda",
+      "name": "Swami Sivananda",
+      "traditions": [
+        "vedanta",
+        "classical-yoga"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Rishikesh, Uttarakhand, IN"
+    },
+    {
+      "slug": "swami-vivekananda",
+      "name": "Swami Vivekananda",
+      "traditions": [
+        "vedanta",
+        "classical-yoga"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Kolkata, West Bengal, IN"
+    },
+    {
+      "slug": "sylvia-boorstein",
+      "name": "Sylvia Boorstein",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "centers": [
+        "spirit-rock",
+        "insight-meditation-society"
+      ],
+      "living": true,
+      "location": "Sonoma County, California, US"
+    },
+    {
+      "slug": "t-krishnamacharya",
+      "name": "T. Krishnamacharya",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Mysore, Karnataka, IN"
+    },
+    {
+      "slug": "tara-brach",
+      "name": "Tara Brach",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "centers": [
+        "insight-meditation-community-of-washington"
+      ],
+      "living": true,
+      "location": "Bethesda, Maryland, US"
+    },
+    {
+      "slug": "tenshin-reb-anderson",
+      "name": "Tenshin Reb Anderson",
+      "traditions": [
+        "zen"
+      ],
+      "centers": [
+        "san-francisco-zen-center"
+      ],
+      "living": true,
+      "location": "San Francisco, California, US"
+    },
+    {
+      "slug": "tenzin-wangyal-rinpoche",
+      "name": "Tenzin Wangyal Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "centers": [
+        "ligmincha-international"
+      ],
+      "living": true,
+      "location": "Charlottesville, Virginia, US"
+    },
+    {
+      "slug": "thich-nhat-hanh",
+      "name": "Thich Nhat Hanh",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "centers": [
+        "deer-park-monastery",
+        "blue-cliff-monastery",
+        "magnolia-grove-monastery"
+      ],
+      "living": false,
+      "location": "Escondido, California, US"
+    },
+    {
+      "slug": "thomas-hubl",
+      "name": "Thomas Hubl",
+      "traditions": [
+        "secular-mindfulness"
+      ],
+      "centers": [],
+      "living": true,
+      "location": ""
+    },
+    {
+      "slug": "tilopa",
+      "name": "Tilopa",
+      "traditions": [
+        "vajrayana"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Nalanda, Bihar, IN"
+    },
+    {
+      "slug": "tina-rasmussen",
+      "name": "Tina Rasmussen",
+      "traditions": [
+        "theravada",
+        "vipassana-movement",
+        "dzogchen"
+      ],
+      "centers": [
+        "spirit-rock"
+      ],
+      "living": true,
+      "location": "US"
+    },
+    {
+      "slug": "trudy-goodman",
+      "name": "Trudy Goodman",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "centers": [
+        "insightla",
+        "insight-meditation-society"
+      ],
+      "living": true,
+      "location": "Los Angeles, California, US"
+    },
+    {
+      "slug": "tsoknyi-rinpoche",
+      "name": "Tsoknyi Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "centers": [],
+      "living": true,
+      "location": ""
+    },
+    {
+      "slug": "tsultrim-allione",
+      "name": "Tsultrim Allione",
+      "traditions": [
+        "vajrayana"
+      ],
+      "centers": [
+        "tara-mandala"
+      ],
+      "living": true,
+      "location": "Pagosa Springs, Colorado, US"
+    },
+    {
+      "slug": "tsultrim-gyamtso-rinpoche",
+      "name": "Tsultrim Gyamtso Rinpoche",
+      "traditions": [
+        "tibetan-buddhism-kagyu",
+        "vajrayana"
+      ],
+      "centers": [],
+      "living": true,
+      "location": ""
+    },
+    {
+      "slug": "tuere-sala",
+      "name": "Tuere Sala",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "centers": [
+        "seattle-insight-meditation-society",
+        "cambridge-insight-meditation-center",
+        "insight-meditation-center",
+        "insight-meditation-society"
+      ],
+      "living": true,
+      "location": "Seattle, Washington, US"
+    },
+    {
+      "slug": "tulku-urgyen-rinpoche",
+      "name": "Tulku Urgyen Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Kathmandu, Bagmati, NP"
+    },
+    {
+      "slug": "victoria-cary",
+      "name": "Victoria Cary",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "centers": [
+        "spirit-rock",
+        "insight-meditation-society"
+      ],
+      "living": true,
+      "location": "San Francisco, California, US"
+    },
+    {
+      "slug": "wes-nisker",
+      "name": "Wes Nisker",
+      "traditions": [
+        "early-buddhism",
+        "theravada",
+        "vipassana-movement"
+      ],
+      "centers": [],
+      "living": true,
+      "location": ""
+    },
+    {
+      "slug": "zenju-earthlyn-manuel",
+      "name": "Zenju Earthlyn Manuel",
+      "traditions": [
+        "zen"
+      ],
+      "centers": [],
+      "living": true,
+      "location": ""
+    }
+  ],
+  "centers": [
+    {
+      "slug": "abbey-of-gethsemani",
+      "name": "Abbey of Gethsemani",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "james-finley"
+      ],
+      "location": "Trappist, Kentucky, US"
+    },
+    {
+      "slug": "abhayagiri-buddhist-monastery",
+      "name": "Abhayagiri Buddhist Monastery",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ajahn-pasanno",
+        "ajahn-sumedho"
+      ],
+      "location": "Redwood Valley, California, US"
+    },
+    {
+      "slug": "atlanta-soto-zen-center",
+      "name": "Atlanta Soto Zen Center",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [],
+      "location": "Atlanta, Georgia, US"
+    },
+    {
+      "slug": "barre-center-for-buddhist-studies",
+      "name": "Barre Center for Buddhist Studies",
+      "traditions": [
+        "theravada",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "stephen-batchelor"
+      ],
+      "location": "Barre, Massachusetts, US"
+    },
+    {
+      "slug": "bhavana-society",
+      "name": "Bhavana Society",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [],
+      "location": "High View, West Virginia, US"
+    },
+    {
+      "slug": "blue-cliff-monastery",
+      "name": "Blue Cliff Monastery",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "teachers": [
+        "thich-nhat-hanh"
+      ],
+      "location": "Pine Bush, New York, US"
+    },
+    {
+      "slug": "boundless-way-zen",
+      "name": "Boundless Way Zen",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [],
+      "location": "Worcester, Massachusetts, US"
+    },
+    {
+      "slug": "california-vipassana-center",
+      "name": "California Vipassana Center",
+      "traditions": [
+        "vipassana-movement"
+      ],
+      "teachers": [],
+      "location": "North Fork, California, US"
+    },
+    {
+      "slug": "cambridge-insight-meditation-center",
+      "name": "Cambridge Insight Meditation Center",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "larry-rosenberg"
+      ],
+      "location": "Cambridge, Massachusetts, US"
+    },
+    {
+      "slug": "center-for-action-and-contemplation",
+      "name": "Center for Action and Contemplation",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "richard-rohr",
+        "cynthia-bourgeault",
+        "james-finley"
+      ],
+      "location": "Albuquerque, New Mexico, US"
+    },
+    {
+      "slug": "chan-meditation-center",
+      "name": "Chan Meditation Center",
+      "traditions": [
+        "chan-buddhism",
+        "mahayana"
+      ],
+      "teachers": [],
+      "location": "Elmhurst, New York, US"
+    },
+    {
+      "slug": "chuang-yen-monastery",
+      "name": "Chuang Yen Monastery",
+      "traditions": [
+        "mahayana"
+      ],
+      "teachers": [
+        "bhikkhu-bodhi"
+      ],
+      "location": "Carmel, New York, US"
+    },
+    {
+      "slug": "city-of-ten-thousand-buddhas",
+      "name": "City of Ten Thousand Buddhas",
+      "traditions": [
+        "chan-buddhism",
+        "mahayana"
+      ],
+      "teachers": [],
+      "location": "Talmage, California, US"
+    },
+    {
+      "slug": "cloud-mountain-retreat-center",
+      "name": "Cloud Mountain Retreat Center",
+      "traditions": [
+        "vipassana-movement",
+        "zen"
+      ],
+      "teachers": [],
+      "location": "Castle Rock, Washington, US"
+    },
+    {
+      "slug": "dai-bosatsu-zendo",
+      "name": "Dai Bosatsu Zendo",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [],
+      "location": "Livingston Manor, New York, US"
+    },
+    {
+      "slug": "deer-park-monastery",
+      "name": "Deer Park Monastery",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "teachers": [
+        "thich-nhat-hanh"
+      ],
+      "location": "Escondido, California, US"
+    },
+    {
+      "slug": "dhamma-dhara",
+      "name": "Dhamma Dhara Vipassana Meditation Center",
+      "traditions": [
+        "vipassana-movement"
+      ],
+      "teachers": [],
+      "location": "Shelburne Falls, Massachusetts, US"
+    },
+    {
+      "slug": "dhamma-patapa",
+      "name": "Southwest Vipassana Meditation Center",
+      "traditions": [
+        "vipassana-movement"
+      ],
+      "teachers": [],
+      "location": "Kaufman, Texas, US"
+    },
+    {
+      "slug": "dharma-ocean-foundation",
+      "name": "Dharma Ocean Foundation",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [],
+      "location": "Crestone, Colorado, US"
+    },
+    {
+      "slug": "dzogchen-center",
+      "name": "Dzogchen Center",
+      "traditions": [
+        "dzogchen"
+      ],
+      "teachers": [
+        "lama-surya-das"
+      ],
+      "location": "Cambridge, Massachusetts, US"
+    },
+    {
+      "slug": "east-bay-meditation-center",
+      "name": "East Bay Meditation Center",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "spring-washam"
+      ],
+      "location": "Oakland, California, US"
+    },
+    {
+      "slug": "esalen-institute",
+      "name": "Esalen Institute",
+      "traditions": [
+        "classical-yoga",
+        "secular-mindfulness"
+      ],
+      "teachers": [],
+      "location": "Big Sur, California, US"
+    },
+    {
+      "slug": "gampo-abbey",
+      "name": "Gampo Abbey",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "pema-chodron"
+      ],
+      "location": "Pleasant Bay, Nova Scotia, CA"
+    },
+    {
+      "slug": "garrison-institute",
+      "name": "Garrison Institute",
+      "traditions": [
+        "vipassana-movement",
+        "secular-mindfulness"
+      ],
+      "teachers": [],
+      "location": "Garrison, New York, US"
+    },
+    {
+      "slug": "great-vow-zen-monastery",
+      "name": "Great Vow Zen Monastery",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "jan-chozen-bays"
+      ],
+      "location": "Clatskanie, Oregon, US"
+    },
+    {
+      "slug": "green-gulch-farm",
+      "name": "Green Gulch Farm Zen Center",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "norman-fischer"
+      ],
+      "location": "Muir Beach, California, US"
+    },
+    {
+      "slug": "holy-cross-monastery",
+      "name": "Holy Cross Monastery",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [],
+      "location": "West Park, New York, US"
+    },
+    {
+      "slug": "hsi-lai-temple",
+      "name": "Hsi Lai Temple",
+      "traditions": [
+        "mahayana",
+        "chan-buddhism"
+      ],
+      "teachers": [],
+      "location": "Hacienda Heights, California, US"
+    },
+    {
+      "slug": "insight-meditation-center",
+      "name": "Insight Meditation Center",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "gil-fronsdal"
+      ],
+      "location": "Redwood City, California, US"
+    },
+    {
+      "slug": "insight-meditation-community-of-washington",
+      "name": "Insight Meditation Community of Washington",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "tara-brach"
+      ],
+      "location": "Bethesda, Maryland, US"
+    },
+    {
+      "slug": "insight-meditation-society",
+      "name": "Insight Meditation Society",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "joseph-goldstein",
+        "sharon-salzberg",
+        "jack-kornfield",
+        "sylvia-boorstein",
+        "larry-rosenberg",
+        "jack-engler",
+        "rob-burbea"
+      ],
+      "location": "Barre, Massachusetts, US"
+    },
+    {
+      "slug": "insightla",
+      "name": "InsightLA",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "trudy-goodman",
+        "christiane-wolf"
+      ],
+      "location": "Los Angeles, California, US"
+    },
+    {
+      "slug": "integral-yoga-institute-new-york",
+      "name": "Integral Yoga Institute New York",
+      "traditions": [
+        "classical-yoga",
+        "bhakti"
+      ],
+      "teachers": [],
+      "location": "New York, New York, US"
+    },
+    {
+      "slug": "isha-institute-of-inner-sciences",
+      "name": "Isha Institute of Inner-Sciences",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "sadhguru"
+      ],
+      "location": "McMinnville, Tennessee, US"
+    },
+    {
+      "slug": "kadampa-center-raleigh",
+      "name": "Kadampa Center",
+      "traditions": [
+        "tibetan-buddhism-gelug"
+      ],
+      "teachers": [],
+      "location": "Raleigh, North Carolina, US"
+    },
+    {
+      "slug": "kadampa-meditation-center-new-york",
+      "name": "Kadampa Meditation Center New York",
+      "traditions": [
+        "tibetan-buddhism-gelug"
+      ],
+      "teachers": [],
+      "location": "Glen Spey, New York, US"
+    },
+    {
+      "slug": "karme-choling",
+      "name": "Karme Choling",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [],
+      "location": "Barnet, Vermont, US"
+    },
+    {
+      "slug": "kripalu-center",
+      "name": "Kripalu Center for Yoga and Health",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "rolf-gates"
+      ],
+      "location": "Stockbridge, Massachusetts, US"
+    },
+    {
+      "slug": "land-of-medicine-buddha",
+      "name": "Land of Medicine Buddha",
+      "traditions": [
+        "tibetan-buddhism-gelug"
+      ],
+      "teachers": [],
+      "location": "Soquel, California, US"
+    },
+    {
+      "slug": "ligmincha-international",
+      "name": "Ligmincha International",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tenzin-wangyal-rinpoche"
+      ],
+      "location": "Charlottesville, Virginia, US"
+    },
+    {
+      "slug": "magnolia-grove-monastery",
+      "name": "Magnolia Grove Monastery",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "teachers": [
+        "thich-nhat-hanh"
+      ],
+      "location": "Batesville, Mississippi, US"
+    },
+    {
+      "slug": "metta-forest-monastery",
+      "name": "Metta Forest Monastery",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [],
+      "location": "Valley Center, California, US"
+    },
+    {
+      "slug": "minnesota-zen-meditation-center",
+      "name": "Minnesota Zen Meditation Center",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [],
+      "location": "Minneapolis, Minnesota, US"
+    },
+    {
+      "slug": "monastery-of-the-holy-spirit",
+      "name": "Monastery of the Holy Spirit",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [],
+      "location": "Conyers, Georgia, US"
+    },
+    {
+      "slug": "mount-baldy-zen-center",
+      "name": "Mt. Baldy Zen Center",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [],
+      "location": "Mt. Baldy, California, US"
+    },
+    {
+      "slug": "mount-madonna-center",
+      "name": "Mount Madonna Center",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [],
+      "location": "Watsonville, California, US"
+    },
+    {
+      "slug": "naropa-university",
+      "name": "Naropa University",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "dzigar-kongtrul-rinpoche"
+      ],
+      "location": "Boulder, Colorado, US"
+    },
+    {
+      "slug": "new-camaldoli-hermitage",
+      "name": "New Camaldoli Hermitage",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [],
+      "location": "Big Sur, California, US"
+    },
+    {
+      "slug": "new-york-insight",
+      "name": "New York Insight Meditation Center",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [],
+      "location": "New York, New York, US"
+    },
+    {
+      "slug": "omega-institute",
+      "name": "Omega Institute for Holistic Studies",
+      "traditions": [
+        "classical-yoga",
+        "vipassana-movement",
+        "secular-mindfulness"
+      ],
+      "teachers": [],
+      "location": "Rhinebeck, New York, US"
+    },
+    {
+      "slug": "pendle-hill",
+      "name": "Pendle Hill",
+      "traditions": [
+        "quaker-inner-light"
+      ],
+      "teachers": [],
+      "location": "Wallingford, Pennsylvania, US"
+    },
+    {
+      "slug": "providence-zen-center",
+      "name": "Providence Zen Center",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [],
+      "location": "Cumberland, Rhode Island, US"
+    },
+    {
+      "slug": "rinzai-ji-zen-center",
+      "name": "Rinzai-ji Zen Center",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [],
+      "location": "Los Angeles, California, US"
+    },
+    {
+      "slug": "rochester-zen-center",
+      "name": "Rochester Zen Center",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [],
+      "location": "Rochester, New York, US"
+    },
+    {
+      "slug": "san-francisco-zen-center",
+      "name": "San Francisco Zen Center",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "shunryu-suzuki",
+        "norman-fischer",
+        "tenshin-reb-anderson"
+      ],
+      "location": "San Francisco, California, US"
+    },
+    {
+      "slug": "satchidananda-ashram-yogaville",
+      "name": "Satchidananda Ashram - Yogaville",
+      "traditions": [
+        "classical-yoga",
+        "bhakti"
+      ],
+      "teachers": [],
+      "location": "Buckingham, Virginia, US"
+    },
+    {
+      "slug": "seattle-insight-meditation-society",
+      "name": "Seattle Insight Meditation Society",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "rodney-smith"
+      ],
+      "location": "Seattle, Washington, US"
+    },
+    {
+      "slug": "shambhala-mountain-center",
+      "name": "Shambhala Mountain Center",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "sakyong-mipham",
+        "david-nichtern"
+      ],
+      "location": "Red Feather Lakes, Colorado, US"
+    },
+    {
+      "slug": "shoshoni-yoga-retreat",
+      "name": "Shoshoni Yoga Retreat",
+      "traditions": [
+        "classical-yoga",
+        "advaita-vedanta"
+      ],
+      "teachers": [],
+      "location": "Rollinsville, Colorado, US"
+    },
+    {
+      "slug": "sivananda-yoga-ranch",
+      "name": "Sivananda Yoga Ranch",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [],
+      "location": "Woodbourne, New York, US"
+    },
+    {
+      "slug": "sky-lake-lodge",
+      "name": "Sky Lake Lodge",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [],
+      "location": "Rosendale, New York, US"
+    },
+    {
+      "slug": "southern-dharma-retreat-center",
+      "name": "Southern Dharma Retreat Center",
+      "traditions": [
+        "vipassana-movement",
+        "zen",
+        "classical-yoga"
+      ],
+      "teachers": [],
+      "location": "Hot Springs, North Carolina, US"
+    },
+    {
+      "slug": "spirit-rock",
+      "name": "Spirit Rock Meditation Center",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "jack-kornfield",
+        "sylvia-boorstein",
+        "spring-washam",
+        "phillip-moffitt",
+        "anna-douglas",
+        "donald-rothberg"
+      ],
+      "location": "Woodacre, California, US"
+    },
+    {
+      "slug": "st-benedicts-monastery-snowmass",
+      "name": "St. Benedict's Monastery",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "father-thomas-keating"
+      ],
+      "location": "Snowmass, Colorado, US"
+    },
+    {
+      "slug": "st-josephs-abbey",
+      "name": "St. Joseph's Abbey",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "father-thomas-keating"
+      ],
+      "location": "Spencer, Massachusetts, US"
+    },
+    {
+      "slug": "tara-mandala",
+      "name": "Tara Mandala",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "tsultrim-allione"
+      ],
+      "location": "Pagosa Springs, Colorado, US"
+    },
+    {
+      "slug": "tassajara-zen-mountain-center",
+      "name": "Tassajara Zen Mountain Center",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "shunryu-suzuki"
+      ],
+      "location": "Carmel Valley, California, US"
+    },
+    {
+      "slug": "temple-of-the-universe",
+      "name": "Temple of the Universe",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "michael-singer"
+      ],
+      "location": "Alachua, Florida, US"
+    },
+    {
+      "slug": "tergar-meditation-community",
+      "name": "Tergar Meditation Community",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "mingyur-rinpoche"
+      ],
+      "location": "Minneapolis, Minnesota, US"
+    },
+    {
+      "slug": "tibet-house-us",
+      "name": "Tibet House US",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-gelug"
+      ],
+      "teachers": [
+        "robert-thurman"
+      ],
+      "location": "New York, New York, US"
+    },
+    {
+      "slug": "upaya-zen-center",
+      "name": "Upaya Zen Center",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "roshi-joan-halifax"
+      ],
+      "location": "Santa Fe, New Mexico, US"
+    },
+    {
+      "slug": "village-zendo",
+      "name": "Village Zendo",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "roshi-enkyo-ohara"
+      ],
+      "location": "New York, New York, US"
+    },
+    {
+      "slug": "weston-priory",
+      "name": "Weston Priory",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [],
+      "location": "Weston, Vermont, US"
+    },
+    {
+      "slug": "woolman-hill",
+      "name": "Woolman Hill",
+      "traditions": [
+        "quaker-inner-light"
+      ],
+      "teachers": [],
+      "location": "Deerfield, Massachusetts, US"
+    },
+    {
+      "slug": "yokoji-zen-mountain-center",
+      "name": "Yokoji Zen Mountain Center",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [],
+      "location": "Mountain Center, California, US"
+    },
+    {
+      "slug": "zen-center-of-los-angeles",
+      "name": "Zen Center of Los Angeles",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [],
+      "location": "Los Angeles, California, US"
+    },
+    {
+      "slug": "zen-center-of-new-york-city",
+      "name": "Zen Center of New York City",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [],
+      "location": "Brooklyn, New York, US"
+    },
+    {
+      "slug": "zen-center-of-san-diego",
+      "name": "Zen Center of San Diego",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [],
+      "location": "San Diego, California, US"
+    },
+    {
+      "slug": "zen-mountain-monastery",
+      "name": "Zen Mountain Monastery",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [],
+      "location": "Mount Tremper, New York, US"
+    },
+    {
+      "slug": "zen-peacemakers",
+      "name": "Zen Peacemakers",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "bernie-glassman"
+      ],
+      "location": "Montague, Massachusetts, US"
+    }
+  ],
+  "resources": [
+    {
+      "slug": "a-brief-introduction-to-jainism-and-sikhism",
+      "title": "A Brief Introduction to Jainism and Sikhism",
+      "type": "book",
+      "author": "Christopher Partridge",
+      "traditions": [
+        "jainism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "a-path-with-heart",
+      "title": "A Path with Heart",
+      "type": "book",
+      "author": "Jack Kornfield",
+      "traditions": [
+        "vipassana-movement",
+        "theravada"
+      ],
+      "teachers": [
+        "jack-kornfield"
+      ]
+    },
+    {
+      "slug": "a-testament-of-devotion",
+      "title": "A Testament of Devotion",
+      "type": "book",
+      "author": "Thomas R. Kelly",
+      "traditions": [
+        "quaker-inner-light"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "access-to-insight",
+      "title": "Access to Insight",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "advaita-vedanta-stanford-encyclopedia-of-philosophy",
+      "title": "Advaita Vedanta (Stanford Encyclopedia of Philosophy)",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "advaita-vedanta",
+        "vedanta"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "adyashanti-emptiness-dancing",
+      "title": "Emptiness Dancing",
+      "type": "book",
+      "author": "Adyashanti",
+      "traditions": [
+        "zen",
+        "modern-non-dual",
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "adyashanti"
+      ]
+    },
+    {
+      "slug": "adyashanti-falling-into-grace",
+      "title": "Falling into Grace",
+      "type": "book",
+      "author": "Adyashanti",
+      "traditions": [
+        "zen",
+        "modern-non-dual",
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "adyashanti"
+      ]
+    },
+    {
+      "slug": "adyashanti-my-secret-is-silence",
+      "title": "My Secret is Silence",
+      "type": "book",
+      "author": "Adyashanti",
+      "traditions": [
+        "zen",
+        "modern-non-dual",
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "adyashanti"
+      ]
+    },
+    {
+      "slug": "adyashanti-resurrecting-jesus",
+      "title": "Resurrecting Jesus",
+      "type": "book",
+      "author": "Adyashanti",
+      "traditions": [
+        "zen",
+        "modern-non-dual",
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "adyashanti"
+      ]
+    },
+    {
+      "slug": "adyashanti-the-direct-way",
+      "title": "The Direct Way",
+      "type": "book",
+      "author": "Adyashanti",
+      "traditions": [
+        "zen",
+        "modern-non-dual",
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "adyashanti"
+      ]
+    },
+    {
+      "slug": "adyashanti-the-most-important-thing",
+      "title": "The Most Important Thing",
+      "type": "book",
+      "author": "Adyashanti",
+      "traditions": [
+        "zen",
+        "modern-non-dual",
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "adyashanti"
+      ]
+    },
+    {
+      "slug": "adyashanti-true-meditation",
+      "title": "True Meditation",
+      "type": "book",
+      "author": "Adyashanti",
+      "traditions": [
+        "zen",
+        "modern-non-dual",
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "adyashanti"
+      ]
+    },
+    {
+      "slug": "adyashanti",
+      "title": "直捷之道【阿迪亞香提的覺醒課】",
+      "type": "book",
+      "author": "Adyashanti",
+      "traditions": [
+        "zen",
+        "modern-non-dual",
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "adyashanti"
+      ]
+    },
+    {
+      "slug": "allione-feeding-your-demons",
+      "title": "Feeding Your Demons",
+      "type": "book",
+      "author": "Tsultrim Allione",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "tsultrim-allione"
+      ]
+    },
+    {
+      "slug": "allione-il-mandala-femminile",
+      "title": "Il mandala femminile",
+      "type": "book",
+      "author": "Tsultrim Allione",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "tsultrim-allione"
+      ]
+    },
+    {
+      "slug": "allione-kobiety-madrosci",
+      "title": "Kobiety mądrości",
+      "type": "book",
+      "author": "Tsultrim Allione",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "tsultrim-allione"
+      ]
+    },
+    {
+      "slug": "allione-nutri-i-tuoi-demoni",
+      "title": "Nutri i tuoi demoni",
+      "type": "book",
+      "author": "Tsultrim Allione",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "tsultrim-allione"
+      ]
+    },
+    {
+      "slug": "allione-tibets-weise-frauen",
+      "title": "Tibets weise Frauen",
+      "type": "book",
+      "author": "Tsultrim Allione",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "tsultrim-allione"
+      ]
+    },
+    {
+      "slug": "allione-wisdom-rising",
+      "title": "Wisdom Rising",
+      "type": "book",
+      "author": "Lama Tsultrim Allione",
+      "traditions": [
+        "tibetan-buddhism-nyingma",
+        "tibetan-buddhism-kagyu",
+        "vajrayana"
+      ],
+      "teachers": [
+        "lama-tsultrim-allione"
+      ]
+    },
+    {
+      "slug": "allione-women-of-wisdom",
+      "title": "Women of Wisdom",
+      "type": "book",
+      "author": "Tsultrim Allione",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "tsultrim-allione"
+      ]
+    },
+    {
+      "slug": "almaas-brilliancy",
+      "title": "Brilliancy",
+      "type": "book",
+      "author": "A.H. Almaas",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual",
+        "sufism"
+      ],
+      "teachers": [
+        "ah-almaas"
+      ]
+    },
+    {
+      "slug": "almaas-diamond-heart-being-and-the-meaning-of-life",
+      "title": "Diamond Heart: Being and the Meaning of Life",
+      "type": "book",
+      "author": "A.H. Almaas",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual",
+        "sufism"
+      ],
+      "teachers": [
+        "ah-almaas"
+      ]
+    },
+    {
+      "slug": "almaas-diamond-heart-book-three",
+      "title": "Diamond Heart: Book Three",
+      "type": "book",
+      "author": "A.H. Almaas",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual",
+        "sufism"
+      ],
+      "teachers": [
+        "ah-almaas"
+      ]
+    },
+    {
+      "slug": "almaas-diamond-heart-elements-of-the-real-in-man",
+      "title": "Diamond Heart: Elements of the Real in Man",
+      "type": "book",
+      "author": "A.H. Almaas",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual",
+        "sufism"
+      ],
+      "teachers": [
+        "ah-almaas"
+      ]
+    },
+    {
+      "slug": "almaas-diamond-heart-indestructible-innocence",
+      "title": "Diamond Heart: Indestructible Innocence",
+      "type": "book",
+      "author": "A.H. Almaas",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual",
+        "sufism"
+      ],
+      "teachers": [
+        "ah-almaas"
+      ]
+    },
+    {
+      "slug": "almaas-diamond-heart-the-freedom-to-be",
+      "title": "Diamond Heart: The Freedom to Be",
+      "type": "book",
+      "author": "A.H. Almaas",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual",
+        "sufism"
+      ],
+      "teachers": [
+        "ah-almaas"
+      ]
+    },
+    {
+      "slug": "almaas-facets-of-unity",
+      "title": "Facets of Unity",
+      "type": "book",
+      "author": "A.H. Almaas",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual",
+        "sufism"
+      ],
+      "teachers": [
+        "ah-almaas"
+      ]
+    },
+    {
+      "slug": "almaas-keys-to-the-enneagram",
+      "title": "Keys to the Enneagram",
+      "type": "book",
+      "author": "A.H. Almaas",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual",
+        "sufism"
+      ],
+      "teachers": [
+        "ah-almaas"
+      ]
+    },
+    {
+      "slug": "almaas-love-unveiled",
+      "title": "Love Unveiled",
+      "type": "book",
+      "author": "A.H. Almaas",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual",
+        "sufism"
+      ],
+      "teachers": [
+        "ah-almaas"
+      ]
+    },
+    {
+      "slug": "almaas-luminous-night-s-journey",
+      "title": "Luminous Night's Journey",
+      "type": "book",
+      "author": "A.H. Almaas",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual",
+        "sufism"
+      ],
+      "teachers": [
+        "ah-almaas"
+      ]
+    },
+    {
+      "slug": "almaas-nondual-love",
+      "title": "Nondual Love",
+      "type": "book",
+      "author": "A.H. Almaas",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual",
+        "sufism"
+      ],
+      "teachers": [
+        "ah-almaas"
+      ]
+    },
+    {
+      "slug": "almaas-runaway-realization",
+      "title": "Runaway Realization",
+      "type": "book",
+      "author": "A.H. Almaas",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual",
+        "sufism"
+      ],
+      "teachers": [
+        "ah-almaas"
+      ]
+    },
+    {
+      "slug": "almaas-spacecruiser-inquiry",
+      "title": "Spacecruiser Inquiry",
+      "type": "book",
+      "author": "A.H. Almaas",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual",
+        "sufism"
+      ],
+      "teachers": [
+        "ah-almaas"
+      ]
+    },
+    {
+      "slug": "almaas-the-alchemy-of-freedom",
+      "title": "The Alchemy of Freedom",
+      "type": "book",
+      "author": "A.H. Almaas",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual",
+        "sufism"
+      ],
+      "teachers": [
+        "ah-almaas"
+      ]
+    },
+    {
+      "slug": "almaas-the-diamond-approach",
+      "title": "The Diamond Approach",
+      "type": "book",
+      "author": "A.H. Almaas",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual",
+        "sufism"
+      ],
+      "teachers": [
+        "ah-almaas"
+      ]
+    },
+    {
+      "slug": "almaas-the-inner-beloved",
+      "title": "The Inner Beloved",
+      "type": "book",
+      "author": "A.H. Almaas",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual",
+        "sufism"
+      ],
+      "teachers": [
+        "ah-almaas"
+      ]
+    },
+    {
+      "slug": "almaas-the-pearl-beyond-price",
+      "title": "The Pearl Beyond Price",
+      "type": "book",
+      "author": "A.H. Almaas",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual",
+        "sufism"
+      ],
+      "teachers": [
+        "ah-almaas"
+      ]
+    },
+    {
+      "slug": "almaas-the-power-of-divine-eros",
+      "title": "The Power of Divine Eros",
+      "type": "book",
+      "author": "A.H. Almaas",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual",
+        "sufism"
+      ],
+      "teachers": [
+        "ah-almaas"
+      ]
+    },
+    {
+      "slug": "almaas-the-unfolding-now",
+      "title": "The Unfolding Now",
+      "type": "book",
+      "author": "A.H. Almaas",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual",
+        "sufism"
+      ],
+      "teachers": [
+        "ah-almaas"
+      ]
+    },
+    {
+      "slug": "anderson-the-third-turning-of-the-wheel",
+      "title": "The Third Turning of the Wheel",
+      "type": "book",
+      "author": "Tenshin Reb Anderson",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "tenshin-reb-anderson"
+      ]
+    },
+    {
+      "slug": "arnold-o-beautiful-end",
+      "title": "O, Beautiful End",
+      "type": "book",
+      "author": "Geoffrey Shugen Arnold",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "geoffrey-shugen-arnold"
+      ]
+    },
+    {
+      "slug": "avila-autobiography-of-st-teresa-of-avila",
+      "title": "Autobiography of St. Teresa of Avila",
+      "type": "book",
+      "author": "St. Teresa of Avila",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "st-teresa-of-avila"
+      ]
+    },
+    {
+      "slug": "avila-interior-castle-100-copy-collector-s-edition",
+      "title": "Interior Castle (100 Copy Collector's Edition)",
+      "type": "book",
+      "author": "St. Teresa of Avila",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "st-teresa-of-avila"
+      ]
+    },
+    {
+      "slug": "avila-interior-castle-or-the-mansions",
+      "title": "Interior Castle, Or the Mansions",
+      "type": "book",
+      "author": "St. Teresa of Avila",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "st-teresa-of-avila"
+      ]
+    },
+    {
+      "slug": "avila-interior-castle",
+      "title": "Interior Castle",
+      "type": "book",
+      "author": "St. Teresa of Avila",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "st-teresa-of-avila"
+      ]
+    },
+    {
+      "slug": "avila-the-interior-castle-mass-market-paperback",
+      "title": "The Interior Castle (Mass Market Paperback)",
+      "type": "book",
+      "author": "St. Teresa of Avila",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "st-teresa-of-avila"
+      ]
+    },
+    {
+      "slug": "avila-the-interior-castle-or-the-mansions",
+      "title": "The Interior Castle, Or the Mansions",
+      "type": "book",
+      "author": "St. Teresa of Avila",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "st-teresa-of-avila"
+      ]
+    },
+    {
+      "slug": "avila-the-interior-castle-study-edition-second-edition-revised",
+      "title": "The Interior Castle: Study Edition / Second Edition, Revised",
+      "type": "book",
+      "author": "St. Teresa of Avila",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "st-teresa-of-avila"
+      ]
+    },
+    {
+      "slug": "avila-the-letters-of-saint-teresa-of-avila",
+      "title": "The Letters of Saint Teresa of Avila",
+      "type": "book",
+      "author": "St. Teresa of Avila",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "st-teresa-of-avila"
+      ]
+    },
+    {
+      "slug": "avila-the-life-of-st-teresa-of-avila",
+      "title": "The Life of St. Teresa of Avila",
+      "type": "book",
+      "author": "St. Teresa of Avila",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "st-teresa-of-avila"
+      ]
+    },
+    {
+      "slug": "avila-the-life-of-st-teresa-of-jesus",
+      "title": "The Life of St. Teresa of Jesus",
+      "type": "book",
+      "author": "St. Teresa of Avila",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "st-teresa-of-avila"
+      ]
+    },
+    {
+      "slug": "avila-the-way-of-perfection",
+      "title": "The Way of Perfection",
+      "type": "book",
+      "author": "St. Teresa of Avila",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "st-teresa-of-avila"
+      ]
+    },
+    {
+      "slug": "avila-way-of-perfection",
+      "title": "Way of Perfection",
+      "type": "book",
+      "author": "St. Teresa of Avila",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "st-teresa-of-avila"
+      ]
+    },
+    {
+      "slug": "awakening-buddha-within",
+      "title": "Awakening the Buddha Within",
+      "type": "book",
+      "author": "Lama Surya Das",
+      "traditions": [
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "dzogchen"
+      ],
+      "teachers": [
+        "lama-surya-das"
+      ]
+    },
+    {
+      "slug": "awakening-of-the-heart",
+      "title": "Awakening of the Heart",
+      "type": "book",
+      "author": "Thich Nhat Hanh",
+      "traditions": [
+        "mahayana",
+        "zen"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "batchelor-after-buddhism",
+      "title": "After Buddhism",
+      "type": "book",
+      "author": "Stephen Batchelor",
+      "traditions": [
+        "secular-mindfulness",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "stephen-batchelor"
+      ]
+    },
+    {
+      "slug": "batchelor-alone-with-others",
+      "title": "Alone With Others",
+      "type": "book",
+      "author": "Stephen Batchelor",
+      "traditions": [
+        "secular-mindfulness",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "stephen-batchelor"
+      ]
+    },
+    {
+      "slug": "batchelor-buddha-socrates-and-us",
+      "title": "Buddha, Socrates, and Us",
+      "type": "book",
+      "author": "Stephen Batchelor",
+      "traditions": [
+        "secular-mindfulness",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "stephen-batchelor"
+      ]
+    },
+    {
+      "slug": "batchelor-buddhism-without-beliefs",
+      "title": "Buddhism without Beliefs",
+      "type": "book",
+      "author": "Stephen Batchelor",
+      "traditions": [
+        "secular-mindfulness",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "stephen-batchelor"
+      ]
+    },
+    {
+      "slug": "batchelor-collected-wheel-publications-volume-xxi",
+      "title": "Collected Wheel Publications Volume XXI",
+      "type": "book",
+      "author": "Stephen Batchelor",
+      "traditions": [
+        "secular-mindfulness",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "stephen-batchelor"
+      ]
+    },
+    {
+      "slug": "batchelor-confession-of-a-buddhist-atheist",
+      "title": "Confession of a Buddhist Atheist",
+      "type": "book",
+      "author": "Stephen Batchelor",
+      "traditions": [
+        "secular-mindfulness",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "stephen-batchelor"
+      ]
+    },
+    {
+      "slug": "batchelor-living-with-the-devil",
+      "title": "Living with the Devil",
+      "type": "book",
+      "author": "Stephen Batchelor",
+      "traditions": [
+        "secular-mindfulness",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "stephen-batchelor"
+      ]
+    },
+    {
+      "slug": "batchelor-medieval-history-for-dummies",
+      "title": "Medieval History For Dummies",
+      "type": "book",
+      "author": "Stephen Batchelor",
+      "traditions": [
+        "secular-mindfulness",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "stephen-batchelor"
+      ]
+    },
+    {
+      "slug": "batchelor-secular-buddhism",
+      "title": "Secular Buddhism",
+      "type": "book",
+      "author": "Stephen Batchelor",
+      "traditions": [
+        "secular-mindfulness",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "stephen-batchelor"
+      ]
+    },
+    {
+      "slug": "batchelor-the-ancient-greeks-for-dummies",
+      "title": "The Ancient Greeks For Dummies",
+      "type": "book",
+      "author": "Stephen Batchelor",
+      "traditions": [
+        "secular-mindfulness",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "stephen-batchelor"
+      ]
+    },
+    {
+      "slug": "batchelor-the-art-of-solitude",
+      "title": "The Art of Solitude",
+      "type": "book",
+      "author": "Stephen Batchelor",
+      "traditions": [
+        "secular-mindfulness",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "stephen-batchelor"
+      ]
+    },
+    {
+      "slug": "batchelor-the-awakening-of-the-west",
+      "title": "The Awakening of the West",
+      "type": "book",
+      "author": "Stephen Batchelor",
+      "traditions": [
+        "secular-mindfulness",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "stephen-batchelor"
+      ]
+    },
+    {
+      "slug": "batchelor-the-faith-to-doubt",
+      "title": "The Faith to Doubt",
+      "type": "book",
+      "author": "Stephen Batchelor",
+      "traditions": [
+        "secular-mindfulness",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "stephen-batchelor"
+      ]
+    },
+    {
+      "slug": "batchelor-verses-from-the-center",
+      "title": "Verses from the Center",
+      "type": "book",
+      "author": "Stephen Batchelor",
+      "traditions": [
+        "secular-mindfulness",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "stephen-batchelor"
+      ]
+    },
+    {
+      "slug": "batchelor-what-is-this",
+      "title": "What is This?",
+      "type": "book",
+      "author": "Stephen Batchelor",
+      "traditions": [
+        "secular-mindfulness",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "stephen-batchelor"
+      ]
+    },
+    {
+      "slug": "bays-achtsam-durch-den-tag",
+      "title": "Achtsam durch den Tag",
+      "type": "book",
+      "author": "Jan Chozen Bays",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "jan-chozen-bays"
+      ]
+    },
+    {
+      "slug": "bays-comer-atentos-mindful-eating",
+      "title": "Comer atentos (Mindful Eating)",
+      "type": "book",
+      "author": "Jan Chozen Bays",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "jan-chozen-bays"
+      ]
+    },
+    {
+      "slug": "bays-how-to-train-a-wild-elephant",
+      "title": "How to Train a Wild Elephant",
+      "type": "book",
+      "author": "Jan Chozen Bays",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "jan-chozen-bays"
+      ]
+    },
+    {
+      "slug": "bays-jizo-bodhisattva",
+      "title": "Jizo Bodhisattva",
+      "type": "book",
+      "author": "Jan Chozen Bays",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "jan-chozen-bays"
+      ]
+    },
+    {
+      "slug": "bays-manger-en-pleine-conscience",
+      "title": "Manger en pleine conscience",
+      "type": "book",
+      "author": "Jan Chozen Bays",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "jan-chozen-bays"
+      ]
+    },
+    {
+      "slug": "bays-mindful-eating-on-the-go",
+      "title": "Mindful Eating on the Go",
+      "type": "book",
+      "author": "Jan Chozen Bays",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "jan-chozen-bays"
+      ]
+    },
+    {
+      "slug": "bays-mindful-eating",
+      "title": "Mindful Eating",
+      "type": "book",
+      "author": "Jan Chozen Bays",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "jan-chozen-bays"
+      ]
+    },
+    {
+      "slug": "bays-mindful-medicine",
+      "title": "Mindful Medicine",
+      "type": "book",
+      "author": "Jan Chozen Bays",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "jan-chozen-bays"
+      ]
+    },
+    {
+      "slug": "bays-mindfulness-on-the-go-shambhala-pocket-classic",
+      "title": "Mindfulness on the Go (Shambhala Pocket Classic)",
+      "type": "book",
+      "author": "Jan Chozen Bays",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "jan-chozen-bays"
+      ]
+    },
+    {
+      "slug": "bays-mindfulness-on-the-go",
+      "title": "Mindfulness on the Go",
+      "type": "book",
+      "author": "Jan Chozen Bays",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "jan-chozen-bays"
+      ]
+    },
+    {
+      "slug": "bays-reapprendre-a-manger",
+      "title": "Réapprendre à manger",
+      "type": "book",
+      "author": "Jan Chozen Bays",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "jan-chozen-bays"
+      ]
+    },
+    {
+      "slug": "bays-the-vow-powered-life",
+      "title": "The Vow-Powered Life",
+      "type": "book",
+      "author": "Jan Chozen Bays",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "jan-chozen-bays"
+      ]
+    },
+    {
+      "slug": "bdk-tripitaka-digital-archives",
+      "title": "BDK Tripitaka Digital Archives",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "mahayana"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "be-as-you-are",
+      "title": "Be As You Are: The Teachings of Sri Ramana Maharshi",
+      "type": "book",
+      "author": "David Godman",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "be-here-now",
+      "title": "Be Here Now",
+      "type": "book",
+      "author": "Ram Dass",
+      "traditions": [
+        "bhakti",
+        "vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "ram-dass"
+      ]
+    },
+    {
+      "slug": "bhagavad-gita",
+      "title": "The Bhagavad Gita",
+      "type": "book",
+      "author": "Eknath Easwaran",
+      "traditions": [
+        "vedanta",
+        "bhakti",
+        "classical-yoga"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "bhakti-movement-encyclopaedia-britannica",
+      "title": "Bhakti Movement (Encyclopaedia Britannica)",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "bhakti"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "bhakti-yoga",
+      "title": "Bhakti Yoga: Tales and Teachings from the Bhagavata Purana",
+      "type": "book",
+      "author": "Edwin F. Bryant",
+      "traditions": [
+        "bhakti",
+        "vedanta"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "blackstone-belonging-here",
+      "title": "Belonging Here",
+      "type": "book",
+      "author": "Judith Blackstone",
+      "traditions": [
+        "modern-non-dual",
+        "advaita-vedanta",
+        "kashmir-shaivism",
+        "zen"
+      ],
+      "teachers": [
+        "judith-blackstone"
+      ]
+    },
+    {
+      "slug": "blackstone-habita-tu-cuerpo",
+      "title": "Habita tu cuerpo",
+      "type": "book",
+      "author": "Judith Blackstone",
+      "traditions": [
+        "modern-non-dual",
+        "advaita-vedanta",
+        "kashmir-shaivism",
+        "zen"
+      ],
+      "teachers": [
+        "judith-blackstone"
+      ]
+    },
+    {
+      "slug": "blackstone-living-intimately",
+      "title": "Living Intimately",
+      "type": "book",
+      "author": "Judith Blackstone",
+      "traditions": [
+        "modern-non-dual",
+        "advaita-vedanta",
+        "kashmir-shaivism",
+        "zen"
+      ],
+      "teachers": [
+        "judith-blackstone"
+      ]
+    },
+    {
+      "slug": "blackstone-pit-ugensyut-ain",
+      "title": "Pit'ŭgensyut'ain",
+      "type": "book",
+      "author": "Judith Blackstone",
+      "traditions": [
+        "modern-non-dual",
+        "advaita-vedanta",
+        "kashmir-shaivism",
+        "zen"
+      ],
+      "teachers": [
+        "judith-blackstone"
+      ]
+    },
+    {
+      "slug": "blackstone-the-empathic-ground",
+      "title": "The Empathic Ground",
+      "type": "book",
+      "author": "Judith Blackstone",
+      "traditions": [
+        "modern-non-dual",
+        "advaita-vedanta",
+        "kashmir-shaivism",
+        "zen"
+      ],
+      "teachers": [
+        "judith-blackstone"
+      ]
+    },
+    {
+      "slug": "blackstone-the-enlightenment-process",
+      "title": "The Enlightenment Process",
+      "type": "book",
+      "author": "Judith Blackstone",
+      "traditions": [
+        "modern-non-dual",
+        "advaita-vedanta",
+        "kashmir-shaivism",
+        "zen"
+      ],
+      "teachers": [
+        "judith-blackstone"
+      ]
+    },
+    {
+      "slug": "blackstone-the-fullness-of-the-ground",
+      "title": "The Fullness of the Ground",
+      "type": "book",
+      "author": "Judith Blackstone",
+      "traditions": [
+        "modern-non-dual",
+        "advaita-vedanta",
+        "kashmir-shaivism",
+        "zen"
+      ],
+      "teachers": [
+        "judith-blackstone"
+      ]
+    },
+    {
+      "slug": "blackstone-the-intimate-life",
+      "title": "The Intimate Life",
+      "type": "book",
+      "author": "Judith Blackstone",
+      "traditions": [
+        "modern-non-dual",
+        "advaita-vedanta",
+        "kashmir-shaivism",
+        "zen"
+      ],
+      "teachers": [
+        "judith-blackstone"
+      ]
+    },
+    {
+      "slug": "blackstone-the-relevance-of-nondual-realization-for-the-psychotherapeutic-proces",
+      "title": "The Relevance of Nondual Realization for the Psychotherapeutic Process",
+      "type": "book",
+      "author": "Judith Blackstone",
+      "traditions": [
+        "modern-non-dual",
+        "advaita-vedanta",
+        "kashmir-shaivism",
+        "zen"
+      ],
+      "teachers": [
+        "judith-blackstone"
+      ]
+    },
+    {
+      "slug": "blackstone-the-subtle-self",
+      "title": "The Subtle Self",
+      "type": "book",
+      "author": "Judith Blackstone",
+      "traditions": [
+        "modern-non-dual",
+        "advaita-vedanta",
+        "kashmir-shaivism",
+        "zen"
+      ],
+      "teachers": [
+        "judith-blackstone"
+      ]
+    },
+    {
+      "slug": "blackstone-trauma-and-the-unbound-body",
+      "title": "Trauma and the Unbound Body",
+      "type": "book",
+      "author": "Judith Blackstone",
+      "traditions": [
+        "modern-non-dual",
+        "advaita-vedanta",
+        "kashmir-shaivism",
+        "zen"
+      ],
+      "teachers": [
+        "judith-blackstone"
+      ]
+    },
+    {
+      "slug": "blackstone-zen-for-beginners",
+      "title": "Zen For Beginners",
+      "type": "book",
+      "author": "Judith Blackstone",
+      "traditions": [
+        "modern-non-dual",
+        "advaita-vedanta",
+        "kashmir-shaivism",
+        "zen"
+      ],
+      "teachers": [
+        "judith-blackstone"
+      ]
+    },
+    {
+      "slug": "blackstone",
+      "title": "ஜென்",
+      "type": "book",
+      "author": "Judith Blackstone",
+      "traditions": [
+        "modern-non-dual",
+        "advaita-vedanta",
+        "kashmir-shaivism",
+        "zen"
+      ],
+      "teachers": [
+        "judith-blackstone"
+      ]
+    },
+    {
+      "slug": "blue-cliff-record",
+      "title": "Blue Cliff Record",
+      "type": "book",
+      "author": "Thomas Cleary (trans.)",
+      "traditions": [
+        "zen",
+        "chan-buddhism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "bodhi-collected-bodhi-leaves-volume-v",
+      "title": "Collected Bodhi Leaves Volume V",
+      "type": "book",
+      "author": "Bhikkhu Bodhi",
+      "traditions": [
+        "theravada",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "bhikkhu-bodhi"
+      ]
+    },
+    {
+      "slug": "bodhi-collected-wheel-publications-vol-xi",
+      "title": "Collected Wheel Publications Vol. XI",
+      "type": "book",
+      "author": "Bhikkhu Bodhi",
+      "traditions": [
+        "theravada",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "bhikkhu-bodhi"
+      ]
+    },
+    {
+      "slug": "bodhi-collected-wheel-publications-volume-xiv",
+      "title": "Collected Wheel Publications Volume XIV",
+      "type": "book",
+      "author": "Bhikkhu Bodhi",
+      "traditions": [
+        "theravada",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "bhikkhu-bodhi"
+      ]
+    },
+    {
+      "slug": "bodhi-collected-wheel-publications-volume-xix",
+      "title": "Collected Wheel Publications Volume XIX",
+      "type": "book",
+      "author": "Bhikkhu Bodhi",
+      "traditions": [
+        "theravada",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "bhikkhu-bodhi"
+      ]
+    },
+    {
+      "slug": "bodhi-collected-wheel-publications-volume-xvii",
+      "title": "Collected Wheel Publications Volume XVII",
+      "type": "book",
+      "author": "Bhikkhu Bodhi",
+      "traditions": [
+        "theravada",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "bhikkhu-bodhi"
+      ]
+    },
+    {
+      "slug": "bodhi-collected-wheel-publications-volume-xviii",
+      "title": "Collected Wheel Publications Volume XVIII",
+      "type": "book",
+      "author": "Bhikkhu Bodhi",
+      "traditions": [
+        "theravada",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "bhikkhu-bodhi"
+      ]
+    },
+    {
+      "slug": "bodhi-collected-wheel-publications-volume-xxv",
+      "title": "Collected Wheel Publications Volume XXV",
+      "type": "book",
+      "author": "Bhikkhu Bodhi",
+      "traditions": [
+        "theravada",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "bhikkhu-bodhi"
+      ]
+    },
+    {
+      "slug": "bodhi-collected-wheel-publications-volume-xxvi",
+      "title": "Collected Wheel Publications Volume XXVI",
+      "type": "book",
+      "author": "Bhikkhu Bodhi",
+      "traditions": [
+        "theravada",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "bhikkhu-bodhi"
+      ]
+    },
+    {
+      "slug": "bodhi-dhamma-reflections",
+      "title": "Dhamma Reflections",
+      "type": "book",
+      "author": "Bhikkhu Bodhi",
+      "traditions": [
+        "theravada",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "bhikkhu-bodhi"
+      ]
+    },
+    {
+      "slug": "bodhi-investigating-the-dhamma",
+      "title": "Investigating the Dhamma",
+      "type": "book",
+      "author": "Bhikkhu Bodhi",
+      "traditions": [
+        "theravada",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "bhikkhu-bodhi"
+      ]
+    },
+    {
+      "slug": "bodhi-noble-eightfold-path",
+      "title": "Noble Eightfold Path",
+      "type": "book",
+      "author": "Bhikkhu Bodhi",
+      "traditions": [
+        "theravada",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "bhikkhu-bodhi"
+      ]
+    },
+    {
+      "slug": "bodhi-noble-truths-noble-path",
+      "title": "Noble Truths, Noble Path",
+      "type": "book",
+      "author": "Bhikkhu Bodhi",
+      "traditions": [
+        "theravada",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "bhikkhu-bodhi"
+      ]
+    },
+    {
+      "slug": "bodhi-reading-the-buddha-s-discourses-in-pali",
+      "title": "Reading the Buddha's Discourses in Pali",
+      "type": "book",
+      "author": "Bhikkhu Bodhi",
+      "traditions": [
+        "theravada",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "bhikkhu-bodhi"
+      ]
+    },
+    {
+      "slug": "bodhi-the-buddha-and-his-dhamma",
+      "title": "The Buddha and His Dhamma",
+      "type": "book",
+      "author": "Bhikkhu Bodhi",
+      "traditions": [
+        "theravada",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "bhikkhu-bodhi"
+      ]
+    },
+    {
+      "slug": "bodhi-the-noble-eightfold-path",
+      "title": "The Noble Eightfold Path",
+      "type": "book",
+      "author": "Bhikkhu Bodhi",
+      "traditions": [
+        "theravada",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "bhikkhu-bodhi"
+      ]
+    },
+    {
+      "slug": "boorstein-don-t-just-do-something-sit-there",
+      "title": "Don't Just Do Something, Sit There",
+      "type": "book",
+      "author": "Sylvia Boorstein",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "sylvia-boorstein"
+      ]
+    },
+    {
+      "slug": "boorstein-el-secreto-de-la-felicidad-esta-en-tu-interior",
+      "title": "El secreto de la felicidad está en tu interior",
+      "type": "book",
+      "author": "Sylvia Boorstein",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "sylvia-boorstein"
+      ]
+    },
+    {
+      "slug": "boorstein-happiness-is-an-inside-job",
+      "title": "Happiness is an Inside Job",
+      "type": "book",
+      "author": "Sylvia Boorstein",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "sylvia-boorstein"
+      ]
+    },
+    {
+      "slug": "boorstein-making-friends-with-the-present-moment",
+      "title": "Making Friends with the Present Moment",
+      "type": "book",
+      "author": "Sylvia Boorstein",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "sylvia-boorstein"
+      ]
+    },
+    {
+      "slug": "boorstein-nao-faca-nada-so-fique-sentado",
+      "title": "Não faça nada, só fique sentado",
+      "type": "book",
+      "author": "Sylvia Boorstein",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "sylvia-boorstein"
+      ]
+    },
+    {
+      "slug": "boorstein-pay-attention-for-goodness-sake",
+      "title": "Pay Attention, for Goodness' Sake",
+      "type": "book",
+      "author": "Sylvia Boorstein",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "sylvia-boorstein"
+      ]
+    },
+    {
+      "slug": "boorstein-pay-attention-for-goodness-sakes",
+      "title": "Pay Attention, for Goodness' Sakes",
+      "type": "book",
+      "author": "Sylvia Boorstein",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "sylvia-boorstein"
+      ]
+    },
+    {
+      "slug": "boorstein-radical-generosity",
+      "title": "Radical Generosity",
+      "type": "book",
+      "author": "Sylvia Boorstein",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "sylvia-boorstein"
+      ]
+    },
+    {
+      "slug": "boorstein-solid-ground",
+      "title": "Solid Ground",
+      "type": "book",
+      "author": "Sylvia Boorstein",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "sylvia-boorstein"
+      ]
+    },
+    {
+      "slug": "boorstein-that-s-funny-you-don-t-look-buddhist",
+      "title": "That's Funny, You Don't Look Buddhist",
+      "type": "book",
+      "author": "Sylvia Boorstein",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "sylvia-boorstein"
+      ]
+    },
+    {
+      "slug": "boorstein",
+      "title": "快樂佛法書",
+      "type": "book",
+      "author": "Sylvia Boorstein",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "sylvia-boorstein"
+      ]
+    },
+    {
+      "slug": "bourgeault-centering-prayer-and-inner-awakening",
+      "title": "Centering Prayer and Inner Awakening",
+      "type": "book",
+      "author": "Cynthia Bourgeault",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "cynthia-bourgeault"
+      ]
+    },
+    {
+      "slug": "bourgeault-chanting-the-psalms",
+      "title": "Chanting the Psalms",
+      "type": "book",
+      "author": "Cynthia Bourgeault",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "cynthia-bourgeault"
+      ]
+    },
+    {
+      "slug": "bourgeault-eye-of-the-heart",
+      "title": "Eye of the Heart",
+      "type": "book",
+      "author": "Cynthia Bourgeault",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "cynthia-bourgeault"
+      ]
+    },
+    {
+      "slug": "bourgeault-love-is-stronger-than-death",
+      "title": "Love Is Stronger Than Death",
+      "type": "book",
+      "author": "Cynthia Bourgeault",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "cynthia-bourgeault"
+      ]
+    },
+    {
+      "slug": "bourgeault-maria-magdalena",
+      "title": "Maria Magdalena",
+      "type": "book",
+      "author": "Cynthia Bourgeault",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "cynthia-bourgeault"
+      ]
+    },
+    {
+      "slug": "bourgeault-mystical-hope",
+      "title": "Mystical Hope",
+      "type": "book",
+      "author": "Cynthia Bourgeault",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "cynthia-bourgeault"
+      ]
+    },
+    {
+      "slug": "bourgeault-richtig-alt-werden",
+      "title": "Richtig alt werden",
+      "type": "book",
+      "author": "Cynthia Bourgeault",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "cynthia-bourgeault"
+      ]
+    },
+    {
+      "slug": "bourgeault-the-corner-of-fourth-and-nondual",
+      "title": "The Corner of Fourth and Nondual",
+      "type": "book",
+      "author": "Cynthia Bourgeault",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "cynthia-bourgeault"
+      ]
+    },
+    {
+      "slug": "bourgeault-the-heart-of-centering-prayer",
+      "title": "The Heart of Centering Prayer",
+      "type": "book",
+      "author": "Cynthia Bourgeault",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "cynthia-bourgeault"
+      ]
+    },
+    {
+      "slug": "bourgeault-the-holy-trinity-and-the-law-of-three",
+      "title": "The Holy Trinity and the Law of Three",
+      "type": "book",
+      "author": "Cynthia Bourgeault",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "cynthia-bourgeault"
+      ]
+    },
+    {
+      "slug": "bourgeault-the-meaning-of-mary-magdalene",
+      "title": "The Meaning of Mary Magdalene",
+      "type": "book",
+      "author": "Cynthia Bourgeault",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "cynthia-bourgeault"
+      ]
+    },
+    {
+      "slug": "bourgeault-the-wisdom-jesus",
+      "title": "The Wisdom Jesus",
+      "type": "book",
+      "author": "Cynthia Bourgeault",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "cynthia-bourgeault"
+      ]
+    },
+    {
+      "slug": "bourgeault-the-wisdom-way-of-knowing",
+      "title": "The Wisdom Way of Knowing",
+      "type": "book",
+      "author": "Cynthia Bourgeault",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "cynthia-bourgeault"
+      ]
+    },
+    {
+      "slug": "bourgeault-thomas-keating",
+      "title": "Thomas Keating",
+      "type": "book",
+      "author": "Cynthia Bourgeault",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "cynthia-bourgeault"
+      ]
+    },
+    {
+      "slug": "brach-acceptarea-neconditionata",
+      "title": "Acceptarea neconditionata",
+      "type": "book",
+      "author": "Tara Brach",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "tara-brach"
+      ]
+    },
+    {
+      "slug": "brach-aceitacao-radical",
+      "title": "Aceitação Radical",
+      "type": "book",
+      "author": "Tara Brach",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "tara-brach"
+      ]
+    },
+    {
+      "slug": "brach-aceptacion-radical",
+      "title": "Aceptación radical",
+      "type": "book",
+      "author": "Tara Brach",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "tara-brach"
+      ]
+    },
+    {
+      "slug": "brach-compasion-radical",
+      "title": "Compasión radical",
+      "type": "book",
+      "author": "Tara Brach",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "tara-brach"
+      ]
+    },
+    {
+      "slug": "brach-disponibilita-incondizionata-nuova-edizione",
+      "title": "Disponibilità incondizionata. Nuova edizione",
+      "type": "book",
+      "author": "Tara Brach",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "tara-brach"
+      ]
+    },
+    {
+      "slug": "brach-disponibilita-incondizionata",
+      "title": "Disponibilità incondizionata",
+      "type": "book",
+      "author": "Tara Brach",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "tara-brach"
+      ]
+    },
+    {
+      "slug": "brach-het-leven-liefhebben-door-acceptatie",
+      "title": "Het leven liefhebben door acceptatie",
+      "type": "book",
+      "author": "Tara Brach",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "tara-brach"
+      ]
+    },
+    {
+      "slug": "brach-l-acceptation-radicale",
+      "title": "L'acceptation radicale",
+      "type": "book",
+      "author": "Tara Brach",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "tara-brach"
+      ]
+    },
+    {
+      "slug": "brach-radical-compassion",
+      "title": "Radical Compassion",
+      "type": "book",
+      "author": "Tara Brach",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "tara-brach"
+      ]
+    },
+    {
+      "slug": "brach-stol-pa-din-godhed",
+      "title": "Stol på din godhed",
+      "type": "book",
+      "author": "Tara Brach",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "tara-brach"
+      ]
+    },
+    {
+      "slug": "brach-true-refuge",
+      "title": "True Refuge",
+      "type": "book",
+      "author": "Tara Brach",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "tara-brach"
+      ]
+    },
+    {
+      "slug": "brach-trusting-the-gold",
+      "title": "Trusting the Gold",
+      "type": "book",
+      "author": "Tara Brach",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "tara-brach"
+      ]
+    },
+    {
+      "slug": "brach",
+      "title": "全然慈悲這樣的我：透過「認出」「容許」「觀察」「愛的滋養」四步驟練習，脫離自我否定的各種內心戲",
+      "type": "book",
+      "author": "Tara Brach",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "tara-brach"
+      ]
+    },
+    {
+      "slug": "brahma-sutras",
+      "title": "Brahma Sutras",
+      "type": "book",
+      "author": "Badarayana / Shankara (commentary)",
+      "traditions": [
+        "vedanta",
+        "advaita-vedanta"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "breath-by-breath",
+      "title": "Breath by Breath",
+      "type": "book",
+      "author": "Larry Rosenberg",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "gil-fronsdal"
+      ]
+    },
+    {
+      "slug": "brown-attachment-disturbances-in-adults",
+      "title": "Attachment Disturbances in Adults",
+      "type": "book",
+      "author": "Daniel P. Brown",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "daniel-brown"
+      ]
+    },
+    {
+      "slug": "brown-cloudless-mind-volume-ii",
+      "title": "Cloudless Mind- Volume II",
+      "type": "book",
+      "author": "Daniel P. Brown",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "daniel-brown"
+      ]
+    },
+    {
+      "slug": "brown-cloudless-mind-volume-iii",
+      "title": "Cloudless Mind- Volume III",
+      "type": "book",
+      "author": "Daniel P. Brown",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "daniel-brown"
+      ]
+    },
+    {
+      "slug": "brown-cloudless-mind",
+      "title": "Cloudless Mind",
+      "type": "book",
+      "author": "Daniel P. Brown",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "daniel-brown"
+      ]
+    },
+    {
+      "slug": "brown-hypnosis-and-behavioral-medicine",
+      "title": "Hypnosis and Behavioral Medicine",
+      "type": "book",
+      "author": "Daniel P. Brown",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "daniel-brown"
+      ]
+    },
+    {
+      "slug": "brown-pith-instructions-for-a-khrid-rdzogs-chen",
+      "title": "Pith Instructions for A Khrid RDzogs Chen",
+      "type": "book",
+      "author": "Daniel P. Brown",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "daniel-brown"
+      ]
+    },
+    {
+      "slug": "brown-pointing-out-the-great-way",
+      "title": "Pointing Out the Great Way",
+      "type": "book",
+      "author": "Daniel P. Brown",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "daniel-brown"
+      ]
+    },
+    {
+      "slug": "brown-the-elephant-path",
+      "title": "The Elephant Path",
+      "type": "book",
+      "author": "Daniel P. Brown",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "daniel-brown"
+      ]
+    },
+    {
+      "slug": "brown-the-twenty-one-nails",
+      "title": "The Twenty-One Nails",
+      "type": "book",
+      "author": "Daniel P. Brown",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "daniel-brown"
+      ]
+    },
+    {
+      "slug": "buddha-stanford-encyclopedia-of-philosophy",
+      "title": "Buddha (Stanford Encyclopedia of Philosophy)",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "early-buddhism",
+        "theravada"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "burbea-seeing-that-frees",
+      "title": "Seeing That Frees",
+      "type": "book",
+      "author": "Rob Burbea",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "rob-burbea"
+      ]
+    },
+    {
+      "slug": "chah-being-dharma",
+      "title": "Being Dharma",
+      "type": "book",
+      "author": "Ajahn Chah",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ajahn-chah"
+      ]
+    },
+    {
+      "slug": "chah-collected-bodhi-leaves-volume-iv",
+      "title": "Collected Bodhi Leaves Volume IV",
+      "type": "book",
+      "author": "Ajahn Chah",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ajahn-chah"
+      ]
+    },
+    {
+      "slug": "chah-collected-wheel-publications-volume-xxiii",
+      "title": "Collected Wheel Publications Volume XXIII",
+      "type": "book",
+      "author": "Ajahn Chah",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ajahn-chah"
+      ]
+    },
+    {
+      "slug": "chah-etre-ce-qui-est",
+      "title": "Etre ce qui est",
+      "type": "book",
+      "author": "Ajahn Chah",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ajahn-chah"
+      ]
+    },
+    {
+      "slug": "chah-everything-arises-everything-falls-away",
+      "title": "Everything Arises, Everything Falls Away",
+      "type": "book",
+      "author": "Ajahn Chah",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ajahn-chah"
+      ]
+    },
+    {
+      "slug": "chah-hypnose-non-directive-et-vies-anterieures",
+      "title": "Hypnose non directive et vies antérieures",
+      "type": "book",
+      "author": "Ajahn Chah",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ajahn-chah"
+      ]
+    },
+    {
+      "slug": "chah-meditation-et-sagesse",
+      "title": "Méditation et sagesse",
+      "type": "book",
+      "author": "Ajahn Chah",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ajahn-chah"
+      ]
+    },
+    {
+      "slug": "chah-nisala-vila",
+      "title": "Nisala vila",
+      "type": "book",
+      "author": "Ajahn Chah",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ajahn-chah"
+      ]
+    },
+    {
+      "slug": "chah-on-meditation",
+      "title": "On Meditation",
+      "type": "book",
+      "author": "Ajahn Chah",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ajahn-chah"
+      ]
+    },
+    {
+      "slug": "chah-the-collected-teachings-of-ajahn-chah",
+      "title": "The Collected Teachings of Ajahn Chah",
+      "type": "book",
+      "author": "Ajahn Chah",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ajahn-chah"
+      ]
+    },
+    {
+      "slug": "chah-tout-apparait-tout-disparait",
+      "title": "Tout apparaît, tout disparaît",
+      "type": "book",
+      "author": "Ajahn Chah",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ajahn-chah"
+      ]
+    },
+    {
+      "slug": "chah-vertu-et-meditation",
+      "title": "Vertu et méditation",
+      "type": "book",
+      "author": "Ajahn Chah",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ajahn-chah"
+      ]
+    },
+    {
+      "slug": "chah",
+      "title": "阿姜查的禪修世界：戒",
+      "type": "book",
+      "author": "Ajahn Chah",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ajahn-chah"
+      ]
+    },
+    {
+      "slug": "chan-buddhism-buddhistdoor-global",
+      "title": "Chan Buddhism (Buddhistdoor Global)",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "chan-buddhism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "chan-buddhism-stanford-encyclopedia-of-philosophy",
+      "title": "Chan Buddhism (Stanford Encyclopedia of Philosophy)",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "chan-buddhism",
+        "zen"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "chinnaiyan-fractals-of-reality",
+      "title": "Fractals of Reality",
+      "type": "book",
+      "author": "Kavitha Chinnaiyan",
+      "traditions": [
+        "tantra",
+        "kashmir-shaivism",
+        "vedanta"
+      ],
+      "teachers": [
+        "kavitha-chinnaiyan"
+      ]
+    },
+    {
+      "slug": "chinnaiyan-glorious-alchemy",
+      "title": "Glorious Alchemy",
+      "type": "book",
+      "author": "Kavitha Chinnaiyan",
+      "traditions": [
+        "tantra",
+        "kashmir-shaivism",
+        "vedanta"
+      ],
+      "teachers": [
+        "kavitha-chinnaiyan"
+      ]
+    },
+    {
+      "slug": "chinnaiyan-shakti-rising",
+      "title": "Shakti Rising",
+      "type": "book",
+      "author": "Kavitha Chinnaiyan",
+      "traditions": [
+        "tantra",
+        "kashmir-shaivism",
+        "vedanta"
+      ],
+      "teachers": [
+        "kavitha-chinnaiyan"
+      ]
+    },
+    {
+      "slug": "chinnaiyan-the-heart-of-wellness",
+      "title": "The Heart of Wellness",
+      "type": "book",
+      "author": "Kavitha Chinnaiyan",
+      "traditions": [
+        "tantra",
+        "kashmir-shaivism",
+        "vedanta"
+      ],
+      "teachers": [
+        "kavitha-chinnaiyan"
+      ]
+    },
+    {
+      "slug": "chodron-always-maintain-a-joyful-mind",
+      "title": "Always Maintain a Joyful Mind",
+      "type": "book",
+      "author": "Pema Chödrön",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu"
+      ],
+      "teachers": [
+        "pema-chodron"
+      ]
+    },
+    {
+      "slug": "chodron-awakening-loving-kindness",
+      "title": "Awakening Loving-Kindness",
+      "type": "book",
+      "author": "Pema Chödrön",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu"
+      ],
+      "teachers": [
+        "pema-chodron"
+      ]
+    },
+    {
+      "slug": "chodron-becoming-bodhisattvas",
+      "title": "Becoming Bodhisattvas",
+      "type": "book",
+      "author": "Pema Chödrön",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu"
+      ],
+      "teachers": [
+        "pema-chodron"
+      ]
+    },
+    {
+      "slug": "chodron-comfortable-with-uncertainty",
+      "title": "Comfortable with Uncertainty",
+      "type": "book",
+      "author": "Pema Chödrön",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu"
+      ],
+      "teachers": [
+        "pema-chodron"
+      ]
+    },
+    {
+      "slug": "chodron-fail-fail-again-fail-better",
+      "title": "Fail, Fail Again, Fail Better",
+      "type": "book",
+      "author": "Pema Chödrön",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu"
+      ],
+      "teachers": [
+        "pema-chodron"
+      ]
+    },
+    {
+      "slug": "chodron-how-to-meditate",
+      "title": "How to Meditate",
+      "type": "book",
+      "author": "Pema Chödrön",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu"
+      ],
+      "teachers": [
+        "pema-chodron"
+      ]
+    },
+    {
+      "slug": "chodron-living-beautifully",
+      "title": "Living Beautifully",
+      "type": "book",
+      "author": "Pema Chödrön",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu"
+      ],
+      "teachers": [
+        "pema-chodron"
+      ]
+    },
+    {
+      "slug": "chodron-start-where-you-are-how-to-accept-yourself-and-others",
+      "title": "Start Where You Are: How to accept yourself and others",
+      "type": "book",
+      "author": "Pema Chödrön",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu"
+      ],
+      "teachers": [
+        "pema-chodron"
+      ]
+    },
+    {
+      "slug": "chodron-start-where-you-are",
+      "title": "Start Where You Are",
+      "type": "book",
+      "author": "Pema Chödrön",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu"
+      ],
+      "teachers": [
+        "pema-chodron"
+      ]
+    },
+    {
+      "slug": "chodron-taking-the-leap",
+      "title": "Taking the Leap",
+      "type": "book",
+      "author": "Pema Chödrön",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu"
+      ],
+      "teachers": [
+        "pema-chodron"
+      ]
+    },
+    {
+      "slug": "chodron-the-compassion-book",
+      "title": "The Compassion Book",
+      "type": "book",
+      "author": "Pema Chödrön",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu"
+      ],
+      "teachers": [
+        "pema-chodron"
+      ]
+    },
+    {
+      "slug": "chodron-the-places-that-scare-you-a-guide-to-fearlessness",
+      "title": "The Places That Scare You: A Guide to Fearlessness",
+      "type": "book",
+      "author": "Pema Chödrön",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu"
+      ],
+      "teachers": [
+        "pema-chodron"
+      ]
+    },
+    {
+      "slug": "chodron-the-pocket-pema-chodron",
+      "title": "The Pocket Pema Chodron",
+      "type": "book",
+      "author": "Pema Chödrön",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu"
+      ],
+      "teachers": [
+        "pema-chodron"
+      ]
+    },
+    {
+      "slug": "chodron-the-wisdom-of-no-escape",
+      "title": "The Wisdom of No Escape",
+      "type": "book",
+      "author": "Pema Chödrön",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu"
+      ],
+      "teachers": [
+        "pema-chodron"
+      ]
+    },
+    {
+      "slug": "chodron-welcoming-the-unwelcome",
+      "title": "Welcoming the Unwelcome",
+      "type": "book",
+      "author": "Pema Chödrön",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu"
+      ],
+      "teachers": [
+        "pema-chodron"
+      ]
+    },
+    {
+      "slug": "christian-classics-ethereal-library",
+      "title": "Christian Classics Ethereal Library",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "christian-mysticism",
+        "hesychasm"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "cioara-el-silencio-de-la-mente",
+      "title": "El Silencio de la Mente",
+      "type": "book",
+      "author": "Ilie Cioara",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "ilie-cioara"
+      ]
+    },
+    {
+      "slug": "cioara-el-viaje-maravilloso",
+      "title": "El Viaje Maravilloso",
+      "type": "book",
+      "author": "Ilie Cioara",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "ilie-cioara"
+      ]
+    },
+    {
+      "slug": "cioara-i-am-boundlessness",
+      "title": "I Am Boundlessness",
+      "type": "book",
+      "author": "Ilie Cioara",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "ilie-cioara"
+      ]
+    },
+    {
+      "slug": "cioara-life-is-eternal-newness",
+      "title": "Life Is Eternal Newness",
+      "type": "book",
+      "author": "Ilie Cioara",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "ilie-cioara"
+      ]
+    },
+    {
+      "slug": "cioara-the-silence-of-the-mind",
+      "title": "The Silence of the Mind",
+      "type": "book",
+      "author": "Ilie Cioara",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "ilie-cioara"
+      ]
+    },
+    {
+      "slug": "cioara-the-wondrous-journey",
+      "title": "The Wondrous Journey",
+      "type": "book",
+      "author": "Ilie Cioara",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "ilie-cioara"
+      ]
+    },
+    {
+      "slug": "cioara-wondrous-journey",
+      "title": "Wondrous Journey",
+      "type": "book",
+      "author": "Ilie Cioara",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "ilie-cioara"
+      ]
+    },
+    {
+      "slug": "cioara-yo-soy-lo-ilimitado",
+      "title": "Yo soy lo ilimitado",
+      "type": "book",
+      "author": "Ilie Cioara",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "ilie-cioara"
+      ]
+    },
+    {
+      "slug": "cloud-of-unknowing",
+      "title": "The Cloud of Unknowing",
+      "type": "book",
+      "author": null,
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "cutting-through-spiritual-materialism",
+      "title": "Cutting Through Spiritual Materialism",
+      "type": "book",
+      "author": "Chogyam Trungpa",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "dark-night-of-the-soul",
+      "title": "Dark Night of the Soul",
+      "type": "book",
+      "author": "St. John of the Cross",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "das-awakening-the-buddhist-heart",
+      "title": "Awakening the Buddhist Heart",
+      "type": "book",
+      "author": "Lama Surya Das",
+      "traditions": [
+        "dzogchen"
+      ],
+      "teachers": [
+        "lama-surya-das"
+      ]
+    },
+    {
+      "slug": "das-awakening-to-the-sacred",
+      "title": "Awakening to the Sacred",
+      "type": "book",
+      "author": "Lama Surya Das",
+      "traditions": [
+        "dzogchen"
+      ],
+      "teachers": [
+        "lama-surya-das"
+      ]
+    },
+    {
+      "slug": "das-buddha-is-as-buddha-does",
+      "title": "Buddha Is as Buddha Does",
+      "type": "book",
+      "author": "Lama Surya Das",
+      "traditions": [
+        "dzogchen"
+      ],
+      "teachers": [
+        "lama-surya-das"
+      ]
+    },
+    {
+      "slug": "das-buddha-standard-time",
+      "title": "Buddha Standard Time",
+      "type": "book",
+      "author": "Lama Surya Das",
+      "traditions": [
+        "dzogchen"
+      ],
+      "teachers": [
+        "lama-surya-das"
+      ]
+    },
+    {
+      "slug": "das-chants-of-a-lifetime",
+      "title": "Chants of a Lifetime",
+      "type": "book",
+      "author": "Krishna Das",
+      "traditions": [
+        "bhakti"
+      ],
+      "teachers": [
+        "krishna-das"
+      ]
+    },
+    {
+      "slug": "das-flow-of-grace",
+      "title": "Flow of Grace",
+      "type": "book",
+      "author": "Krishna Das",
+      "traditions": [
+        "bhakti"
+      ],
+      "teachers": [
+        "krishna-das"
+      ]
+    },
+    {
+      "slug": "das-letting-go-of-the-person-you-used-to-be",
+      "title": "Letting Go of the Person You Used to Be",
+      "type": "book",
+      "author": "Lama Surya Das",
+      "traditions": [
+        "dzogchen"
+      ],
+      "teachers": [
+        "lama-surya-das"
+      ]
+    },
+    {
+      "slug": "das-make-me-one-with-everything",
+      "title": "Make Me One with Everything",
+      "type": "book",
+      "author": "Lama Surya Das",
+      "traditions": [
+        "dzogchen"
+      ],
+      "teachers": [
+        "lama-surya-das"
+      ]
+    },
+    {
+      "slug": "das-natural-great-perfection",
+      "title": "Natural Great Perfection",
+      "type": "book",
+      "author": "Lama Surya Das",
+      "traditions": [
+        "dzogchen"
+      ],
+      "teachers": [
+        "lama-surya-das"
+      ]
+    },
+    {
+      "slug": "das-natural-radiance",
+      "title": "Natural Radiance",
+      "type": "book",
+      "author": "Lama Surya Das",
+      "traditions": [
+        "dzogchen"
+      ],
+      "teachers": [
+        "lama-surya-das"
+      ]
+    },
+    {
+      "slug": "das-open-to-the-infinite",
+      "title": "Open to the Infinite",
+      "type": "book",
+      "author": "Krishna Das",
+      "traditions": [
+        "bhakti"
+      ],
+      "teachers": [
+        "krishna-das"
+      ]
+    },
+    {
+      "slug": "das-the-big-questions",
+      "title": "The Big Questions",
+      "type": "book",
+      "author": "Lama Surya Das",
+      "traditions": [
+        "dzogchen"
+      ],
+      "teachers": [
+        "lama-surya-das"
+      ]
+    },
+    {
+      "slug": "das-the-mind-is-mightier-than-the-sword",
+      "title": "The Mind Is Mightier Than the Sword",
+      "type": "book",
+      "author": "Lama Surya Das",
+      "traditions": [
+        "dzogchen"
+      ],
+      "teachers": [
+        "lama-surya-das"
+      ]
+    },
+    {
+      "slug": "dass-be-love-now",
+      "title": "Be Love Now",
+      "type": "book",
+      "author": "Ram Dass",
+      "traditions": [
+        "bhakti",
+        "vedanta"
+      ],
+      "teachers": [
+        "ram-dass"
+      ]
+    },
+    {
+      "slug": "dass-being-ram-dass",
+      "title": "Being Ram Dass",
+      "type": "book",
+      "author": "Ram Dass",
+      "traditions": [
+        "bhakti",
+        "vedanta"
+      ],
+      "teachers": [
+        "ram-dass"
+      ]
+    },
+    {
+      "slug": "dass-compassion-in-action",
+      "title": "Compassion in Action",
+      "type": "book",
+      "author": "Ram Dass",
+      "traditions": [
+        "bhakti",
+        "vedanta"
+      ],
+      "teachers": [
+        "ram-dass"
+      ]
+    },
+    {
+      "slug": "dass-grist-for-the-mill",
+      "title": "Grist for the Mill",
+      "type": "book",
+      "author": "Ram Dass",
+      "traditions": [
+        "bhakti",
+        "vedanta"
+      ],
+      "teachers": [
+        "ram-dass"
+      ]
+    },
+    {
+      "slug": "dass-how-can-i-help",
+      "title": "How Can I Help?",
+      "type": "book",
+      "author": "Ram Dass",
+      "traditions": [
+        "bhakti",
+        "vedanta"
+      ],
+      "teachers": [
+        "ram-dass"
+      ]
+    },
+    {
+      "slug": "dass-journey-of-awakening",
+      "title": "Journey of Awakening",
+      "type": "book",
+      "author": "Ram Dass",
+      "traditions": [
+        "bhakti",
+        "vedanta"
+      ],
+      "teachers": [
+        "ram-dass"
+      ]
+    },
+    {
+      "slug": "dass-miracle-of-love",
+      "title": "Miracle of Love",
+      "type": "book",
+      "author": "Ram Dass",
+      "traditions": [
+        "bhakti",
+        "vedanta"
+      ],
+      "teachers": [
+        "ram-dass"
+      ]
+    },
+    {
+      "slug": "dass-one-liners",
+      "title": "One-Liners",
+      "type": "book",
+      "author": "Ram Dass",
+      "traditions": [
+        "bhakti",
+        "vedanta"
+      ],
+      "teachers": [
+        "ram-dass"
+      ]
+    },
+    {
+      "slug": "dass-paths-to-god",
+      "title": "Paths to God",
+      "type": "book",
+      "author": "Ram Dass",
+      "traditions": [
+        "bhakti",
+        "vedanta"
+      ],
+      "teachers": [
+        "ram-dass"
+      ]
+    },
+    {
+      "slug": "dass-polishing-the-mirror",
+      "title": "Polishing the Mirror",
+      "type": "book",
+      "author": "Ram Dass",
+      "traditions": [
+        "bhakti",
+        "vedanta"
+      ],
+      "teachers": [
+        "ram-dass"
+      ]
+    },
+    {
+      "slug": "dass-reflections-on-the-journey",
+      "title": "Reflections on the Journey",
+      "type": "book",
+      "author": "Ram Dass",
+      "traditions": [
+        "bhakti",
+        "vedanta"
+      ],
+      "teachers": [
+        "ram-dass"
+      ]
+    },
+    {
+      "slug": "dass-still-here",
+      "title": "Still Here",
+      "type": "book",
+      "author": "Ram Dass",
+      "traditions": [
+        "bhakti",
+        "vedanta"
+      ],
+      "teachers": [
+        "ram-dass"
+      ]
+    },
+    {
+      "slug": "dass-the-only-dance-there-is",
+      "title": "The Only Dance There Is",
+      "type": "book",
+      "author": "Ram Dass",
+      "traditions": [
+        "bhakti",
+        "vedanta"
+      ],
+      "teachers": [
+        "ram-dass"
+      ]
+    },
+    {
+      "slug": "dass-there-is-no-other",
+      "title": "There Is No Other",
+      "type": "book",
+      "author": "Ram Dass",
+      "traditions": [
+        "bhakti",
+        "vedanta"
+      ],
+      "teachers": [
+        "ram-dass"
+      ]
+    },
+    {
+      "slug": "dass-walking-each-other-home",
+      "title": "Walking Each Other Home",
+      "type": "book",
+      "author": "Ram Dass",
+      "traditions": [
+        "bhakti",
+        "vedanta"
+      ],
+      "teachers": [
+        "ram-dass"
+      ]
+    },
+    {
+      "slug": "dass-words-of-wisdom",
+      "title": "Words of Wisdom",
+      "type": "book",
+      "author": "Ram Dass",
+      "traditions": [
+        "bhakti",
+        "vedanta"
+      ],
+      "teachers": [
+        "ram-dass"
+      ]
+    },
+    {
+      "slug": "de-mello-awareness",
+      "title": "Awareness",
+      "type": "book",
+      "author": "Anthony de Mello",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "anthony-de-mello"
+      ]
+    },
+    {
+      "slug": "de-mello-sadhana",
+      "title": "Sadhana: A Way to God",
+      "type": "book",
+      "author": "Anthony de Mello",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "anthony-de-mello"
+      ]
+    },
+    {
+      "slug": "de-mello-the-way-to-love",
+      "title": "The Way to Love",
+      "type": "book",
+      "author": "Anthony de Mello",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "anthony-de-mello"
+      ]
+    },
+    {
+      "slug": "dhammapada",
+      "title": "Dhammapada",
+      "type": "book",
+      "author": "Gil Fronsdal (trans.)",
+      "traditions": [
+        "theravada",
+        "early-buddhism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "dharma-seed",
+      "title": "Dharma Seed",
+      "type": "podcast",
+      "author": null,
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "gil-fronsdal"
+      ]
+    },
+    {
+      "slug": "diamond-sutra",
+      "title": "The Diamond Sutra",
+      "type": "book",
+      "author": "Red Pine",
+      "traditions": [
+        "mahayana",
+        "zen"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "douglas-life-less-ordinary",
+      "title": "Life Less Ordinary",
+      "type": "book",
+      "author": "Anna Douglas",
+      "traditions": [
+        "early-buddhism",
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "anna-douglas"
+      ]
+    },
+    {
+      "slug": "douglas-saturday-night-and-sunday-morning",
+      "title": "Saturday Night and Sunday Morning",
+      "type": "book",
+      "author": "Anna Douglas",
+      "traditions": [
+        "early-buddhism",
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "anna-douglas"
+      ]
+    },
+    {
+      "slug": "douglas-the-changing-winds-of-destiny",
+      "title": "The Changing Winds of Destiny",
+      "type": "book",
+      "author": "Anna Douglas",
+      "traditions": [
+        "early-buddhism",
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "anna-douglas"
+      ]
+    },
+    {
+      "slug": "dzogchen-rigpa-wiki",
+      "title": "Dzogchen (Rigpa Wiki)",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "dzogchen"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "eckhart-meister-eckehart-speaks",
+      "title": "Meister Eckehart Speaks",
+      "type": "book",
+      "author": "Meister Eckhart",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "meister-eckhart"
+      ]
+    },
+    {
+      "slug": "eckhart-meister-eckhart-cws",
+      "title": "Meister Eckhart (CWS)",
+      "type": "book",
+      "author": "Meister Eckhart",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "meister-eckhart"
+      ]
+    },
+    {
+      "slug": "eckhart-meister-eckhart-s-sermons",
+      "title": "Meister Eckhart's Sermons",
+      "type": "book",
+      "author": "Meister Eckhart",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "meister-eckhart"
+      ]
+    },
+    {
+      "slug": "eckhart-meister-eckhart-sermons-treatises",
+      "title": "Meister Eckhart, Sermons & Treatises",
+      "type": "book",
+      "author": "Meister Eckhart",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "meister-eckhart"
+      ]
+    },
+    {
+      "slug": "eckhart-meister-eckhart-teacher-and-preacher",
+      "title": "Meister Eckhart, Teacher and Preacher",
+      "type": "book",
+      "author": "Meister Eckhart",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "meister-eckhart"
+      ]
+    },
+    {
+      "slug": "eckhart-selected-writings",
+      "title": "Selected Writings",
+      "type": "book",
+      "author": "Meister Eckhart",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "meister-eckhart"
+      ]
+    },
+    {
+      "slug": "eckhart-the-complete-mystical-works-of-meister-eckhart",
+      "title": "The Complete Mystical Works of Meister Eckhart",
+      "type": "book",
+      "author": "Meister Eckhart",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "meister-eckhart"
+      ]
+    },
+    {
+      "slug": "eckhart-treatises-and-sermons-of-meister-eckhart",
+      "title": "Treatises and Sermons of Meister Eckhart",
+      "type": "book",
+      "author": "Meister Eckhart",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "meister-eckhart"
+      ]
+    },
+    {
+      "slug": "eckhart-wandering-joy",
+      "title": "Wandering Joy",
+      "type": "book",
+      "author": "Meister Eckhart",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "meister-eckhart"
+      ]
+    },
+    {
+      "slug": "encyclopaedia-britannica-jainism",
+      "title": "Encyclopaedia Britannica: Jainism",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "jainism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "encyclopaedia-britannica-neoplatonism",
+      "title": "Encyclopaedia Britannica: Neoplatonism",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "neoplatonism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "energy-arts",
+      "title": "Energy Arts",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "tai-chi-qigong",
+        "taoism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "engler-the-consumer-s-guide-to-psychotherapy",
+      "title": "The consumer's guide to psychotherapy",
+      "type": "book",
+      "author": "Jack Engler",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "jack-engler"
+      ]
+    },
+    {
+      "slug": "essential-rumi",
+      "title": "The Essential Rumi",
+      "type": "book",
+      "author": "Coleman Barks",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "finley-autobiography-of-rev-james-b-finley-or-pioneer-life-in-the-west",
+      "title": "Autobiography of REV. James B. Finley Or Pioneer Life in the West",
+      "type": "book",
+      "author": "James Finley",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "james-finley"
+      ]
+    },
+    {
+      "slug": "finley-christian-meditation",
+      "title": "Christian Meditation",
+      "type": "book",
+      "author": "James Finley",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "james-finley"
+      ]
+    },
+    {
+      "slug": "finley-history-of-the-wyandott-mission-at-upper-sandusky-ohio-under-the-directio",
+      "title": "History of the Wyandott Mission, at Upper Sandusky, Ohio, Under the Direction of the Methodist Episcopal Church",
+      "type": "book",
+      "author": "James Finley",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "james-finley"
+      ]
+    },
+    {
+      "slug": "finley-history-of-the-wyandott-mission",
+      "title": "History of the Wyandott Mission",
+      "type": "book",
+      "author": "James Finley",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "james-finley"
+      ]
+    },
+    {
+      "slug": "finley-integrating-the-12-steps-into-addiction-therapy",
+      "title": "Integrating the 12 Steps into Addiction Therapy",
+      "type": "book",
+      "author": "James Finley",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "james-finley"
+      ]
+    },
+    {
+      "slug": "finley-merton-s-palace-of-nowhere",
+      "title": "Merton's Palace of Nowhere",
+      "type": "book",
+      "author": "James Finley",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "james-finley"
+      ]
+    },
+    {
+      "slug": "finley-the-contemplative-heart",
+      "title": "The Contemplative Heart",
+      "type": "book",
+      "author": "James Finley",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "james-finley"
+      ]
+    },
+    {
+      "slug": "finley-the-healing-path-a-memoir-and-an-invitation",
+      "title": "The Healing Path: A Memoir and an Invitation",
+      "type": "book",
+      "author": "James Finley",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "james-finley"
+      ]
+    },
+    {
+      "slug": "finley-wake-up-and-preach",
+      "title": "Wake Up and Preach!",
+      "type": "book",
+      "author": "James Finley",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "james-finley"
+      ]
+    },
+    {
+      "slug": "finley-wandering-wounds",
+      "title": "Wandering Wounds",
+      "type": "book",
+      "author": "James Finley",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "james-finley"
+      ]
+    },
+    {
+      "slug": "finley-your-faith-and-you",
+      "title": "Your Faith and You",
+      "type": "book",
+      "author": "James Finley",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "james-finley"
+      ]
+    },
+    {
+      "slug": "fire-inside",
+      "title": "The Fire Inside: The Dharma of James Baldwin and Audre Lorde",
+      "type": "book",
+      "author": "Rima Vesely-Flad",
+      "traditions": [
+        "secular-mindfulness"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "fischer-conflict",
+      "title": "Conflict",
+      "type": "book",
+      "author": "Norman Fischer",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "norman-fischer"
+      ]
+    },
+    {
+      "slug": "fischer-experience",
+      "title": "Experience",
+      "type": "book",
+      "author": "Norman Fischer",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "norman-fischer"
+      ]
+    },
+    {
+      "slug": "fischer-on-a-train-at-night",
+      "title": "On a Train at Night",
+      "type": "book",
+      "author": "Norman Fischer",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "norman-fischer"
+      ]
+    },
+    {
+      "slug": "fischer-on-whether-or-not-to-believe-in-your-mind",
+      "title": "On Whether Or Not to Believe in Your Mind",
+      "type": "book",
+      "author": "Norman Fischer",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "norman-fischer"
+      ]
+    },
+    {
+      "slug": "fischer-sailing-home",
+      "title": "Sailing Home",
+      "type": "book",
+      "author": "Norman Fischer",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "norman-fischer"
+      ]
+    },
+    {
+      "slug": "fischer-suffering-and-possibility",
+      "title": "Suffering and Possibility",
+      "type": "book",
+      "author": "Norman Fischer",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "norman-fischer"
+      ]
+    },
+    {
+      "slug": "fischer-taking-our-places",
+      "title": "Taking Our Places",
+      "type": "book",
+      "author": "Norman Fischer",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "norman-fischer"
+      ]
+    },
+    {
+      "slug": "fischer-the-world-could-be-otherwise",
+      "title": "The World Could Be Otherwise",
+      "type": "book",
+      "author": "Norman Fischer",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "norman-fischer"
+      ]
+    },
+    {
+      "slug": "fischer-through-a-window",
+      "title": "Through a Window",
+      "type": "book",
+      "author": "Norman Fischer",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "norman-fischer"
+      ]
+    },
+    {
+      "slug": "fischer-training-in-compassion",
+      "title": "Training in Compassion",
+      "type": "book",
+      "author": "Norman Fischer",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "norman-fischer"
+      ]
+    },
+    {
+      "slug": "fischer-what-is-zen",
+      "title": "What Is Zen?",
+      "type": "book",
+      "author": "Norman Fischer",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "norman-fischer"
+      ]
+    },
+    {
+      "slug": "fischer-when-you-greet-me-i-bow",
+      "title": "When You Greet Me I Bow",
+      "type": "book",
+      "author": "Norman Fischer",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "norman-fischer"
+      ]
+    },
+    {
+      "slug": "fox-a-spirituality-named-compassion",
+      "title": "A Spirituality Named Compassion",
+      "type": "book",
+      "author": "Matthew Fox",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "matthew-fox"
+      ]
+    },
+    {
+      "slug": "fox-a-way-to-god",
+      "title": "A Way to God",
+      "type": "book",
+      "author": "Matthew Fox",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "matthew-fox"
+      ]
+    },
+    {
+      "slug": "fox-christian-mystics",
+      "title": "Christian Mystics",
+      "type": "book",
+      "author": "Matthew Fox",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "matthew-fox"
+      ]
+    },
+    {
+      "slug": "fox-cicero-s-philosophy-of-history",
+      "title": "Cicero's Philosophy of History",
+      "type": "book",
+      "author": "Matthew Fox",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "matthew-fox"
+      ]
+    },
+    {
+      "slug": "fox-confessions-revised-and-updated",
+      "title": "Confessions, Revised and Updated",
+      "type": "book",
+      "author": "Matthew Fox",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "matthew-fox"
+      ]
+    },
+    {
+      "slug": "fox-creation-spirituality",
+      "title": "Creation Spirituality",
+      "type": "book",
+      "author": "Matthew Fox",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "matthew-fox"
+      ]
+    },
+    {
+      "slug": "fox-creativity",
+      "title": "Creativity",
+      "type": "book",
+      "author": "Matthew Fox",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "matthew-fox"
+      ]
+    },
+    {
+      "slug": "fox-illuminations-of-hildegard-of-bingen",
+      "title": "Illuminations of Hildegard of Bingen",
+      "type": "book",
+      "author": "Matthew Fox",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "matthew-fox"
+      ]
+    },
+    {
+      "slug": "fox-matthew-fox",
+      "title": "Matthew Fox",
+      "type": "book",
+      "author": "Matthew Fox",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "matthew-fox"
+      ]
+    },
+    {
+      "slug": "fox-meister-eckhart",
+      "title": "Meister Eckhart",
+      "type": "book",
+      "author": "Matthew Fox",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "matthew-fox"
+      ]
+    },
+    {
+      "slug": "fox-natural-grace",
+      "title": "Natural Grace",
+      "type": "book",
+      "author": "Matthew Fox",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "matthew-fox"
+      ]
+    },
+    {
+      "slug": "fox-prayer",
+      "title": "Prayer",
+      "type": "book",
+      "author": "Matthew Fox",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "matthew-fox"
+      ]
+    },
+    {
+      "slug": "fox-sins-of-the-spirit-blessings-of-the-flesh",
+      "title": "Sins of the Spirit, Blessings of the Flesh",
+      "type": "book",
+      "author": "Matthew Fox",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "matthew-fox"
+      ]
+    },
+    {
+      "slug": "fox-the-a-w-e-project",
+      "title": "The A.W.E. Project",
+      "type": "book",
+      "author": "Matthew Fox",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "matthew-fox"
+      ]
+    },
+    {
+      "slug": "fox-the-hidden-spirituality-of-men",
+      "title": "The Hidden Spirituality of Men",
+      "type": "book",
+      "author": "Matthew Fox",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "matthew-fox"
+      ]
+    },
+    {
+      "slug": "fox-the-reinvention-of-work",
+      "title": "The Reinvention of Work",
+      "type": "book",
+      "author": "Matthew Fox",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "matthew-fox"
+      ]
+    },
+    {
+      "slug": "fox-whee-we-wee-all-the-way-home",
+      "title": "Whee! We, Wee All the Way Home",
+      "type": "book",
+      "author": "Matthew Fox",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "matthew-fox"
+      ]
+    },
+    {
+      "slug": "fronsdal-a-monastery-within",
+      "title": "A Monastery Within",
+      "type": "book",
+      "author": "Gil Fronsdal",
+      "traditions": [
+        "theravada",
+        "zen"
+      ],
+      "teachers": [
+        "gil-fronsdal"
+      ]
+    },
+    {
+      "slug": "fronsdal-dawn-of-the-bodhisattva-path",
+      "title": "Dawn of the Bodhisattva Path",
+      "type": "book",
+      "author": "Gil Fronsdal",
+      "traditions": [
+        "theravada",
+        "zen"
+      ],
+      "teachers": [
+        "gil-fronsdal"
+      ]
+    },
+    {
+      "slug": "fronsdal-es-liegt-in-deiner-hand",
+      "title": "Es Liegt in Deiner Hand",
+      "type": "book",
+      "author": "Gil Fronsdal",
+      "traditions": [
+        "theravada",
+        "zen"
+      ],
+      "teachers": [
+        "gil-fronsdal"
+      ]
+    },
+    {
+      "slug": "fronsdal-everything-is-practice",
+      "title": "Everything is Practice",
+      "type": "book",
+      "author": "Gil Fronsdal",
+      "traditions": [
+        "theravada",
+        "zen"
+      ],
+      "teachers": [
+        "gil-fronsdal"
+      ]
+    },
+    {
+      "slug": "fronsdal-secularizing-buddhism",
+      "title": "Secularizing Buddhism",
+      "type": "book",
+      "author": "Gil Fronsdal",
+      "traditions": [
+        "theravada",
+        "zen"
+      ],
+      "teachers": [
+        "gil-fronsdal"
+      ]
+    },
+    {
+      "slug": "fronsdal-the-buddha-before-buddhism",
+      "title": "The Buddha before Buddhism",
+      "type": "book",
+      "author": "Gil Fronsdal",
+      "traditions": [
+        "theravada",
+        "zen"
+      ],
+      "teachers": [
+        "gil-fronsdal"
+      ]
+    },
+    {
+      "slug": "fronsdal-the-dhammapada",
+      "title": "The Dhammapada",
+      "type": "book",
+      "author": "Gil Fronsdal",
+      "traditions": [
+        "theravada",
+        "zen"
+      ],
+      "teachers": [
+        "gil-fronsdal"
+      ]
+    },
+    {
+      "slug": "fronsdal-the-issue-at-hand",
+      "title": "The Issue At Hand",
+      "type": "book",
+      "author": "Gil Fronsdal",
+      "traditions": [
+        "theravada",
+        "zen"
+      ],
+      "teachers": [
+        "gil-fronsdal"
+      ]
+    },
+    {
+      "slug": "fronsdal-toucher-le-coeur-du-sujet",
+      "title": "Toucher Le Coeur Du Sujet",
+      "type": "book",
+      "author": "Gil Fronsdal",
+      "traditions": [
+        "theravada",
+        "zen"
+      ],
+      "teachers": [
+        "gil-fronsdal"
+      ]
+    },
+    {
+      "slug": "fronsdal-unhindered",
+      "title": "Unhindered",
+      "type": "book",
+      "author": "Gil Fronsdal",
+      "traditions": [
+        "theravada",
+        "zen"
+      ],
+      "teachers": [
+        "gil-fronsdal"
+      ]
+    },
+    {
+      "slug": "fronsdal-viviendo-en-el-presente-ensayos-sobre-la-practica-budista-de-la-atencio",
+      "title": "Viviendo En El Presente: Ensayos Sobre La Practica Budista de La Atencion Plena",
+      "type": "book",
+      "author": "Gil Fronsdal",
+      "traditions": [
+        "theravada",
+        "zen"
+      ],
+      "teachers": [
+        "gil-fronsdal"
+      ]
+    },
+    {
+      "slug": "full-catastrophe-living",
+      "title": "Full Catastrophe Living",
+      "type": "book",
+      "author": "Jon Kabat-Zinn",
+      "traditions": [
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "jon-kabat-zinn"
+      ]
+    },
+    {
+      "slug": "fusus-al-hikam-the-bezels-of-wisdom",
+      "title": "Fusus al-Hikam (The Bezels of Wisdom)",
+      "type": "book",
+      "author": "Ibn al-Arabi",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "gangaji-de-diamant-in-jezelf",
+      "title": "De diamant in jezelf",
+      "type": "book",
+      "author": "Gangaji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "gangaji"
+      ]
+    },
+    {
+      "slug": "gangaji-el-diamante-en-tu-bolsillo",
+      "title": "El Diamante en tu bolsillo",
+      "type": "book",
+      "author": "Gangaji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "gangaji"
+      ]
+    },
+    {
+      "slug": "gangaji-freedom-and-resolve",
+      "title": "Freedom and Resolve",
+      "type": "book",
+      "author": "Gangaji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "gangaji"
+      ]
+    },
+    {
+      "slug": "gangaji-hidden-treasure",
+      "title": "Hidden Treasure",
+      "type": "book",
+      "author": "Gangaji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "gangaji"
+      ]
+    },
+    {
+      "slug": "gangaji-jij-bent-dat",
+      "title": "Jij bent DAT",
+      "type": "book",
+      "author": "Gangaji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "gangaji"
+      ]
+    },
+    {
+      "slug": "gangaji-the-diamond-in-your-pocket-easyread-comfort-edition",
+      "title": "The Diamond in Your Pocket (EasyRead Comfort Edition)",
+      "type": "book",
+      "author": "Gangaji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "gangaji"
+      ]
+    },
+    {
+      "slug": "gangaji-the-diamond-in-your-pocket",
+      "title": "The Diamond in Your Pocket",
+      "type": "book",
+      "author": "Gangaji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "gangaji"
+      ]
+    },
+    {
+      "slug": "gangaji-the-journey-home",
+      "title": "The Journey Home",
+      "type": "book",
+      "author": "Gangaji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "gangaji"
+      ]
+    },
+    {
+      "slug": "gangaji-tu-eres-eso",
+      "title": "Tu Eres Eso",
+      "type": "book",
+      "author": "Gangaji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "gangaji"
+      ]
+    },
+    {
+      "slug": "gangaji-wake-up-and-roar",
+      "title": "Wake Up and Roar",
+      "type": "book",
+      "author": "Gangaji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "gangaji"
+      ]
+    },
+    {
+      "slug": "gangaji-you-are-that",
+      "title": "You Are That",
+      "type": "book",
+      "author": "Gangaji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "gangaji"
+      ]
+    },
+    {
+      "slug": "gates-daily-reflections-on-addiction-yoga-and-getting-well",
+      "title": "Daily Reflections on Addiction, Yoga, and Getting Well",
+      "type": "book",
+      "author": "Rolf Gates",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "rolf-gates"
+      ]
+    },
+    {
+      "slug": "gates-llewellyn-s-complete-book-of-mindful-living",
+      "title": "Llewellyn's Complete Book of Mindful Living",
+      "type": "book",
+      "author": "Rolf Gates",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "rolf-gates"
+      ]
+    },
+    {
+      "slug": "gates-meditations-from-the-mat",
+      "title": "Meditations from the Mat",
+      "type": "book",
+      "author": "Rolf Gates",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "rolf-gates"
+      ]
+    },
+    {
+      "slug": "gates-meditations-on-intention-and-being",
+      "title": "Meditations on Intention and Being",
+      "type": "book",
+      "author": "Rolf Gates",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "rolf-gates"
+      ]
+    },
+    {
+      "slug": "glassman-bearing-witness",
+      "title": "Bearing Witness",
+      "type": "book",
+      "author": "Bernie Glassman",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "bernie-glassman"
+      ]
+    },
+    {
+      "slug": "glassman-cerchio-infinito-la-via-buddhista-all-illuminazione",
+      "title": "Cerchio infinito. La via buddhista all'illuminazione",
+      "type": "book",
+      "author": "Bernie Glassman",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "bernie-glassman"
+      ]
+    },
+    {
+      "slug": "glassman-el-nota-the-dude-y-el-maestro-zen",
+      "title": "El nota (the dude) y el maestro zen",
+      "type": "book",
+      "author": "Bernie Glassman",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "bernie-glassman"
+      ]
+    },
+    {
+      "slug": "glassman-il-drugo-e-il-maestro-zen",
+      "title": "Il Drugo e il maestro Zen",
+      "type": "book",
+      "author": "Bernie Glassman",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "bernie-glassman"
+      ]
+    },
+    {
+      "slug": "glassman-infinite-circle",
+      "title": "Infinite Circle",
+      "type": "book",
+      "author": "Bernie Glassman",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "bernie-glassman"
+      ]
+    },
+    {
+      "slug": "glassman-instructions-to-the-cook",
+      "title": "Instructions to the Cook",
+      "type": "book",
+      "author": "Bernie Glassman",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "bernie-glassman"
+      ]
+    },
+    {
+      "slug": "glassman-l-art-de-la-paix",
+      "title": "L'art de la paix",
+      "type": "book",
+      "author": "Bernie Glassman",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "bernie-glassman"
+      ]
+    },
+    {
+      "slug": "glassman-la-pratique-du-zen",
+      "title": "La pratique du Zen",
+      "type": "book",
+      "author": "Bernie Glassman",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "bernie-glassman"
+      ]
+    },
+    {
+      "slug": "glassman-le-cercle-infini",
+      "title": "Le cercle infini",
+      "type": "book",
+      "author": "Bernie Glassman",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "bernie-glassman"
+      ]
+    },
+    {
+      "slug": "glassman-the-dude-and-the-zen-master",
+      "title": "The Dude and the Zen Master",
+      "type": "book",
+      "author": "Bernie Glassman",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "bernie-glassman"
+      ]
+    },
+    {
+      "slug": "glassman-the-hazy-moon-of-enlightenment",
+      "title": "The Hazy Moon of Enlightenment",
+      "type": "book",
+      "author": "Bernie Glassman",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "bernie-glassman"
+      ]
+    },
+    {
+      "slug": "gnosticism-new-light",
+      "title": "Gnosticism: New Light on the Ancient Tradition of Inner Knowing",
+      "type": "book",
+      "author": "Stephan A. Hoeller",
+      "traditions": [
+        "gnosticism",
+        "neoplatonism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "gnosticism-stanford-encyclopedia-of-philosophy",
+      "title": "Gnosticism (Stanford Encyclopedia of Philosophy)",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "gnosticism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "goldstein-7-treasures-of-awakening",
+      "title": "7 Treasures of Awakening",
+      "type": "book",
+      "author": "Joseph Goldstein",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "joseph-goldstein"
+      ]
+    },
+    {
+      "slug": "goldstein-a-heart-full-of-peace",
+      "title": "A Heart Full of Peace",
+      "type": "book",
+      "author": "Joseph Goldstein",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "joseph-goldstein"
+      ]
+    },
+    {
+      "slug": "goldstein-beyond-the-best-interests-of-the-child",
+      "title": "Beyond the Best Interests of the Child",
+      "type": "book",
+      "author": "Joseph Goldstein",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "joseph-goldstein"
+      ]
+    },
+    {
+      "slug": "goldstein-insight-meditation",
+      "title": "Insight Meditation",
+      "type": "book",
+      "author": "Joseph Goldstein",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "joseph-goldstein"
+      ]
+    },
+    {
+      "slug": "goldstein-mindfulness",
+      "title": "Mindfulness",
+      "type": "book",
+      "author": "Joseph Goldstein",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "joseph-goldstein"
+      ]
+    },
+    {
+      "slug": "goldstein-one-dharma",
+      "title": "One Dharma",
+      "type": "book",
+      "author": "Joseph Goldstein",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "joseph-goldstein"
+      ]
+    },
+    {
+      "slug": "goldstein-the-experience-of-insight",
+      "title": "The Experience of Insight",
+      "type": "book",
+      "author": "Joseph Goldstein",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "joseph-goldstein"
+      ]
+    },
+    {
+      "slug": "goodman-mente-consciencia-e-bem-estar",
+      "title": "Mente, consciência e bem-estar",
+      "type": "book",
+      "author": "Trudy Goodman",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "trudy-goodman"
+      ]
+    },
+    {
+      "slug": "greater-good-science-center-mindfulness",
+      "title": "Greater Good Science Center: Mindfulness",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "secular-mindfulness"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "gregory-palamas-stanford-encyclopedia-of-philosophy",
+      "title": "Gregory Palamas (Stanford Encyclopedia of Philosophy)",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "hesychasm"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "hafiz-divan-i-hafiz",
+      "title": "Divan-I Hafiz",
+      "type": "book",
+      "author": "Hafiz",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hafiz"
+      ]
+    },
+    {
+      "slug": "hafiz-divan-of-hafiz-of-shiraz",
+      "title": "Divan of Hafiz of Shiraz",
+      "type": "book",
+      "author": "Hafiz",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hafiz"
+      ]
+    },
+    {
+      "slug": "hafiz-hafiz-s-little-book-of-life",
+      "title": "Hafiz's Little Book of Life",
+      "type": "book",
+      "author": "Hafiz",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hafiz"
+      ]
+    },
+    {
+      "slug": "hafiz-hafiz-the-prince-of-persian-lyric-poets",
+      "title": "Hafiz, the Prince of Persian Lyric Poets",
+      "type": "book",
+      "author": "Hafiz",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hafiz"
+      ]
+    },
+    {
+      "slug": "hafiz-hafiz-wisdom-of-madness",
+      "title": "Hafiz: Wisdom of Madness",
+      "type": "book",
+      "author": "Hafiz",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hafiz"
+      ]
+    },
+    {
+      "slug": "hafiz-poems-from-the-divan-of-hafiz",
+      "title": "Poems From the Divan of Hafiz",
+      "type": "book",
+      "author": "Hafiz",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hafiz"
+      ]
+    },
+    {
+      "slug": "hafiz-the-collected-poems-of-hafiz",
+      "title": "The Collected Poems of Hafiz",
+      "type": "book",
+      "author": "Hafiz",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hafiz"
+      ]
+    },
+    {
+      "slug": "hafiz-the-divan-of-hafiz",
+      "title": "The Divan of Hafiz",
+      "type": "book",
+      "author": "Hafiz",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hafiz"
+      ]
+    },
+    {
+      "slug": "hafiz-the-garden-of-heaven",
+      "title": "The Garden of Heaven",
+      "type": "book",
+      "author": "Hafiz",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hafiz"
+      ]
+    },
+    {
+      "slug": "hafiz-the-green-sea-of-heaven",
+      "title": "The Green Sea of Heaven",
+      "type": "book",
+      "author": "Hafiz",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hafiz"
+      ]
+    },
+    {
+      "slug": "hafiz-the-illuminated-hafiz",
+      "title": "The Illuminated Hafiz",
+      "type": "book",
+      "author": "Hafiz",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hafiz"
+      ]
+    },
+    {
+      "slug": "hafiz-the-rubaiyat-of-hafiz",
+      "title": "The Rubàiyàt of Hàfiz",
+      "type": "book",
+      "author": "Hafiz",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hafiz"
+      ]
+    },
+    {
+      "slug": "hamilton-compassionate-conversations",
+      "title": "Compassionate Conversations",
+      "type": "book",
+      "author": "Diane Musho Hamilton",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "diane-musho-hamilton"
+      ]
+    },
+    {
+      "slug": "hamilton-everything-is-workable",
+      "title": "Everything Is Workable",
+      "type": "book",
+      "author": "Diane Musho Hamilton",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "diane-musho-hamilton"
+      ]
+    },
+    {
+      "slug": "hamilton-moi-viec-eu-co-the-giai-quyet",
+      "title": "Mọi việc đều có thể giải quyết",
+      "type": "book",
+      "author": "Diane Musho Hamilton",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "diane-musho-hamilton"
+      ]
+    },
+    {
+      "slug": "hamilton-the-zen-of-you-and-me",
+      "title": "The Zen of You and Me",
+      "type": "book",
+      "author": "Diane Musho Hamilton",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "diane-musho-hamilton"
+      ]
+    },
+    {
+      "slug": "hamilton-waking-up-and-growing-up",
+      "title": "Waking Up and Growing Up",
+      "type": "book",
+      "author": "Diane Musho Hamilton",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "diane-musho-hamilton"
+      ]
+    },
+    {
+      "slug": "hanh-at-home-in-the-world",
+      "title": "At Home in the World",
+      "type": "book",
+      "author": "Thich Nhat Hanh",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "teachers": [
+        "thich-nhat-hanh"
+      ]
+    },
+    {
+      "slug": "hanh-call-me-by-my-true-names",
+      "title": "Call Me by My True Names",
+      "type": "book",
+      "author": "Thich Nhat Hanh",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "teachers": [
+        "thich-nhat-hanh"
+      ]
+    },
+    {
+      "slug": "hanh-how-to-connect",
+      "title": "How to Connect",
+      "type": "book",
+      "author": "Thich Nhat Hanh",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "teachers": [
+        "thich-nhat-hanh"
+      ]
+    },
+    {
+      "slug": "hanh-how-to-eat",
+      "title": "How to Eat",
+      "type": "book",
+      "author": "Thich Nhat Hanh",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "teachers": [
+        "thich-nhat-hanh"
+      ]
+    },
+    {
+      "slug": "hanh-how-to-listen",
+      "title": "How to Listen",
+      "type": "book",
+      "author": "Thich Nhat Hanh",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "teachers": [
+        "thich-nhat-hanh"
+      ]
+    },
+    {
+      "slug": "hanh-how-to-see",
+      "title": "How to See",
+      "type": "book",
+      "author": "Thich Nhat Hanh",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "teachers": [
+        "thich-nhat-hanh"
+      ]
+    },
+    {
+      "slug": "hanh-inside-the-now",
+      "title": "Inside the Now",
+      "type": "book",
+      "author": "Thich Nhat Hanh",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "teachers": [
+        "thich-nhat-hanh"
+      ]
+    },
+    {
+      "slug": "hanh-love-letter-to-the-earth",
+      "title": "Love Letter to the Earth",
+      "type": "book",
+      "author": "Thich Nhat Hanh",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "teachers": [
+        "thich-nhat-hanh"
+      ]
+    },
+    {
+      "slug": "hanh-no-mud-no-lotus",
+      "title": "No Mud, No Lotus",
+      "type": "book",
+      "author": "Thich Nhat Hanh",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "teachers": [
+        "thich-nhat-hanh"
+      ]
+    },
+    {
+      "slug": "hanh-one-buddha-is-not-enough",
+      "title": "One Buddha is Not Enough",
+      "type": "book",
+      "author": "Thich Nhat Hanh",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "teachers": [
+        "thich-nhat-hanh"
+      ]
+    },
+    {
+      "slug": "hanh-our-appointment-with-life",
+      "title": "Our Appointment with Life",
+      "type": "book",
+      "author": "Thich Nhat Hanh",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "teachers": [
+        "thich-nhat-hanh"
+      ]
+    },
+    {
+      "slug": "hanh-peace-is-every-step",
+      "title": "Peace Is Every Step",
+      "type": "book",
+      "author": "Thich Nhat Hanh",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "teachers": [
+        "thich-nhat-hanh"
+      ]
+    },
+    {
+      "slug": "hanh-the-art-of-living",
+      "title": "The Art of Living",
+      "type": "book",
+      "author": "Thich Nhat Hanh",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "teachers": [
+        "thich-nhat-hanh"
+      ]
+    },
+    {
+      "slug": "hanh-the-art-of-power",
+      "title": "The Art of Power",
+      "type": "book",
+      "author": "Thich Nhat Hanh",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "teachers": [
+        "thich-nhat-hanh"
+      ]
+    },
+    {
+      "slug": "hanh-the-pocket-thich-nhat-hanh",
+      "title": "The Pocket Thich Nhat Hanh",
+      "type": "book",
+      "author": "Thich Nhat Hanh",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "teachers": [
+        "thich-nhat-hanh"
+      ]
+    },
+    {
+      "slug": "hanh-the-sun-my-heart",
+      "title": "The Sun My Heart",
+      "type": "book",
+      "author": "Thich Nhat Hanh",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "teachers": [
+        "thich-nhat-hanh"
+      ]
+    },
+    {
+      "slug": "hanh-thich-nhat-hanh-essential-writings",
+      "title": "Thich Nhat Hanh: Essential Writings",
+      "type": "book",
+      "author": "Thich Nhat Hanh",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "teachers": [
+        "thich-nhat-hanh"
+      ]
+    },
+    {
+      "slug": "hanh-understanding-our-mind",
+      "title": "Understanding Our Mind",
+      "type": "book",
+      "author": "Thich Nhat Hanh",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "teachers": [
+        "thich-nhat-hanh"
+      ]
+    },
+    {
+      "slug": "hanh-your-true-home",
+      "title": "Your True Home",
+      "type": "book",
+      "author": "Thich Nhat Hanh",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "teachers": [
+        "thich-nhat-hanh"
+      ]
+    },
+    {
+      "slug": "harris-10-happier",
+      "title": "10% Happier",
+      "type": "book",
+      "author": "Dan Harris",
+      "traditions": [
+        "secular-mindfulness",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "dan-harris"
+      ]
+    },
+    {
+      "slug": "harris-comment-je-suis-devenu-10-plus-heureux",
+      "title": "Comment je suis devenu 10% plus heureux",
+      "type": "book",
+      "author": "Dan Harris",
+      "traditions": [
+        "secular-mindfulness",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "dan-harris"
+      ]
+    },
+    {
+      "slug": "harris-creative-agency",
+      "title": "Creative Agency",
+      "type": "book",
+      "author": "Dan Harris",
+      "traditions": [
+        "secular-mindfulness",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "dan-harris"
+      ]
+    },
+    {
+      "slug": "harris-dan-harris-10-happier",
+      "title": "Dan Harris' 10% Happier",
+      "type": "book",
+      "author": "Dan Harris",
+      "traditions": [
+        "secular-mindfulness",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "dan-harris"
+      ]
+    },
+    {
+      "slug": "harris-hoist-on-my-own-petard",
+      "title": "Hoist on My Own Petard",
+      "type": "book",
+      "author": "Dan Harris",
+      "traditions": [
+        "secular-mindfulness",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "dan-harris"
+      ]
+    },
+    {
+      "slug": "harris-meditacion-para-escepticos-inquietos",
+      "title": "Meditación para escépticos inquietos",
+      "type": "book",
+      "author": "Dan Harris",
+      "traditions": [
+        "secular-mindfulness",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "dan-harris"
+      ]
+    },
+    {
+      "slug": "harris-meditation-for-fidgety-skeptics",
+      "title": "Meditation for Fidgety Skeptics",
+      "type": "book",
+      "author": "Dan Harris",
+      "traditions": [
+        "secular-mindfulness",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "dan-harris"
+      ]
+    },
+    {
+      "slug": "harris-risk-and-return-for-regulated-industries",
+      "title": "Risk and Return for Regulated Industries",
+      "type": "book",
+      "author": "Dan Harris",
+      "traditions": [
+        "secular-mindfulness",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "dan-harris"
+      ]
+    },
+    {
+      "slug": "harris-vivere-sereni",
+      "title": "Vivere + sereni",
+      "type": "book",
+      "author": "Dan Harris",
+      "traditions": [
+        "secular-mindfulness",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "dan-harris"
+      ]
+    },
+    {
+      "slug": "hatha-yoga-pradipika",
+      "title": "Hatha Yoga Pradipika",
+      "type": "book",
+      "author": "Swatmarama / Swami Muktibodhananda (commentary)",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "heart-of-the-buddhas-teaching",
+      "title": "The Heart of the Buddha's Teaching",
+      "type": "book",
+      "author": "Thich Nhat Hanh",
+      "traditions": [
+        "early-buddhism",
+        "mahayana",
+        "zen"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "helminski-bilen-kalp",
+      "title": "Bilen kalp",
+      "type": "book",
+      "author": "Kabir Helminski",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "kabir-helminski"
+      ]
+    },
+    {
+      "slug": "helminski-holistic-islam",
+      "title": "Holistic Islam",
+      "type": "book",
+      "author": "Kabir Helminski",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "kabir-helminski"
+      ]
+    },
+    {
+      "slug": "helminski-in-the-house-of-remembering",
+      "title": "In the House of Remembering",
+      "type": "book",
+      "author": "Kabir Helminski",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "kabir-helminski"
+      ]
+    },
+    {
+      "slug": "helminski-living-presence-revised",
+      "title": "Living Presence (Revised)",
+      "type": "book",
+      "author": "Kabir Helminski",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "kabir-helminski"
+      ]
+    },
+    {
+      "slug": "helminski-rumi-daylight",
+      "title": "Rumi--daylight",
+      "type": "book",
+      "author": "Kabir Helminski",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "kabir-helminski"
+      ]
+    },
+    {
+      "slug": "helminski-rumi",
+      "title": "Rumi",
+      "type": "book",
+      "author": "Kabir Helminski",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "kabir-helminski"
+      ]
+    },
+    {
+      "slug": "helminski-the-beliefnet-guide-to-islam",
+      "title": "The Beliefnet Guide to Islam",
+      "type": "book",
+      "author": "Kabir Helminski",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "kabir-helminski"
+      ]
+    },
+    {
+      "slug": "helminski-the-book-of-revelations",
+      "title": "The Book of Revelations",
+      "type": "book",
+      "author": "Kabir Helminski",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "kabir-helminski"
+      ]
+    },
+    {
+      "slug": "helminski-the-knowing-heart",
+      "title": "The Knowing Heart",
+      "type": "book",
+      "author": "Kabir Helminski",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "kabir-helminski"
+      ]
+    },
+    {
+      "slug": "helminski-the-mysterion",
+      "title": "The Mysterion",
+      "type": "book",
+      "author": "Kabir Helminski",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "kabir-helminski"
+      ]
+    },
+    {
+      "slug": "hesychasm-orthodox-wiki",
+      "title": "Hesychasm (Orthodox Wiki)",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "hesychasm"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "holecek-dream-yoga",
+      "title": "Dream Yoga",
+      "type": "book",
+      "author": "Andrew Holecek",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma"
+      ],
+      "teachers": [
+        "andrew-holecek"
+      ]
+    },
+    {
+      "slug": "holecek-dreams-of-light",
+      "title": "Dreams of Light",
+      "type": "book",
+      "author": "Andrew Holecek",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma"
+      ],
+      "teachers": [
+        "andrew-holecek"
+      ]
+    },
+    {
+      "slug": "holecek-i-m-mindful-now-what",
+      "title": "I'm Mindful, Now What?",
+      "type": "book",
+      "author": "Andrew Holecek",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma"
+      ],
+      "teachers": [
+        "andrew-holecek"
+      ]
+    },
+    {
+      "slug": "holecek-la-meditacion-inversa",
+      "title": "La meditación inversa",
+      "type": "book",
+      "author": "Andrew Holecek",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma"
+      ],
+      "teachers": [
+        "andrew-holecek"
+      ]
+    },
+    {
+      "slug": "holecek-meditation-in-the-igeneration",
+      "title": "Meditation in the Igeneration",
+      "type": "book",
+      "author": "Andrew Holecek",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma"
+      ],
+      "teachers": [
+        "andrew-holecek"
+      ]
+    },
+    {
+      "slug": "holecek-reverse-meditation",
+      "title": "Reverse Meditation",
+      "type": "book",
+      "author": "Andrew Holecek",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma"
+      ],
+      "teachers": [
+        "andrew-holecek"
+      ]
+    },
+    {
+      "slug": "holecek-the-power-and-the-pain",
+      "title": "The Power and the Pain",
+      "type": "book",
+      "author": "Andrew Holecek",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma"
+      ],
+      "teachers": [
+        "andrew-holecek"
+      ]
+    },
+    {
+      "slug": "holecek-total-eclipse-of-the-mind",
+      "title": "Total Eclipse of the Mind",
+      "type": "book",
+      "author": "Andrew Holecek",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma"
+      ],
+      "teachers": [
+        "andrew-holecek"
+      ]
+    },
+    {
+      "slug": "i-am-that",
+      "title": "I Am That",
+      "type": "book",
+      "author": "Nisargadatta Maharaj",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "in-the-buddha-s-words-an-anthology-of-discourses-from-the-pali-canon",
+      "title": "In the Buddha's Words: An Anthology of Discourses from the Pali Canon",
+      "type": "book",
+      "author": "Bhikkhu Bodhi",
+      "traditions": [
+        "early-buddhism",
+        "theravada"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "interior-castle",
+      "title": "The Interior Castle",
+      "type": "book",
+      "author": "Teresa of Avila",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "introduction-to-tantra-the-transformation-of-desire",
+      "title": "Introduction to Tantra: The Transformation of Desire",
+      "type": "book",
+      "author": "Lama Thubten Yeshe",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-gelug"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "iyengar-b-k-s-iyengar-yoga-the-path-to-holistic-health",
+      "title": "B. K. S. Iyengar Yoga the Path to Holistic Health",
+      "type": "book",
+      "author": "BKS Iyengar",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "bks-iyengar"
+      ]
+    },
+    {
+      "slug": "iyengar-b-k-s-iyengar-yoga-wisdom-and-practice",
+      "title": "B.K.S. Iyengar Yoga Wisdom and Practice",
+      "type": "book",
+      "author": "BKS Iyengar",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "bks-iyengar"
+      ]
+    },
+    {
+      "slug": "iyengar-b-k-s-iyengar-yoga",
+      "title": "B.K.S. Iyengar Yoga",
+      "type": "book",
+      "author": "BKS Iyengar",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "bks-iyengar"
+      ]
+    },
+    {
+      "slug": "iyengar-bks-iyengar-yoga-the-path-to-holistic-health",
+      "title": "BKS Iyengar Yoga The Path to Holistic Health",
+      "type": "book",
+      "author": "BKS Iyengar",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "bks-iyengar"
+      ]
+    },
+    {
+      "slug": "iyengar-light-on-life",
+      "title": "Light on Life",
+      "type": "book",
+      "author": "BKS Iyengar",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "bks-iyengar"
+      ]
+    },
+    {
+      "slug": "iyengar-light-on-pranayama",
+      "title": "Light on Pranayama",
+      "type": "book",
+      "author": "BKS Iyengar",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "bks-iyengar"
+      ]
+    },
+    {
+      "slug": "iyengar-light-on-the-yoga-sutras-of-patanjali",
+      "title": "Light on the Yoga Sutras of Patanjali",
+      "type": "book",
+      "author": "BKS Iyengar",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "bks-iyengar"
+      ]
+    },
+    {
+      "slug": "iyengar-light-on-yoga-the-definitive-guide-to-yoga-practice",
+      "title": "Light on Yoga: The Definitive Guide to Yoga Practice",
+      "type": "book",
+      "author": "BKS Iyengar",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "bks-iyengar"
+      ]
+    },
+    {
+      "slug": "iyengar-sparks-of-divinity",
+      "title": "Sparks of Divinity",
+      "type": "book",
+      "author": "BKS Iyengar",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "bks-iyengar"
+      ]
+    },
+    {
+      "slug": "iyengar-the-illustrated-light-on-yoga",
+      "title": "The Illustrated Light on Yoga",
+      "type": "book",
+      "author": "BKS Iyengar",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "bks-iyengar"
+      ]
+    },
+    {
+      "slug": "iyengar-the-tree-of-yoga",
+      "title": "The Tree of Yoga",
+      "type": "book",
+      "author": "BKS Iyengar",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "bks-iyengar"
+      ]
+    },
+    {
+      "slug": "iyengar-yoga-wisdom-practice",
+      "title": "Yoga Wisdom & Practice",
+      "type": "book",
+      "author": "BKS Iyengar",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "bks-iyengar"
+      ]
+    },
+    {
+      "slug": "iyengar-yoga",
+      "title": "Yoga",
+      "type": "book",
+      "author": "BKS Iyengar",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "bks-iyengar"
+      ]
+    },
+    {
+      "slug": "jainism-at-a-glance",
+      "title": "Jainism at a Glance",
+      "type": "book",
+      "author": "Subhash C. Jain",
+      "traditions": [
+        "jainism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "jainism-stanford-encyclopedia-of-philosophy",
+      "title": "Jainism (Stanford Encyclopedia of Philosophy)",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "jainism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "joy-of-living",
+      "title": "The Joy of Living",
+      "type": "book",
+      "author": "Yongey Mingyur Rinpoche",
+      "traditions": [
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "kabat-zinn-arriving-at-your-own-door",
+      "title": "Arriving at Your Own Door",
+      "type": "book",
+      "author": "Jon Kabat-Zinn",
+      "traditions": [
+        "secular-mindfulness",
+        "vipassana-movement",
+        "zen"
+      ],
+      "teachers": [
+        "jon-kabat-zinn"
+      ]
+    },
+    {
+      "slug": "kabat-zinn-coming-to-our-senses",
+      "title": "Coming to Our Senses",
+      "type": "book",
+      "author": "Jon Kabat-Zinn",
+      "traditions": [
+        "secular-mindfulness",
+        "vipassana-movement",
+        "zen"
+      ],
+      "teachers": [
+        "jon-kabat-zinn"
+      ]
+    },
+    {
+      "slug": "kabat-zinn-everyday-blessings",
+      "title": "Everyday Blessings",
+      "type": "book",
+      "author": "Jon Kabat-Zinn",
+      "traditions": [
+        "secular-mindfulness",
+        "vipassana-movement",
+        "zen"
+      ],
+      "teachers": [
+        "jon-kabat-zinn"
+      ]
+    },
+    {
+      "slug": "kabat-zinn-falling-awake",
+      "title": "Falling Awake",
+      "type": "book",
+      "author": "Jon Kabat-Zinn",
+      "traditions": [
+        "secular-mindfulness",
+        "vipassana-movement",
+        "zen"
+      ],
+      "teachers": [
+        "jon-kabat-zinn"
+      ]
+    },
+    {
+      "slug": "kabat-zinn-letting-everything-become-your-teacher",
+      "title": "Letting Everything Become Your Teacher",
+      "type": "book",
+      "author": "Jon Kabat-Zinn",
+      "traditions": [
+        "secular-mindfulness",
+        "vipassana-movement",
+        "zen"
+      ],
+      "teachers": [
+        "jon-kabat-zinn"
+      ]
+    },
+    {
+      "slug": "kabat-zinn-meditation-is-not-what-you-think",
+      "title": "Meditation Is Not What You Think",
+      "type": "book",
+      "author": "Jon Kabat-Zinn",
+      "traditions": [
+        "secular-mindfulness",
+        "vipassana-movement",
+        "zen"
+      ],
+      "teachers": [
+        "jon-kabat-zinn"
+      ]
+    },
+    {
+      "slug": "kabat-zinn-mindful-way-through-depression",
+      "title": "Mindful Way through Depression",
+      "type": "book",
+      "author": "Jon Kabat-Zinn",
+      "traditions": [
+        "secular-mindfulness",
+        "vipassana-movement",
+        "zen"
+      ],
+      "teachers": [
+        "jon-kabat-zinn"
+      ]
+    },
+    {
+      "slug": "kabat-zinn-mindfulness-for-all",
+      "title": "Mindfulness for All",
+      "type": "book",
+      "author": "Jon Kabat-Zinn",
+      "traditions": [
+        "secular-mindfulness",
+        "vipassana-movement",
+        "zen"
+      ],
+      "teachers": [
+        "jon-kabat-zinn"
+      ]
+    },
+    {
+      "slug": "kabat-zinn-mindfulness-for-beginners",
+      "title": "Mindfulness for Beginners",
+      "type": "book",
+      "author": "Jon Kabat-Zinn",
+      "traditions": [
+        "secular-mindfulness",
+        "vipassana-movement",
+        "zen"
+      ],
+      "teachers": [
+        "jon-kabat-zinn"
+      ]
+    },
+    {
+      "slug": "kabat-zinn-mindfulness-meditation-for-everyday-life",
+      "title": "Mindfulness Meditation for Everyday Life",
+      "type": "book",
+      "author": "Jon Kabat-Zinn",
+      "traditions": [
+        "secular-mindfulness",
+        "vipassana-movement",
+        "zen"
+      ],
+      "teachers": [
+        "jon-kabat-zinn"
+      ]
+    },
+    {
+      "slug": "kabat-zinn-mindfulness-meditation-for-pain-relief",
+      "title": "Mindfulness Meditation for Pain Relief",
+      "type": "book",
+      "author": "Jon Kabat-Zinn",
+      "traditions": [
+        "secular-mindfulness",
+        "vipassana-movement",
+        "zen"
+      ],
+      "teachers": [
+        "jon-kabat-zinn"
+      ]
+    },
+    {
+      "slug": "kabat-zinn-the-healing-power-of-mindfulness",
+      "title": "The Healing Power of Mindfulness",
+      "type": "book",
+      "author": "Jon Kabat-Zinn",
+      "traditions": [
+        "secular-mindfulness",
+        "vipassana-movement",
+        "zen"
+      ],
+      "teachers": [
+        "jon-kabat-zinn"
+      ]
+    },
+    {
+      "slug": "kabbalah-stanford-encyclopedia-of-philosophy",
+      "title": "Kabbalah (Stanford Encyclopedia of Philosophy)",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "kabbalah"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "kabbalah-very-short-introduction",
+      "title": "Kabbalah: A Very Short Introduction",
+      "type": "book",
+      "author": "Joseph Dan",
+      "traditions": [
+        "kabbalah"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "kashmir-shaivism-internet-encyclopedia-of-philosophy",
+      "title": "Kashmir Shaivism (Internet Encyclopedia of Philosophy)",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "kashmir-shaivism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "kashmir-shaivism-secret-supreme",
+      "title": "Kashmir Shaivism: The Secret Supreme",
+      "type": "book",
+      "author": "Swami Lakshmanjoo",
+      "traditions": [
+        "kashmir-shaivism",
+        "tantra"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "keating-active-meditations-for-contemplative-prayer",
+      "title": "Active Meditations for Contemplative Prayer",
+      "type": "book",
+      "author": "Thomas Keating",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "father-thomas-keating"
+      ]
+    },
+    {
+      "slug": "keating-an-interview-with-thomas-keating",
+      "title": "An Interview with Thomas Keating",
+      "type": "book",
+      "author": "Thomas Keating",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "father-thomas-keating"
+      ]
+    },
+    {
+      "slug": "keating-and-the-word-was-made-flesh",
+      "title": "And the Word Was Made Flesh",
+      "type": "book",
+      "author": "Thomas Keating",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "father-thomas-keating"
+      ]
+    },
+    {
+      "slug": "keating-centering-prayer-in-daily-life-and-ministry",
+      "title": "Centering Prayer in Daily Life and Ministry",
+      "type": "book",
+      "author": "Thomas Keating",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "father-thomas-keating"
+      ]
+    },
+    {
+      "slug": "keating-fruits-and-gifts-of-the-spirit",
+      "title": "Fruits and Gifts of the Spirit",
+      "type": "book",
+      "author": "Thomas Keating",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "father-thomas-keating"
+      ]
+    },
+    {
+      "slug": "keating-intimacy-with-god",
+      "title": "Intimacy with God",
+      "type": "book",
+      "author": "Thomas Keating",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "father-thomas-keating"
+      ]
+    },
+    {
+      "slug": "keating-open-mind-open-heart",
+      "title": "Open Mind, Open Heart",
+      "type": "book",
+      "author": "Thomas Keating",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "father-thomas-keating"
+      ]
+    },
+    {
+      "slug": "keating-reflections-on-the-unknowable",
+      "title": "Reflections on the Unknowable",
+      "type": "book",
+      "author": "Thomas Keating",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "father-thomas-keating"
+      ]
+    },
+    {
+      "slug": "keating-spirituality-contemplation-and-transformation",
+      "title": "Spirituality, Contemplation, and Transformation",
+      "type": "book",
+      "author": "Thomas Keating",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "father-thomas-keating"
+      ]
+    },
+    {
+      "slug": "keating-st-therese-of-lisieux",
+      "title": "St. Thérèse of Lisieux",
+      "type": "book",
+      "author": "Thomas Keating",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "father-thomas-keating"
+      ]
+    },
+    {
+      "slug": "keating-the-better-part",
+      "title": "The Better Part",
+      "type": "book",
+      "author": "Thomas Keating",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "father-thomas-keating"
+      ]
+    },
+    {
+      "slug": "keating-the-daily-reader-for-contemplative-living",
+      "title": "The Daily Reader for Contemplative Living",
+      "type": "book",
+      "author": "Thomas Keating",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "father-thomas-keating"
+      ]
+    },
+    {
+      "slug": "keating-the-divine-indwelling",
+      "title": "The Divine Indwelling",
+      "type": "book",
+      "author": "Thomas Keating",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "father-thomas-keating"
+      ]
+    },
+    {
+      "slug": "keating-the-human-condition",
+      "title": "The Human Condition",
+      "type": "book",
+      "author": "Thomas Keating",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "father-thomas-keating"
+      ]
+    },
+    {
+      "slug": "keating-the-thomas-keating-reader",
+      "title": "The Thomas Keating Reader",
+      "type": "book",
+      "author": "Thomas Keating",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "father-thomas-keating"
+      ]
+    },
+    {
+      "slug": "kelly-la-voie-de-la-pleine-conscience-sans-effort-un-guide-revolutionnaire-pour-",
+      "title": "La voie de la pleine conscience sans effort - Un guide révolutionnaire pour vivre une vie éveillée",
+      "type": "book",
+      "author": "Loch Kelly",
+      "traditions": [
+        "dzogchen",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "loch-kelly"
+      ]
+    },
+    {
+      "slug": "kelly-muhelose-achtsamkeit",
+      "title": "Mühelose Achtsamkeit",
+      "type": "book",
+      "author": "Loch Kelly",
+      "traditions": [
+        "dzogchen",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "loch-kelly"
+      ]
+    },
+    {
+      "slug": "kelly-salto-a-la-libertad",
+      "title": "Salto a la Libertad",
+      "type": "book",
+      "author": "Loch Kelly",
+      "traditions": [
+        "dzogchen",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "loch-kelly"
+      ]
+    },
+    {
+      "slug": "kelly-shift-into-freedom",
+      "title": "Shift into Freedom",
+      "type": "book",
+      "author": "Loch Kelly",
+      "traditions": [
+        "dzogchen",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "loch-kelly"
+      ]
+    },
+    {
+      "slug": "kelly-the-way-of-effortless-mindfulness",
+      "title": "The Way of Effortless Mindfulness",
+      "type": "book",
+      "author": "Loch Kelly",
+      "traditions": [
+        "dzogchen",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "loch-kelly"
+      ]
+    },
+    {
+      "slug": "kempton-awakening-shakti",
+      "title": "Awakening Shakti",
+      "type": "book",
+      "author": "Sally Kempton",
+      "traditions": [
+        "kashmir-shaivism"
+      ],
+      "teachers": [
+        "sally-kempton"
+      ]
+    },
+    {
+      "slug": "kempton-awakening-to-kali",
+      "title": "Awakening to Kali",
+      "type": "book",
+      "author": "Sally Kempton",
+      "traditions": [
+        "kashmir-shaivism"
+      ],
+      "teachers": [
+        "sally-kempton"
+      ]
+    },
+    {
+      "slug": "kempton-el-placer-de-meditar",
+      "title": "El Placer de Meditar",
+      "type": "book",
+      "author": "Sally Kempton",
+      "traditions": [
+        "kashmir-shaivism"
+      ],
+      "teachers": [
+        "sally-kempton"
+      ]
+    },
+    {
+      "slug": "kempton-goddess",
+      "title": "Goddess",
+      "type": "book",
+      "author": "Sally Kempton",
+      "traditions": [
+        "kashmir-shaivism"
+      ],
+      "teachers": [
+        "sally-kempton"
+      ]
+    },
+    {
+      "slug": "kempton-liefde-voor-meditatie",
+      "title": "Liefde voor meditatie",
+      "type": "book",
+      "author": "Sally Kempton",
+      "traditions": [
+        "kashmir-shaivism"
+      ],
+      "teachers": [
+        "sally-kempton"
+      ]
+    },
+    {
+      "slug": "kempton-meditacija",
+      "title": "Meditacija",
+      "type": "book",
+      "author": "Sally Kempton",
+      "traditions": [
+        "kashmir-shaivism"
+      ],
+      "teachers": [
+        "sally-kempton"
+      ]
+    },
+    {
+      "slug": "kempton-meditation-for-the-love-of-it",
+      "title": "Meditation for the Love of It",
+      "type": "book",
+      "author": "Sally Kempton",
+      "traditions": [
+        "kashmir-shaivism"
+      ],
+      "teachers": [
+        "sally-kempton"
+      ]
+    },
+    {
+      "slug": "kempton-the-heart-of-meditation",
+      "title": "The Heart of Meditation",
+      "type": "book",
+      "author": "Sally Kempton",
+      "traditions": [
+        "kashmir-shaivism"
+      ],
+      "teachers": [
+        "sally-kempton"
+      ]
+    },
+    {
+      "slug": "kempton-why-am-i",
+      "title": "Why Am I",
+      "type": "book",
+      "author": "Sally Kempton",
+      "traditions": [
+        "kashmir-shaivism"
+      ],
+      "teachers": [
+        "sally-kempton"
+      ]
+    },
+    {
+      "slug": "khan-bowl-of-saki",
+      "title": "Bowl of Saki",
+      "type": "book",
+      "author": "Hazrat Inayat Khan",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hazrat-inayat-khan"
+      ]
+    },
+    {
+      "slug": "khan-mastery-through-accomplishment",
+      "title": "Mastery Through Accomplishment",
+      "type": "book",
+      "author": "Hazrat Inayat Khan",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hazrat-inayat-khan"
+      ]
+    },
+    {
+      "slug": "khan-the-mysticism-of-sound-and-music",
+      "title": "The Mysticism of Sound and Music",
+      "type": "book",
+      "author": "Hazrat Inayat Khan",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hazrat-inayat-khan"
+      ]
+    },
+    {
+      "slug": "khan-the-sayings-of-hazrat-inayat-khan",
+      "title": "The Sayings of Hazrat Inayat Khan",
+      "type": "book",
+      "author": "Hazrat Inayat Khan",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hazrat-inayat-khan"
+      ]
+    },
+    {
+      "slug": "khan-the-sufi-message-of-hazrat-inayat-khan-healing-mental-purification-and-the-",
+      "title": "The Sufi Message of Hazrat Inayat Khan: Healing, Mental Purification and the Mind World",
+      "type": "book",
+      "author": "Hazrat Inayat Khan",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hazrat-inayat-khan"
+      ]
+    },
+    {
+      "slug": "khan-the-sufi-message-of-hazrat-inayat-khan-philosophy-psychology-and-myst",
+      "title": "The Sufi Message of Hazrat Inayat Khan: Philosophy, Psychology and Myst",
+      "type": "book",
+      "author": "Hazrat Inayat Khan",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hazrat-inayat-khan"
+      ]
+    },
+    {
+      "slug": "khan-the-sufi-message-of-hazrat-inayat-khan-sufi-mysticism",
+      "title": "The Sufi Message of Hazrat Inayat Khan: Sufi Mysticism",
+      "type": "book",
+      "author": "Hazrat Inayat Khan",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hazrat-inayat-khan"
+      ]
+    },
+    {
+      "slug": "khan-the-sufi-message-of-hazrat-inayat-khan-the-art-of-being",
+      "title": "The Sufi Message of Hazrat Inayat Khan: The Art of Being",
+      "type": "book",
+      "author": "Hazrat Inayat Khan",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hazrat-inayat-khan"
+      ]
+    },
+    {
+      "slug": "khan-the-sufi-message-of-hazrat-inayat-khan-the-art-of-personality",
+      "title": "The Sufi Message of Hazrat Inayat Khan: The Art of Personality",
+      "type": "book",
+      "author": "Hazrat Inayat Khan",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hazrat-inayat-khan"
+      ]
+    },
+    {
+      "slug": "khan-the-sufi-message-of-hazrat-inayat-khan-the-gathas",
+      "title": "The Sufi Message of Hazrat Inayat Khan: The Gathas",
+      "type": "book",
+      "author": "Hazrat Inayat Khan",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hazrat-inayat-khan"
+      ]
+    },
+    {
+      "slug": "khan-the-sufi-message-of-hazrat-inayat-khan-the-mysticism-of-sound-music-the-pow",
+      "title": "The Sufi Message of Hazrat Inayat Khan: The Mysticism of Sound, Music, The Power of the Word, Cosmic Language",
+      "type": "book",
+      "author": "Hazrat Inayat Khan",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hazrat-inayat-khan"
+      ]
+    },
+    {
+      "slug": "khan-the-sufi-message-of-hazrat-inayat-khan-the-smiling-forehead",
+      "title": "The Sufi Message of Hazrat Inayat Khan: The Smiling Forehead",
+      "type": "book",
+      "author": "Hazrat Inayat Khan",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hazrat-inayat-khan"
+      ]
+    },
+    {
+      "slug": "khan-the-sufi-message-of-hazrat-inayat-khan-the-sufi-teachings",
+      "title": "The Sufi Message of Hazrat Inayat Khan: The Sufi Teachings",
+      "type": "book",
+      "author": "Hazrat Inayat Khan",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hazrat-inayat-khan"
+      ]
+    },
+    {
+      "slug": "khan-the-sufi-message-of-hazrat-inayat-khan-the-unity-of-religious-ideals",
+      "title": "The Sufi Message of Hazrat Inayat Khan: The Unity of Religious Ideals",
+      "type": "book",
+      "author": "Hazrat Inayat Khan",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hazrat-inayat-khan"
+      ]
+    },
+    {
+      "slug": "khan-the-sufi-message-of-hazrat-inayat-khan-the-vision-of-god-and-man-confession",
+      "title": "The Sufi Message of Hazrat Inayat Khan: The Vision of God and Man, Confessions, Four Plays",
+      "type": "book",
+      "author": "Hazrat Inayat Khan",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hazrat-inayat-khan"
+      ]
+    },
+    {
+      "slug": "khan-the-sufi-message-of-hazrat-inayat-khan-the-way-of-illumination",
+      "title": "The Sufi Message of Hazrat Inayat Khan: The Way of Illumination",
+      "type": "book",
+      "author": "Hazrat Inayat Khan",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hazrat-inayat-khan"
+      ]
+    },
+    {
+      "slug": "khan-the-sufi-message-volume-7",
+      "title": "The Sufi Message Volume 7",
+      "type": "book",
+      "author": "Hazrat Inayat Khan",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hazrat-inayat-khan"
+      ]
+    },
+    {
+      "slug": "khema-12-steps-on-buddha-s-path",
+      "title": "12 Steps on Buddha's Path",
+      "type": "book",
+      "author": "Ayya Khema",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ayya-khema"
+      ]
+    },
+    {
+      "slug": "khema-all-of-us",
+      "title": "All of Us",
+      "type": "book",
+      "author": "Ayya Khema",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ayya-khema"
+      ]
+    },
+    {
+      "slug": "khema-be-an-island",
+      "title": "Be an Island",
+      "type": "book",
+      "author": "Ayya Khema",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ayya-khema"
+      ]
+    },
+    {
+      "slug": "khema-being-nobody-going-nowhere",
+      "title": "Being Nobody, Going Nowhere",
+      "type": "book",
+      "author": "Ayya Khema",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ayya-khema"
+      ]
+    },
+    {
+      "slug": "khema-buddha-ohne-geheimnis",
+      "title": "Buddha ohne Geheimnis",
+      "type": "book",
+      "author": "Ayya Khema",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ayya-khema"
+      ]
+    },
+    {
+      "slug": "khema-i-give-you-my-life",
+      "title": "I Give You My Life",
+      "type": "book",
+      "author": "Ayya Khema",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ayya-khema"
+      ]
+    },
+    {
+      "slug": "khema-know-where-you-re-going",
+      "title": "Know Where You're Going",
+      "type": "book",
+      "author": "Ayya Khema",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ayya-khema"
+      ]
+    },
+    {
+      "slug": "khema-meditation-ohne-geheimnis",
+      "title": "Meditation ohne Geheimnis",
+      "type": "book",
+      "author": "Ayya Khema",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ayya-khema"
+      ]
+    },
+    {
+      "slug": "khema-the-path-to-peace",
+      "title": "The Path to Peace",
+      "type": "book",
+      "author": "Ayya Khema",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ayya-khema"
+      ]
+    },
+    {
+      "slug": "khema-visible-here-and-now",
+      "title": "Visible Here and Now",
+      "type": "book",
+      "author": "Ayya Khema",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ayya-khema"
+      ]
+    },
+    {
+      "slug": "khema-when-the-iron-eagle-flies",
+      "title": "When the Iron Eagle Flies",
+      "type": "book",
+      "author": "Ayya Khema",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ayya-khema"
+      ]
+    },
+    {
+      "slug": "khema-within-our-own-hearts",
+      "title": "Within Our Own Hearts",
+      "type": "book",
+      "author": "Ayya Khema",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ayya-khema"
+      ]
+    },
+    {
+      "slug": "klein-be-who-you-are",
+      "title": "Be who You are",
+      "type": "book",
+      "author": "Jean Klein",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "jean-klein"
+      ]
+    },
+    {
+      "slug": "klein-beyond-knowledge",
+      "title": "Beyond Knowledge",
+      "type": "book",
+      "author": "Jean Klein",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "jean-klein"
+      ]
+    },
+    {
+      "slug": "klein-dictionnaire-de-strategie",
+      "title": "Dictionnaire de stratégie",
+      "type": "book",
+      "author": "Jean Klein",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "jean-klein"
+      ]
+    },
+    {
+      "slug": "klein-etre-approches-de-la-non-dualite",
+      "title": "Etre - Approches de la non-dualité",
+      "type": "book",
+      "author": "Jean Klein",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "jean-klein"
+      ]
+    },
+    {
+      "slug": "klein-i-am",
+      "title": "I Am",
+      "type": "book",
+      "author": "Jean Klein",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "jean-klein"
+      ]
+    },
+    {
+      "slug": "klein-la-joie-sans-objet-l-ultime-realite-sois-ce-que-tu-es-suivi-d-entretiens-i",
+      "title": "La joie sans objet - L'ultime réalité - Sois ce que tu es - Suivi d'Entretiens inédits",
+      "type": "book",
+      "author": "Jean Klein",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "jean-klein"
+      ]
+    },
+    {
+      "slug": "klein-living-truth",
+      "title": "Living Truth",
+      "type": "book",
+      "author": "Jean Klein",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "jean-klein"
+      ]
+    },
+    {
+      "slug": "klein-margaret-junkin-preston-poet-of-the-confederacy",
+      "title": "Margaret Junkin Preston, Poet of the Confederacy",
+      "type": "book",
+      "author": "Jean Klein",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "jean-klein"
+      ]
+    },
+    {
+      "slug": "klein-the-book-of-listening",
+      "title": "The Book of Listening",
+      "type": "book",
+      "author": "Jean Klein",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "jean-klein"
+      ]
+    },
+    {
+      "slug": "klein-the-ease-of-being",
+      "title": "The Ease of Being",
+      "type": "book",
+      "author": "Jean Klein",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "jean-klein"
+      ]
+    },
+    {
+      "slug": "klein-transmettre-la-lumiere",
+      "title": "Transmettre la lumière",
+      "type": "book",
+      "author": "Jean Klein",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "jean-klein"
+      ]
+    },
+    {
+      "slug": "klein-who-am-i",
+      "title": "Who Am I?",
+      "type": "book",
+      "author": "Jean Klein",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "jean-klein"
+      ]
+    },
+    {
+      "slug": "know-yourself-balyani",
+      "title": "Know Yourself: An Explanation of the Oneness of Being",
+      "type": "book",
+      "author": "Awhad al-Din Balyani",
+      "traditions": [
+        "sufism",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "rupert-spira"
+      ]
+    },
+    {
+      "slug": "kornfield-a-lamp-in-the-darkness",
+      "title": "A Lamp in the Darkness",
+      "type": "book",
+      "author": "Jack Kornfield",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "jack-kornfield"
+      ]
+    },
+    {
+      "slug": "kornfield-after-the-ecstasy-the-laundry",
+      "title": "After the Ecstasy, the Laundry",
+      "type": "book",
+      "author": "Jack Kornfield",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "jack-kornfield"
+      ]
+    },
+    {
+      "slug": "kornfield-all-in-this-together",
+      "title": "All in This Together",
+      "type": "book",
+      "author": "Jack Kornfield",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "jack-kornfield"
+      ]
+    },
+    {
+      "slug": "kornfield-bringing-home-the-dharma",
+      "title": "Bringing Home the Dharma",
+      "type": "book",
+      "author": "Jack Kornfield",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "jack-kornfield"
+      ]
+    },
+    {
+      "slug": "kornfield-buddha-s-little-instruction-book",
+      "title": "Buddha's Little Instruction Book",
+      "type": "book",
+      "author": "Jack Kornfield",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "jack-kornfield"
+      ]
+    },
+    {
+      "slug": "kornfield-meditation-for-beginners-easyread-large-bold-edition",
+      "title": "Meditation For Beginners (EasyRead Large Bold Edition)",
+      "type": "book",
+      "author": "Jack Kornfield",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "jack-kornfield"
+      ]
+    },
+    {
+      "slug": "kornfield-modern-buddhist-masters",
+      "title": "Modern Buddhist Masters",
+      "type": "book",
+      "author": "Jack Kornfield",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "jack-kornfield"
+      ]
+    },
+    {
+      "slug": "kornfield-no-time-like-the-present",
+      "title": "No Time Like the Present",
+      "type": "book",
+      "author": "Jack Kornfield",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "jack-kornfield"
+      ]
+    },
+    {
+      "slug": "kornfield-seeking-the-heart-of-wisdom",
+      "title": "Seeking the Heart of Wisdom",
+      "type": "book",
+      "author": "Jack Kornfield",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "jack-kornfield"
+      ]
+    },
+    {
+      "slug": "kornfield-teachings-of-the-buddha",
+      "title": "Teachings of the Buddha",
+      "type": "book",
+      "author": "Jack Kornfield",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "jack-kornfield"
+      ]
+    },
+    {
+      "slug": "kornfield-the-art-of-forgiveness-lovingkindness-and-peace",
+      "title": "The Art of Forgiveness, Lovingkindness, and Peace",
+      "type": "book",
+      "author": "Jack Kornfield",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "jack-kornfield"
+      ]
+    },
+    {
+      "slug": "kornfield-the-path-of-insight-meditation",
+      "title": "The Path of Insight Meditation",
+      "type": "book",
+      "author": "Jack Kornfield",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "jack-kornfield"
+      ]
+    },
+    {
+      "slug": "kornfield-the-wise-heart",
+      "title": "The Wise Heart",
+      "type": "book",
+      "author": "Jack Kornfield",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "jack-kornfield"
+      ]
+    },
+    {
+      "slug": "krishnamacharya-il-nettare-dello-yoga",
+      "title": "Il nettare dello yoga",
+      "type": "book",
+      "author": "T. Krishnamacharya",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "t-krishnamacharya"
+      ]
+    },
+    {
+      "slug": "krishnamacharya-nathamuni-s-yoga-rahasya",
+      "title": "Nāthamuni's Yoga Rahasya",
+      "type": "book",
+      "author": "T. Krishnamacharya",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "t-krishnamacharya"
+      ]
+    },
+    {
+      "slug": "levine-against-the-stream",
+      "title": "Against the Stream",
+      "type": "book",
+      "author": "Noah Levine",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "noah-levine"
+      ]
+    },
+    {
+      "slug": "levine-dharma-punx",
+      "title": "Dharma Punx",
+      "type": "book",
+      "author": "Noah Levine",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "noah-levine"
+      ]
+    },
+    {
+      "slug": "levine-refuge-recovery",
+      "title": "Refuge Recovery",
+      "type": "book",
+      "author": "Noah Levine",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "noah-levine"
+      ]
+    },
+    {
+      "slug": "levine-the-heart-of-the-revolution",
+      "title": "The Heart of the Revolution",
+      "type": "book",
+      "author": "Noah Levine",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "noah-levine"
+      ]
+    },
+    {
+      "slug": "liberation-av-neryah",
+      "title": "Liberation: A Spiritual Autobiography",
+      "type": "book",
+      "author": "Av Neryah",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "av-neryah"
+      ]
+    },
+    {
+      "slug": "liebenson-the-magnanimous-heart",
+      "title": "The Magnanimous Heart",
+      "type": "book",
+      "author": "Narayan Helen Liebenson",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "narayan-helen-liebenson"
+      ]
+    },
+    {
+      "slug": "light-on-yoga",
+      "title": "Light on Yoga",
+      "type": "book",
+      "author": "B.K.S. Iyengar",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "lingo-healing-our-way-home",
+      "title": "Healing Our Way Home",
+      "type": "book",
+      "author": "Kaira Jewel Lingo",
+      "traditions": [
+        "vipassana-movement",
+        "zen"
+      ],
+      "teachers": [
+        "kaira-jewel-lingo"
+      ]
+    },
+    {
+      "slug": "lingo-we-were-made-for-these-times",
+      "title": "We Were Made for These Times",
+      "type": "book",
+      "author": "Kaira Jewel Lingo",
+      "traditions": [
+        "vipassana-movement",
+        "zen"
+      ],
+      "teachers": [
+        "kaira-jewel-lingo"
+      ]
+    },
+    {
+      "slug": "lingo-wir-wurden-fur-diese-zeiten-geschaffen",
+      "title": "Wir wurden für diese Zeiten geschaffen",
+      "type": "book",
+      "author": "Kaira Jewel Lingo",
+      "traditions": [
+        "vipassana-movement",
+        "zen"
+      ],
+      "teachers": [
+        "kaira-jewel-lingo"
+      ]
+    },
+    {
+      "slug": "living-dharma",
+      "title": "Living Dharma",
+      "type": "book",
+      "author": "Jack Kornfield",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "jack-kornfield"
+      ]
+    },
+    {
+      "slug": "longchenpa-a-collection-of-essential-tsok-offering-prayers",
+      "title": "A Collection of Essential Tsok Offering Prayers",
+      "type": "book",
+      "author": "Longchenpa",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": [
+        "longchenpa"
+      ]
+    },
+    {
+      "slug": "longchenpa-collection-of-essential-tsok-offering-prayers",
+      "title": "Collection of Essential Tsok Offering Prayers",
+      "type": "book",
+      "author": "Longchenpa",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": [
+        "longchenpa"
+      ]
+    },
+    {
+      "slug": "longchenpa-finding-rest-in-illusion",
+      "title": "Finding Rest in Illusion",
+      "type": "book",
+      "author": "Longchenpa",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": [
+        "longchenpa"
+      ]
+    },
+    {
+      "slug": "longchenpa-finding-rest-in-meditation",
+      "title": "Finding Rest in Meditation",
+      "type": "book",
+      "author": "Longchenpa",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": [
+        "longchenpa"
+      ]
+    },
+    {
+      "slug": "longchenpa-finding-rest-in-the-nature-of-the-mind",
+      "title": "Finding Rest in the Nature of the Mind",
+      "type": "book",
+      "author": "Longchenpa",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": [
+        "longchenpa"
+      ]
+    },
+    {
+      "slug": "longchenpa-la-liberte-naturelle-de-l-esprit",
+      "title": "La liberté naturelle de l'esprit",
+      "type": "book",
+      "author": "Longchenpa",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": [
+        "longchenpa"
+      ]
+    },
+    {
+      "slug": "longchenpa-the-practice-of-dzogchen",
+      "title": "The Practice of Dzogchen",
+      "type": "book",
+      "author": "Longchenpa",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": [
+        "longchenpa"
+      ]
+    },
+    {
+      "slug": "longchenpa-the-precious-treasury-of-essential-instructions",
+      "title": "The Precious Treasury of Essential Instructions",
+      "type": "book",
+      "author": "Longchenpa",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": [
+        "longchenpa"
+      ]
+    },
+    {
+      "slug": "longchenpa-the-precious-treasury-of-the-dharmadhatu",
+      "title": "The Precious Treasury of the Dharmadhatu",
+      "type": "book",
+      "author": "Longchenpa",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": [
+        "longchenpa"
+      ]
+    },
+    {
+      "slug": "longchenpa-the-precious-treasury-of-the-fundamental-nature",
+      "title": "The Precious Treasury of the Fundamental Nature",
+      "type": "book",
+      "author": "Longchenpa",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": [
+        "longchenpa"
+      ]
+    },
+    {
+      "slug": "longchenpa-you-are-the-eyes-of-the-world",
+      "title": "You Are the Eyes of the World",
+      "type": "book",
+      "author": "Longchenpa",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": [
+        "longchenpa"
+      ]
+    },
+    {
+      "slug": "lotsawa-house",
+      "title": "Lotsawa House",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-nyingma",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-gelug",
+        "dzogchen"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "lovingkindness",
+      "title": "Lovingkindness: The Revolutionary Art of Happiness",
+      "type": "book",
+      "author": "Sharon Salzberg",
+      "traditions": [
+        "vipassana-movement",
+        "theravada"
+      ],
+      "teachers": [
+        "sharon-salzberg"
+      ]
+    },
+    {
+      "slug": "maharaj-awaken-to-the-eternal",
+      "title": "Awaken to the Eternal",
+      "type": "book",
+      "author": "Nisargadatta Maharaj",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "nisargadatta-maharaj"
+      ]
+    },
+    {
+      "slug": "maharaj-beyond-freedom",
+      "title": "Beyond Freedom",
+      "type": "book",
+      "author": "Nisargadatta Maharaj",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "nisargadatta-maharaj"
+      ]
+    },
+    {
+      "slug": "maharaj-experience-of-nothingness",
+      "title": "Experience of Nothingness",
+      "type": "book",
+      "author": "Nisargadatta Maharaj",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "nisargadatta-maharaj"
+      ]
+    },
+    {
+      "slug": "maharaj-nectar-of-immortality",
+      "title": "Nectar of Immortality",
+      "type": "book",
+      "author": "Nisargadatta Maharaj",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "nisargadatta-maharaj"
+      ]
+    },
+    {
+      "slug": "maharaj-self-knowledge-self-realization",
+      "title": "Self Knowledge & Self Realization",
+      "type": "book",
+      "author": "Nisargadatta Maharaj",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "nisargadatta-maharaj"
+      ]
+    },
+    {
+      "slug": "maharaj-the-experience-of-nothingness-sri-nisargadatta-maharaja-s-talks-on-reali",
+      "title": "The Experience Of Nothingness Sri Nisargadatta Maharaja`S Talks On Realizing The Infinite",
+      "type": "book",
+      "author": "Nisargadatta Maharaj",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "nisargadatta-maharaj"
+      ]
+    },
+    {
+      "slug": "maharaj-the-nectar-of-immortality",
+      "title": "The Nectar of Immortality",
+      "type": "book",
+      "author": "Nisargadatta Maharaj",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "nisargadatta-maharaj"
+      ]
+    },
+    {
+      "slug": "maharaj-the-ultimate-medicine",
+      "title": "The Ultimate Medicine",
+      "type": "book",
+      "author": "Nisargadatta Maharaj",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "nisargadatta-maharaj"
+      ]
+    },
+    {
+      "slug": "maharaj-ultimate-medicine",
+      "title": "Ultimate Medicine",
+      "type": "book",
+      "author": "Nisargadatta Maharaj",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "nisargadatta-maharaj"
+      ]
+    },
+    {
+      "slug": "maharshi-aham-sphurana-i-sri-ramana-maharshi-i-new-book-i-advaita-vedanta",
+      "title": "Aham Sphurana I Sri Ramana Maharshi I NEW BOOK I Advaita Vedanta",
+      "type": "book",
+      "author": "Ramana Maharshi",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "ramana-maharshi"
+      ]
+    },
+    {
+      "slug": "maharshi-be-as-you-are",
+      "title": "Be As You Are",
+      "type": "book",
+      "author": "Ramana Maharshi",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "ramana-maharshi"
+      ]
+    },
+    {
+      "slug": "maharshi-nan-yar-who-am-i-i-sri-ramana-maharshi-i-spiritual-classic-i-advaita-ve",
+      "title": "Nan Yar – Who am I? I Sri Ramana Maharshi I Spiritual Classic I Advaita Vedanta",
+      "type": "book",
+      "author": "Ramana Maharshi",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "ramana-maharshi"
+      ]
+    },
+    {
+      "slug": "maharshi-the-collected-works-of-ramana-maharshi",
+      "title": "The Collected Works of Ramana Maharshi",
+      "type": "book",
+      "author": "Ramana Maharshi",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "ramana-maharshi"
+      ]
+    },
+    {
+      "slug": "maharshi-the-spiritual-teaching-of-ramana-maharshi",
+      "title": "The Spiritual Teaching of Ramana Maharshi",
+      "type": "book",
+      "author": "Ramana Maharshi",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "ramana-maharshi"
+      ]
+    },
+    {
+      "slug": "mahayana-buddhism-stanford-encyclopedia-of-philosophy",
+      "title": "Mahayana Buddhism (Stanford Encyclopedia of Philosophy)",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "mahayana"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "mandukya-upanishad-with-gaudapada-s-karika",
+      "title": "Mandukya Upanishad with Gaudapada's Karika",
+      "type": "book",
+      "author": "Gaudapada / Shankara (commentary)",
+      "traditions": [
+        "advaita-vedanta",
+        "vedanta"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "manual-of-insight",
+      "title": "Manual of Insight",
+      "type": "book",
+      "author": "Mahasi Sayadaw",
+      "traditions": [
+        "vipassana-movement",
+        "theravada"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "manuel-opening-to-darkness",
+      "title": "Opening to Darkness",
+      "type": "book",
+      "author": "Zenju Earthlyn Manuel",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "zenju-earthlyn-manuel"
+      ]
+    },
+    {
+      "slug": "manuel-our-black-was-water",
+      "title": "Our Black was Water",
+      "type": "book",
+      "author": "Zenju Earthlyn Manuel",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "zenju-earthlyn-manuel"
+      ]
+    },
+    {
+      "slug": "manuel-sanctuary",
+      "title": "Sanctuary",
+      "type": "book",
+      "author": "Zenju Earthlyn Manuel",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "zenju-earthlyn-manuel"
+      ]
+    },
+    {
+      "slug": "manuel-tell-me-something-about-buddhism",
+      "title": "Tell Me Something About Buddhism",
+      "type": "book",
+      "author": "Zenju Earthlyn Manuel",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "zenju-earthlyn-manuel"
+      ]
+    },
+    {
+      "slug": "manuel-the-deepest-peace",
+      "title": "The Deepest Peace",
+      "type": "book",
+      "author": "Zenju Earthlyn Manuel",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "zenju-earthlyn-manuel"
+      ]
+    },
+    {
+      "slug": "manuel-the-shamanic-bones-of-zen",
+      "title": "The Shamanic Bones of Zen",
+      "type": "book",
+      "author": "Zenju Earthlyn Manuel",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "zenju-earthlyn-manuel"
+      ]
+    },
+    {
+      "slug": "manuel-the-way-of-tenderness",
+      "title": "The Way of Tenderness",
+      "type": "book",
+      "author": "Zenju Earthlyn Manuel",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "zenju-earthlyn-manuel"
+      ]
+    },
+    {
+      "slug": "mate-close-encounters-with-addiction",
+      "title": "Close Encounters with Addiction",
+      "type": "book",
+      "author": "Gabor Maté",
+      "traditions": [
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "gabor-mate"
+      ]
+    },
+    {
+      "slug": "mate-de-mythe-van-normaal",
+      "title": "De mythe van normaal",
+      "type": "book",
+      "author": "Gabor Maté",
+      "traditions": [
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "gabor-mate"
+      ]
+    },
+    {
+      "slug": "mate-in-the-realm-of-hungry-ghosts",
+      "title": "In the Realm of Hungry Ghosts",
+      "type": "book",
+      "author": "Gabor Maté",
+      "traditions": [
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "gabor-mate"
+      ]
+    },
+    {
+      "slug": "mate-mentes-dispersas",
+      "title": "Mentes Dispersas",
+      "type": "book",
+      "author": "Gabor Maté",
+      "traditions": [
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "gabor-mate"
+      ]
+    },
+    {
+      "slug": "mate-o-mito-do-normal",
+      "title": "O Mito do Normal",
+      "type": "book",
+      "author": "Gabor Maté",
+      "traditions": [
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "gabor-mate"
+      ]
+    },
+    {
+      "slug": "mate-scattered-minds",
+      "title": "Scattered Minds",
+      "type": "book",
+      "author": "Gabor Maté",
+      "traditions": [
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "gabor-mate"
+      ]
+    },
+    {
+      "slug": "mate-the-myth-of-normal-trauma-illness-and-healing-in-a-toxic-culture",
+      "title": "The Myth of Normal: Trauma, Illness, and Healing in a Toxic Culture",
+      "type": "book",
+      "author": "Gabor Maté",
+      "traditions": [
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "gabor-mate"
+      ]
+    },
+    {
+      "slug": "mate-the-myth-of-normal",
+      "title": "The Myth of Normal",
+      "type": "book",
+      "author": "Gabor Maté",
+      "traditions": [
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "gabor-mate"
+      ]
+    },
+    {
+      "slug": "mate-when-the-body-says-no",
+      "title": "When the Body Says No",
+      "type": "book",
+      "author": "Gabor Maté",
+      "traditions": [
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "gabor-mate"
+      ]
+    },
+    {
+      "slug": "maull-dharma-in-hell",
+      "title": "Dharma in Hell",
+      "type": "book",
+      "author": "Fleet Maull",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "fleet-maull"
+      ]
+    },
+    {
+      "slug": "maull-radical-responsibility",
+      "title": "Radical Responsibility",
+      "type": "book",
+      "author": "Fleet Maull",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "fleet-maull"
+      ]
+    },
+    {
+      "slug": "maull-the-resilient-c-o",
+      "title": "The Resilient C.O.",
+      "type": "book",
+      "author": "Fleet Maull",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "fleet-maull"
+      ]
+    },
+    {
+      "slug": "meister-eckhart-selected-writings",
+      "title": "Meister Eckhart: Selected Writings",
+      "type": "book",
+      "author": "Meister Eckhart",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "mindfulness-a-practical-guide-to-awakening",
+      "title": "Mindfulness: A Practical Guide to Awakening",
+      "type": "book",
+      "author": "Joseph Goldstein",
+      "traditions": [
+        "vipassana-movement",
+        "theravada",
+        "early-buddhism"
+      ],
+      "teachers": [
+        "joseph-goldstein"
+      ]
+    },
+    {
+      "slug": "mindfulness-in-plain-english",
+      "title": "Mindfulness in Plain English",
+      "type": "book",
+      "author": "Bhante Gunaratana",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "mindfulness-psychology-today",
+      "title": "Mindfulness (Psychology Today)",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "secular-mindfulness"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "mingyur-rinpoche-happiness-is-here",
+      "title": "Yongey Mingyur Rinpoche: Happiness Is Here and Now",
+      "type": "video",
+      "author": "Yongey Mingyur Rinpoche",
+      "traditions": [
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "mipham-meester-over-je-eigen-leven-druk-1",
+      "title": "Meester over je eigen leven / druk 1",
+      "type": "book",
+      "author": "Sakyong Mipham",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "sakyong-mipham"
+      ]
+    },
+    {
+      "slug": "mipham-meester-over-je-eigen-leven-druk-3",
+      "title": "Meester over je eigen leven / druk 3",
+      "type": "book",
+      "author": "Sakyong Mipham",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "sakyong-mipham"
+      ]
+    },
+    {
+      "slug": "mipham-quiet-mind",
+      "title": "Quiet Mind",
+      "type": "book",
+      "author": "Sakyong Mipham",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "sakyong-mipham"
+      ]
+    },
+    {
+      "slug": "mipham-ruling-your-world",
+      "title": "Ruling Your World",
+      "type": "book",
+      "author": "Sakyong Mipham",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "sakyong-mipham"
+      ]
+    },
+    {
+      "slug": "mipham-running-buddha",
+      "title": "Running buddha",
+      "type": "book",
+      "author": "Sakyong Mipham",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "sakyong-mipham"
+      ]
+    },
+    {
+      "slug": "mipham-running-with-the-mind-of-meditation",
+      "title": "Running with the Mind of Meditation",
+      "type": "book",
+      "author": "Sakyong Mipham",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "sakyong-mipham"
+      ]
+    },
+    {
+      "slug": "mipham-the-lost-art-of-good-conversation",
+      "title": "The Lost Art of Good Conversation",
+      "type": "book",
+      "author": "Sakyong Mipham",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "sakyong-mipham"
+      ]
+    },
+    {
+      "slug": "mipham-the-shambhala-principle",
+      "title": "The Shambhala Principle",
+      "type": "book",
+      "author": "Sakyong Mipham",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "sakyong-mipham"
+      ]
+    },
+    {
+      "slug": "mipham-turning-the-mind-into-an-ally",
+      "title": "Turning the Mind Into an Ally",
+      "type": "book",
+      "author": "Sakyong Mipham",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "sakyong-mipham"
+      ]
+    },
+    {
+      "slug": "mipham",
+      "title": "統御你的世界",
+      "type": "book",
+      "author": "Sakyong Mipham",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "sakyong-mipham"
+      ]
+    },
+    {
+      "slug": "moffitt-awakening-through-the-nine-bodies",
+      "title": "Awakening through the Nine Bodies",
+      "type": "book",
+      "author": "Phillip Moffitt",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "phillip-moffitt"
+      ]
+    },
+    {
+      "slug": "moffitt-bailando-con-la-vida",
+      "title": "Bailando con la Vida",
+      "type": "book",
+      "author": "Phillip Moffitt",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "phillip-moffitt"
+      ]
+    },
+    {
+      "slug": "moffitt-dancing-with-life",
+      "title": "Dancing With Life",
+      "type": "book",
+      "author": "Phillip Moffitt",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "phillip-moffitt"
+      ]
+    },
+    {
+      "slug": "moffitt-emotional-chaos-to-clarity",
+      "title": "Emotional Chaos to Clarity",
+      "type": "book",
+      "author": "Phillip Moffitt",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "phillip-moffitt"
+      ]
+    },
+    {
+      "slug": "moffitt-the-power-to-heal",
+      "title": "The Power to Heal",
+      "type": "book",
+      "author": "Phillip Moffitt",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "phillip-moffitt"
+      ]
+    },
+    {
+      "slug": "moffitt-van-emotionele-chaos-naar-helderheid-in-je-hoofd-druk-1",
+      "title": "Van emotionele chaos naar helderheid in je hoofd / druk 1",
+      "type": "book",
+      "author": "Phillip Moffitt",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "phillip-moffitt"
+      ]
+    },
+    {
+      "slug": "mooji-an-invitation-to-freedom",
+      "title": "An Invitation to Freedom",
+      "type": "book",
+      "author": "Mooji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "mooji"
+      ]
+    },
+    {
+      "slug": "mooji-antes-de-yo-soy",
+      "title": "Antes de yo soy",
+      "type": "book",
+      "author": "Mooji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "mooji"
+      ]
+    },
+    {
+      "slug": "mooji-before-i-am",
+      "title": "Before I Am",
+      "type": "book",
+      "author": "Mooji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "mooji"
+      ]
+    },
+    {
+      "slug": "mooji-breath-of-the-absolute",
+      "title": "Breath of the Absolute",
+      "type": "book",
+      "author": "Mooji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "mooji"
+      ]
+    },
+    {
+      "slug": "mooji-el-mala-de-dios",
+      "title": "El Mala de Dios",
+      "type": "book",
+      "author": "Mooji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "mooji"
+      ]
+    },
+    {
+      "slug": "mooji-fuego-blanco-segunda-edicion-volumen-i",
+      "title": "Fuego blanco, segunda edición, volumen I",
+      "type": "book",
+      "author": "Mooji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "mooji"
+      ]
+    },
+    {
+      "slug": "mooji-the-mala-of-god",
+      "title": "The Mala of God",
+      "type": "book",
+      "author": "Mooji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "mooji"
+      ]
+    },
+    {
+      "slug": "mooji-white-ffre",
+      "title": "White FFre",
+      "type": "book",
+      "author": "Mooji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "mooji"
+      ]
+    },
+    {
+      "slug": "mooji-white-fire-2nd-edition",
+      "title": "White Fire (2ND EDITION)",
+      "type": "book",
+      "author": "Mooji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "mooji"
+      ]
+    },
+    {
+      "slug": "mooji-white-fire",
+      "title": "White Fire",
+      "type": "book",
+      "author": "Mooji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "mooji"
+      ]
+    },
+    {
+      "slug": "mooji-wit-vuur",
+      "title": "Wit vuur",
+      "type": "book",
+      "author": "Mooji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "mooji"
+      ]
+    },
+    {
+      "slug": "mooji-writing-on-water",
+      "title": "Writing on Water",
+      "type": "book",
+      "author": "Mooji",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "mooji"
+      ]
+    },
+    {
+      "slug": "morgan-the-heart-of-who-we-are",
+      "title": "The Heart of Who We Are",
+      "type": "book",
+      "author": "Caverly Morgan",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "caverly-morgan"
+      ]
+    },
+    {
+      "slug": "mumford-a-century-on-new-brunswick-s-n-w-miramichi",
+      "title": "A Century on New Brunswick's N.W. Miramichi",
+      "type": "book",
+      "author": "George Mumford",
+      "traditions": [
+        "vipassana-movement",
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "george-mumford"
+      ]
+    },
+    {
+      "slug": "mumford-la-mentalita-vincente",
+      "title": "La mentalità vincente",
+      "type": "book",
+      "author": "George Mumford",
+      "traditions": [
+        "vipassana-movement",
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "george-mumford"
+      ]
+    },
+    {
+      "slug": "mumford-libera-la-tua-mente-cambia-la-tua-vita-come-sbloccare-il-tuo-potenziale-",
+      "title": "Libera la tua mente cambia la tua vita. Come sbloccare il tuo potenziale e raggiungere il successo",
+      "type": "book",
+      "author": "George Mumford",
+      "traditions": [
+        "vipassana-movement",
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "george-mumford"
+      ]
+    },
+    {
+      "slug": "mumford-libera-la-tua-mente-cambia-la-tua-vita",
+      "title": "Libera la tua mente, cambia la tua vita",
+      "type": "book",
+      "author": "George Mumford",
+      "traditions": [
+        "vipassana-movement",
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "george-mumford"
+      ]
+    },
+    {
+      "slug": "mumford-the-environment-and-history-of-pegan-hill-and-rocky-narrows-premiere-con",
+      "title": "The Environment and History of Pegan Hill and Rocky Narrows Premiere Conservation Lands",
+      "type": "book",
+      "author": "George Mumford",
+      "traditions": [
+        "vipassana-movement",
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "george-mumford"
+      ]
+    },
+    {
+      "slug": "mumford-the-mindful-athlete-second-edition",
+      "title": "The Mindful Athlete: Second Edition",
+      "type": "book",
+      "author": "George Mumford",
+      "traditions": [
+        "vipassana-movement",
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "george-mumford"
+      ]
+    },
+    {
+      "slug": "mumford-the-mindful-athlete",
+      "title": "The Mindful Athlete",
+      "type": "book",
+      "author": "George Mumford",
+      "traditions": [
+        "vipassana-movement",
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "george-mumford"
+      ]
+    },
+    {
+      "slug": "mumford-unlocked",
+      "title": "Unlocked",
+      "type": "book",
+      "author": "George Mumford",
+      "traditions": [
+        "vipassana-movement",
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "george-mumford"
+      ]
+    },
+    {
+      "slug": "mysticism-stanford-encyclopedia-of-philosophy",
+      "title": "Mysticism (Stanford Encyclopedia of Philosophy)",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "christian-mysticism",
+        "hesychasm"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "narada-bhakti-sutras",
+      "title": "Narada Bhakti Sutras",
+      "type": "book",
+      "author": "Narada",
+      "traditions": [
+        "bhakti"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "naropa-iniziazione-kalacakra",
+      "title": "Iniziazione (Kalacakra)",
+      "type": "book",
+      "author": "Naropa",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "naropa"
+      ]
+    },
+    {
+      "slug": "naropa-speaking-of-silence-christians-and-buddhists-in-dialogue",
+      "title": "Speaking of Silence : Christians and Buddhists in Dialogue",
+      "type": "book",
+      "author": "Naropa",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "naropa"
+      ]
+    },
+    {
+      "slug": "nature-of-consciousness",
+      "title": "The Nature of Consciousness",
+      "type": "book",
+      "author": "Rupert Spira",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "rupert-spira"
+      ]
+    },
+    {
+      "slug": "neoplatonism-stanford-encyclopedia-of-philosophy",
+      "title": "Neoplatonism (Stanford Encyclopedia of Philosophy)",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "neoplatonism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "neoplatonism",
+      "title": "Neoplatonism",
+      "type": "book",
+      "author": "Pauliina Remes",
+      "traditions": [
+        "neoplatonism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "neryah-liberation-gita",
+      "title": "Liberation Gita",
+      "type": "book",
+      "author": "Av Neryah",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "av-neryah"
+      ]
+    },
+    {
+      "slug": "nichtern-awakening-from-the-daydream",
+      "title": "Awakening from the Daydream",
+      "type": "book",
+      "author": "David Nichtern",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "david-nichtern"
+      ]
+    },
+    {
+      "slug": "nichtern-creativity-spirituality-and-making-a-buck",
+      "title": "Creativity, Spirituality, and Making a Buck",
+      "type": "book",
+      "author": "David Nichtern",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "david-nichtern"
+      ]
+    },
+    {
+      "slug": "nisker-being-nature",
+      "title": "Being Nature",
+      "type": "book",
+      "author": "Wes Nisker",
+      "traditions": [
+        "early-buddhism",
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "wes-nisker"
+      ]
+    },
+    {
+      "slug": "nisker-buddha-s-nature",
+      "title": "Buddha's Nature",
+      "type": "book",
+      "author": "Wes Nisker",
+      "traditions": [
+        "early-buddhism",
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "wes-nisker"
+      ]
+    },
+    {
+      "slug": "nisker-crazy-wisdom-save-the-world-again",
+      "title": "Crazy Wisdom Save the World Again!",
+      "type": "book",
+      "author": "Wes Nisker",
+      "traditions": [
+        "early-buddhism",
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "wes-nisker"
+      ]
+    },
+    {
+      "slug": "nisker-crazy-wisdom-saves-the-world-again",
+      "title": "Crazy Wisdom Saves the World Again!",
+      "type": "book",
+      "author": "Wes Nisker",
+      "traditions": [
+        "early-buddhism",
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "wes-nisker"
+      ]
+    },
+    {
+      "slug": "nisker-the-big-bang-the-buddha-and-the-baby-boom",
+      "title": "The Big Bang, the Buddha, and the Baby Boom",
+      "type": "book",
+      "author": "Wes Nisker",
+      "traditions": [
+        "early-buddhism",
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "wes-nisker"
+      ]
+    },
+    {
+      "slug": "nisker-the-essential-crazy-wisdom",
+      "title": "The Essential Crazy Wisdom",
+      "type": "book",
+      "author": "Wes Nisker",
+      "traditions": [
+        "early-buddhism",
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "wes-nisker"
+      ]
+    },
+    {
+      "slug": "nisker-you-are-not-your-fault-and-other-revelations",
+      "title": "You Are Not Your Fault and Other Revelations",
+      "type": "book",
+      "author": "Wes Nisker",
+      "traditions": [
+        "early-buddhism",
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "wes-nisker"
+      ]
+    },
+    {
+      "slug": "non-dual-awareness-science-and-nonduality",
+      "title": "Non-Dual Awareness (Science and Nonduality)",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "modern-non-dual",
+        "advaita-vedanta"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "o-hara-a-little-bit-of-zen",
+      "title": "A Little Bit of Zen",
+      "type": "book",
+      "author": "Roshi Pat Enkyo O'Hara",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "roshi-enkyo-ohara"
+      ]
+    },
+    {
+      "slug": "o-hara-most-intimate",
+      "title": "Most Intimate",
+      "type": "book",
+      "author": "Roshi Pat Enkyo O'Hara",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "roshi-enkyo-ohara"
+      ]
+    },
+    {
+      "slug": "on-the-prayer-of-jesus",
+      "title": "On the Prayer of Jesus",
+      "type": "book",
+      "author": "Ignatius Brianchaninov",
+      "traditions": [
+        "hesychasm",
+        "christian-mysticism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "open-awareness-open-mind",
+      "title": "Open Awareness, Open Mind",
+      "type": "book",
+      "author": "Georgiann Voissem",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "origins-of-yoga-and-tantra",
+      "title": "The Origins of Yoga and Tantra",
+      "type": "book",
+      "author": "Geoffrey Samuel",
+      "traditions": [
+        "classical-yoga",
+        "tantra"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "owens-love-and-rage",
+      "title": "Love and Rage",
+      "type": "book",
+      "author": "Lama Rod Owens",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu"
+      ],
+      "teachers": [
+        "lama-rod-owens"
+      ]
+    },
+    {
+      "slug": "owens-the-new-saints",
+      "title": "The New Saints",
+      "type": "book",
+      "author": "Lama Rod Owens",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu"
+      ],
+      "teachers": [
+        "lama-rod-owens"
+      ]
+    },
+    {
+      "slug": "padmasambhava-a-garland-of-views",
+      "title": "A Garland of Views",
+      "type": "book",
+      "author": "Padmasambhava",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "padmasambhava"
+      ]
+    },
+    {
+      "slug": "padmasambhava-bardo-thodol",
+      "title": "Bardo Thödol",
+      "type": "book",
+      "author": "Padmasambhava",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "padmasambhava"
+      ]
+    },
+    {
+      "slug": "padmasambhava-dakini-activity",
+      "title": "Dakini Activity",
+      "type": "book",
+      "author": "Padmasambhava",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "padmasambhava"
+      ]
+    },
+    {
+      "slug": "padmasambhava-dakini-teachings",
+      "title": "Dakini Teachings",
+      "type": "book",
+      "author": "Padmasambhava",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "padmasambhava"
+      ]
+    },
+    {
+      "slug": "padmasambhava-light-of-wisdom-volume-i",
+      "title": "Light of Wisdom, Volume I",
+      "type": "book",
+      "author": "Padmasambhava",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "padmasambhava"
+      ]
+    },
+    {
+      "slug": "padmasambhava-natural-liberation",
+      "title": "Natural Liberation",
+      "type": "book",
+      "author": "Padmasambhava",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "padmasambhava"
+      ]
+    },
+    {
+      "slug": "padmasambhava-perfect-clarity",
+      "title": "Perfect Clarity",
+      "type": "book",
+      "author": "Padmasambhava",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "padmasambhava"
+      ]
+    },
+    {
+      "slug": "padmasambhava-secret-teachings-of-padmasambhava",
+      "title": "Secret Teachings of Padmasambhava",
+      "type": "book",
+      "author": "Padmasambhava",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "padmasambhava"
+      ]
+    },
+    {
+      "slug": "padmasambhava-the-tibetan-book-of-the-dead",
+      "title": "The Tibetan Book of the Dead",
+      "type": "book",
+      "author": "Padmasambhava",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "padmasambhava"
+      ]
+    },
+    {
+      "slug": "pali-text-society",
+      "title": "Pali Text Society",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "early-buddhism",
+        "theravada"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "patanjali-the-yoga-aphorisms-of-patanjali",
+      "title": "The Yoga Aphorisms of Patañjali",
+      "type": "book",
+      "author": "Patanjali",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "patanjali"
+      ]
+    },
+    {
+      "slug": "patanjali-the-yoga-sutras-of-patanjali-the-book-of-the-spiritual-man-annotated-e",
+      "title": "The Yoga Sutras Of Patanjali - The Book Of The Spiritual Man (Annotated Edition)",
+      "type": "book",
+      "author": "Patanjali",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "patanjali"
+      ]
+    },
+    {
+      "slug": "patanjali-the-yoga-sutras-of-patanjali-translated-with-a-preface-by-william-q-ju",
+      "title": "The Yoga Sutras of Patanjali (Translated with a Preface by William Q. Judge)",
+      "type": "book",
+      "author": "Patanjali",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "patanjali"
+      ]
+    },
+    {
+      "slug": "patanjali-yoga-sutras-of-patanjali",
+      "title": "Yoga Sutras of Patanjali",
+      "type": "book",
+      "author": "Patanjali",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "patanjali"
+      ]
+    },
+    {
+      "slug": "patanjali-yoga-sutras",
+      "title": "Yoga-Sutras",
+      "type": "book",
+      "author": "Patanjali",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "patanjali"
+      ]
+    },
+    {
+      "slug": "pendle-hill-pamphlets",
+      "title": "Pendle Hill Pamphlets",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "quaker-inner-light"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "philokalia",
+      "title": "The Philokalia",
+      "type": "book",
+      "author": null,
+      "traditions": [
+        "hesychasm",
+        "christian-mysticism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "plotinus-introduction-to-the-enneads",
+      "title": "Plotinus: An Introduction to the Enneads",
+      "type": "book",
+      "author": "Dominic J. O'Meara",
+      "traditions": [
+        "neoplatonism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "precious-treasury-of-the-way-of-abiding",
+      "title": "The Precious Treasury of the Way of Abiding",
+      "type": "book",
+      "author": "Longchenpa (Longchen Rabjam)",
+      "traditions": [
+        "dzogchen"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "quaker-heritage-press",
+      "title": "Quaker Heritage Press",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "quaker-inner-light"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "quaker-spirituality",
+      "title": "Quaker Spirituality: Selected Writings",
+      "type": "book",
+      "author": "Douglas V. Steere",
+      "traditions": [
+        "quaker-inner-light"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "quakers-stanford-encyclopedia-of-philosophy",
+      "title": "Quakers (Stanford Encyclopedia of Philosophy)",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "quaker-inner-light"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "radical-acceptance",
+      "title": "Radical Acceptance",
+      "type": "book",
+      "author": "Tara Brach",
+      "traditions": [
+        "vipassana-movement",
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "tara-brach"
+      ]
+    },
+    {
+      "slug": "rasmussen-practicing-the-jhanas",
+      "title": "Practicing the Jhanas",
+      "type": "book",
+      "author": "Tina Rasmussen",
+      "traditions": [
+        "theravada",
+        "vipassana-movement",
+        "dzogchen"
+      ],
+      "teachers": [
+        "tina-rasmussen"
+      ]
+    },
+    {
+      "slug": "rasmussen-the-astd-trainer-s-sourcebook",
+      "title": "The ASTD Trainer's Sourcebook",
+      "type": "book",
+      "author": "Tina Rasmussen",
+      "traditions": [
+        "theravada",
+        "vipassana-movement",
+        "dzogchen"
+      ],
+      "teachers": [
+        "tina-rasmussen"
+      ]
+    },
+    {
+      "slug": "revival-of-the-religious-sciences-ihya-ulum-al-din",
+      "title": "Revival of the Religious Sciences (Ihya Ulum al-Din)",
+      "type": "book",
+      "author": "Abu Hamid al-Ghazali",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "rinpoche-14",
+      "title": "醒了就好：擁抱真愛的14段旅程",
+      "type": "book",
+      "author": "Tsoknyi Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tsoknyi-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-a-torch-lighting-the-way-to-freedom",
+      "title": "A Torch Lighting the Way to Freedom",
+      "type": "book",
+      "author": "Dudjom Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "dudjom-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-alegre-sabedoria",
+      "title": "Alegre sabedoria",
+      "type": "book",
+      "author": "Yongey Mingyur Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "mingyur-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-as-it-is",
+      "title": "As it is",
+      "type": "book",
+      "author": "Tulku Urgyen Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "tulku-urgyen-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-auf-dem-weg",
+      "title": "Auf dem Weg",
+      "type": "book",
+      "author": "Yongey Mingyur Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "mingyur-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-awakening-the-luminous-mind",
+      "title": "Awakening the Luminous Mind",
+      "type": "book",
+      "author": "Tenzin Wangyal Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tenzin-wangyal-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-awakening-the-sacred-body",
+      "title": "Awakening the Sacred Body",
+      "type": "book",
+      "author": "Tenzin Wangyal Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tenzin-wangyal-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-beyond-the-ordinary-mind",
+      "title": "Beyond the Ordinary Mind",
+      "type": "book",
+      "author": "Patrul Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "patrul-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-blazing-splendor",
+      "title": "Blazing Splendor",
+      "type": "book",
+      "author": "Tulku Urgyen Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "tulku-urgyen-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-bucuriile-intelepciunii",
+      "title": "Bucuriile înțelepciunii",
+      "type": "book",
+      "author": "Yongey Mingyur Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "mingyur-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-carefree-dignity",
+      "title": "Carefree Dignity",
+      "type": "book",
+      "author": "Tsoknyi Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tsoknyi-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-coracao-aberto-mente-aberta",
+      "title": "Coração aberto, mente aberta",
+      "type": "book",
+      "author": "Tsoknyi Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tsoknyi-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-criatividade-espontanea",
+      "title": "Criatividade espontânea",
+      "type": "book",
+      "author": "Tenzin Wangyal Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tenzin-wangyal-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-de-ce-meditam",
+      "title": "De ce medităm",
+      "type": "book",
+      "author": "Tsoknyi Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tsoknyi-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-deity-mantra-and-wisdom",
+      "title": "Deity, Mantra, and Wisdom",
+      "type": "book",
+      "author": "Patrul Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "patrul-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-dza-patrul-rinpoche-s-self-liberated-mind",
+      "title": "Dza Patrul Rinpoche's Self-Liberated Mind",
+      "type": "book",
+      "author": "Dzigar Kongtrul Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "dzigar-kongtrul-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-dzogchen-e-vita-quotidiana",
+      "title": "Dzogchen e vita quotidiana",
+      "type": "book",
+      "author": "Dilgo Khyentse Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "dilgo-khyentse-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-dzogchen-practitioner-s-daily-manual",
+      "title": "Dzogchen Practitioner's Daily Manual",
+      "type": "book",
+      "author": "Tulku Urgyen Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "tulku-urgyen-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-empowerment-samaya",
+      "title": "Empowerment & Samaya",
+      "type": "book",
+      "author": "Tulku Urgyen Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "tulku-urgyen-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-eq",
+      "title": "放不下，就握手言和吧：EQ始祖丹尼爾．高曼與措尼仁波切的冥想智慧",
+      "type": "book",
+      "author": "Tsoknyi Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tsoknyi-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-fearless-simplicity",
+      "title": "Fearless Simplicity",
+      "type": "book",
+      "author": "Tsoknyi Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tsoknyi-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-forelsket-i-verden",
+      "title": "Forelsket i verden",
+      "type": "book",
+      "author": "Yongey Mingyur Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "mingyur-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-gl-den-ved-at-v-re-til",
+      "title": "Glæden ved at være til",
+      "type": "book",
+      "author": "Yongey Mingyur Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "mingyur-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-great-accomplishment",
+      "title": "Great Accomplishment",
+      "type": "book",
+      "author": "Tulku Urgyen Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "tulku-urgyen-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-hinting-at-dzogchen",
+      "title": "Hinting at Dzogchen",
+      "type": "book",
+      "author": "Tsoknyi Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tsoknyi-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-how-mindfulness-works",
+      "title": "How Mindfulness Works",
+      "type": "book",
+      "author": "Tsoknyi Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tsoknyi-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-in-love-with-the-world",
+      "title": "In Love with the World",
+      "type": "book",
+      "author": "Yongey Mingyur Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "mingyur-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-indragostit-de-lume",
+      "title": "Indragostit de lume",
+      "type": "book",
+      "author": "Yongey Mingyur Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "mingyur-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-intrepida-compassione",
+      "title": "Intrepida compassione",
+      "type": "book",
+      "author": "Dilgo Khyentse Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "dilgo-khyentse-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-joyful-wisdom",
+      "title": "Joyful Wisdom",
+      "type": "book",
+      "author": "Yongey Mingyur Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "mingyur-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-la-mente-oltre-la-morte",
+      "title": "La mente oltre la morte",
+      "type": "book",
+      "author": "Ponlop Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "ponlop-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-la-source-veritable-de-la-guerison",
+      "title": "La source véritable de la guérison",
+      "type": "book",
+      "author": "Tenzin Wangyal Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tenzin-wangyal-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-maravillas-de-la-mente-natural",
+      "title": "Maravillas de la Mente Natural",
+      "type": "book",
+      "author": "Tenzin Wangyal Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tenzin-wangyal-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-meditieren",
+      "title": "Meditieren",
+      "type": "book",
+      "author": "Tsoknyi Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tsoknyi-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-open-heart-open-mind",
+      "title": "Open Heart, Open Mind",
+      "type": "book",
+      "author": "Tsoknyi Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tsoknyi-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-petites-instructions-essentielles",
+      "title": "Petites instructions essentielles",
+      "type": "book",
+      "author": "Dudjom Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "dudjom-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-por-que-meditamos",
+      "title": "Por que meditamos",
+      "type": "book",
+      "author": "Tsoknyi Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tsoknyi-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-por-que-meditar",
+      "title": "Por qué meditar",
+      "type": "book",
+      "author": "Tsoknyi Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tsoknyi-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-powerful-transformation",
+      "title": "Powerful Transformation",
+      "type": "book",
+      "author": "Dilgo Khyentse Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "dilgo-khyentse-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-profound-view-fearless-path",
+      "title": "Profound View, Fearless Path",
+      "type": "book",
+      "author": "Ponlop Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "ponlop-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-progressive-stages-of-meditation-on-emptiness",
+      "title": "Progressive Stages of Meditation on Emptiness",
+      "type": "book",
+      "author": "Tsultrim Gyamtso Rinpoche",
+      "traditions": [
+        "tibetan-buddhism-kagyu",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tsultrim-gyamtso-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-quintessential-dzogchen",
+      "title": "Quintessential Dzogchen",
+      "type": "book",
+      "author": "Tulku Urgyen Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "tulku-urgyen-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-rainbow-painting",
+      "title": "Rainbow Painting",
+      "type": "book",
+      "author": "Tulku Urgyen Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "tulku-urgyen-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-rebel-buddha",
+      "title": "Rebel Buddha",
+      "type": "book",
+      "author": "Ponlop Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "ponlop-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-repeating-the-words-of-the-buddha",
+      "title": "Repeating the Words of the Buddha",
+      "type": "book",
+      "author": "Tulku Urgyen Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "tulku-urgyen-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-skillful-grace",
+      "title": "Skillful Grace",
+      "type": "book",
+      "author": "Tulku Urgyen Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "tulku-urgyen-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-spontaneous-creativity",
+      "title": "Spontaneous Creativity",
+      "type": "book",
+      "author": "Tenzin Wangyal Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tenzin-wangyal-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-sublime-lady-of-immortality",
+      "title": "Sublime Lady of Immortality",
+      "type": "book",
+      "author": "Dilgo Khyentse Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "dilgo-khyentse-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-sunlight-speech-that-dispels-the-darkness-of-doubt",
+      "title": "Sunlight Speech That Dispels the Darkness of Doubt",
+      "type": "book",
+      "author": "Dudjom Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "dudjom-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-the-bountiful-cow-of-accomplishments",
+      "title": "The Bountiful Cow of Accomplishments",
+      "type": "book",
+      "author": "Dudjom Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "dudjom-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-the-gathering-of-vidyadharas",
+      "title": "The Gathering of Vidyadharas",
+      "type": "book",
+      "author": "Patrul Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "patrul-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-the-heart-treasure-of-the-enlightened-ones",
+      "title": "The Heart Treasure of the Enlightened Ones",
+      "type": "book",
+      "author": "Patrul Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "patrul-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-the-nature-of-mind",
+      "title": "The Nature of Mind",
+      "type": "book",
+      "author": "Patrul Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "patrul-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-the-propitious-speech-from-the-beginning-middle-and-end",
+      "title": "The Propitious Speech from the Beginning, Middle and End",
+      "type": "book",
+      "author": "Patrul Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "patrul-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-the-tibetan-book-of-success",
+      "title": "The Tibetan Book of Success",
+      "type": "book",
+      "author": "Patrul Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "patrul-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-the-true-source-of-healing",
+      "title": "The True Source of Healing",
+      "type": "book",
+      "author": "Tenzin Wangyal Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tenzin-wangyal-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-the-words-of-my-perfect-teacher",
+      "title": "The Words of My Perfect Teacher",
+      "type": "book",
+      "author": "Patrul Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "patrul-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-tibetan-sound-healing",
+      "title": "Tibetan Sound Healing",
+      "type": "book",
+      "author": "Tenzin Wangyal Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tenzin-wangyal-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-transformar-la-confusion-en-claridad",
+      "title": "Transformar la confusión en claridad",
+      "type": "book",
+      "author": "Yongey Mingyur Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "mingyur-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-treasures-from-juniper-ridge",
+      "title": "Treasures from Juniper Ridge",
+      "type": "book",
+      "author": "Tulku Urgyen Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "tulku-urgyen-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-turning-confusion-into-clarity",
+      "title": "Turning Confusion into Clarity",
+      "type": "book",
+      "author": "Yongey Mingyur Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "mingyur-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-turning-towards-liberation",
+      "title": "Turning Towards Liberation",
+      "type": "book",
+      "author": "Ponlop Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "ponlop-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-unbounded-wholeness",
+      "title": "Unbounded Wholeness",
+      "type": "book",
+      "author": "Tenzin Wangyal Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tenzin-wangyal-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-uncommon-happiness",
+      "title": "Uncommon Happiness",
+      "type": "book",
+      "author": "Dzigar Kongtrul Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "dzigar-kongtrul-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-vajra-heart-revisited",
+      "title": "Vajra Heart Revisited",
+      "type": "book",
+      "author": "Tulku Urgyen Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "tulku-urgyen-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-vajra-speech",
+      "title": "Vajra Speech",
+      "type": "book",
+      "author": "Tulku Urgyen Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "tulku-urgyen-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-waarom-we-mediteren",
+      "title": "Waarom we mediteren",
+      "type": "book",
+      "author": "Tsoknyi Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tsoknyi-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-wandering",
+      "title": "Wandering",
+      "type": "book",
+      "author": "Yongey Mingyur Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "mingyur-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-why-we-meditate",
+      "title": "Why We Meditate",
+      "type": "book",
+      "author": "Tsoknyi Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "tsoknyi-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-wisdom-nectar",
+      "title": "Wisdom Nectar",
+      "type": "book",
+      "author": "Dudjom Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "dudjom-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche-ziji-the-puppy-who-learned-to-meditate",
+      "title": "Ziji, the Puppy who Learned to Meditate",
+      "type": "book",
+      "author": "Yongey Mingyur Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "mingyur-rinpoche"
+      ]
+    },
+    {
+      "slug": "rinpoche",
+      "title": "我心教言——敦珠法王的智慧心語",
+      "type": "book",
+      "author": "Dudjom Rinpoche",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "dudjom-rinpoche"
+      ]
+    },
+    {
+      "slug": "rohr-breathing-under-water",
+      "title": "Breathing Under Water",
+      "type": "book",
+      "author": "Richard Rohr",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "richard-rohr"
+      ]
+    },
+    {
+      "slug": "rohr-eager-to-love",
+      "title": "Eager to Love",
+      "type": "book",
+      "author": "Richard Rohr",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "richard-rohr"
+      ]
+    },
+    {
+      "slug": "rohr-every-thing-is-sacred",
+      "title": "Every Thing Is Sacred",
+      "type": "book",
+      "author": "Richard Rohr",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "richard-rohr"
+      ]
+    },
+    {
+      "slug": "rohr-falling-upward",
+      "title": "Falling Upward",
+      "type": "book",
+      "author": "Richard Rohr",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "richard-rohr"
+      ]
+    },
+    {
+      "slug": "rohr-from-wild-man-to-wise-man",
+      "title": "From Wild Man to Wise Man",
+      "type": "book",
+      "author": "Richard Rohr",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "richard-rohr"
+      ]
+    },
+    {
+      "slug": "rohr-great-themes-of-scripture-new-testament",
+      "title": "Great Themes of Scripture: New Testament",
+      "type": "book",
+      "author": "Richard Rohr",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "richard-rohr"
+      ]
+    },
+    {
+      "slug": "rohr-immortal-diamond",
+      "title": "Immortal Diamond",
+      "type": "book",
+      "author": "Richard Rohr",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "richard-rohr"
+      ]
+    },
+    {
+      "slug": "rohr-jesus-alternative-plan",
+      "title": "Jesus' Alternative Plan",
+      "type": "book",
+      "author": "Richard Rohr",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "richard-rohr"
+      ]
+    },
+    {
+      "slug": "rohr-jesus-plan-for-a-new-world",
+      "title": "Jesus' Plan for a New World",
+      "type": "book",
+      "author": "Richard Rohr",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "richard-rohr"
+      ]
+    },
+    {
+      "slug": "rohr-on-the-threshold-of-transformation",
+      "title": "On the Threshold of Transformation",
+      "type": "book",
+      "author": "Richard Rohr",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "richard-rohr"
+      ]
+    },
+    {
+      "slug": "rohr-preparing-for-christmas",
+      "title": "Preparing for Christmas",
+      "type": "book",
+      "author": "Richard Rohr",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "richard-rohr"
+      ]
+    },
+    {
+      "slug": "rohr-silent-compassion",
+      "title": "Silent Compassion",
+      "type": "book",
+      "author": "Richard Rohr",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "richard-rohr"
+      ]
+    },
+    {
+      "slug": "rohr-the-divine-dance",
+      "title": "The Divine Dance",
+      "type": "book",
+      "author": "Richard Rohr",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "richard-rohr"
+      ]
+    },
+    {
+      "slug": "rohr-the-universal-christ",
+      "title": "The Universal Christ",
+      "type": "book",
+      "author": "Richard Rohr",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "richard-rohr"
+      ]
+    },
+    {
+      "slug": "rohr-the-wisdom-pattern",
+      "title": "The Wisdom Pattern",
+      "type": "book",
+      "author": "Richard Rohr",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "richard-rohr"
+      ]
+    },
+    {
+      "slug": "rohr-things-hidden",
+      "title": "Things Hidden",
+      "type": "book",
+      "author": "Richard Rohr",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "richard-rohr"
+      ]
+    },
+    {
+      "slug": "rosenberg-living-in-the-light-of-death",
+      "title": "Living in the Light of Death",
+      "type": "book",
+      "author": "Larry Rosenberg",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "larry-rosenberg"
+      ]
+    },
+    {
+      "slug": "rosenberg-test-item-file-to-accompany-social-problems-third-edition",
+      "title": "Test Item File [to Accompany] Social Problems, Third Edition",
+      "type": "book",
+      "author": "Larry Rosenberg",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "larry-rosenberg"
+      ]
+    },
+    {
+      "slug": "rosenberg-the-world-exists-to-set-us-free",
+      "title": "The World Exists to Set Us Free",
+      "type": "book",
+      "author": "Larry Rosenberg",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "larry-rosenberg"
+      ]
+    },
+    {
+      "slug": "rosenberg-three-steps-to-awakening",
+      "title": "Three Steps to Awakening",
+      "type": "book",
+      "author": "Larry Rosenberg",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "larry-rosenberg"
+      ]
+    },
+    {
+      "slug": "rothberg-the-engaged-spiritual-life",
+      "title": "The Engaged Spiritual Life",
+      "type": "book",
+      "author": "Donald Rothberg",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "donald-rothberg"
+      ]
+    },
+    {
+      "slug": "rumi-love-is-a-stranger",
+      "title": "Love is a Stranger",
+      "type": "book",
+      "author": "Rumi",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "rumi"
+      ]
+    },
+    {
+      "slug": "rumi-love-is-my-savior",
+      "title": "Love Is My Savior",
+      "type": "book",
+      "author": "Rumi",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "rumi"
+      ]
+    },
+    {
+      "slug": "rumi-rumi-day-by-day",
+      "title": "Rumi, Day by Day",
+      "type": "book",
+      "author": "Rumi",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "rumi"
+      ]
+    },
+    {
+      "slug": "rumi-rumi-s-little-book-of-wisdom",
+      "title": "Rumi's Little Book of Wisdom",
+      "type": "book",
+      "author": "Rumi",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "rumi"
+      ]
+    },
+    {
+      "slug": "rumi-selected-poems-of-rumi",
+      "title": "Selected Poems of Rumi",
+      "type": "book",
+      "author": "Rumi",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "rumi"
+      ]
+    },
+    {
+      "slug": "rumi-selected-poems",
+      "title": "Selected Poems",
+      "type": "book",
+      "author": "Rumi",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "rumi"
+      ]
+    },
+    {
+      "slug": "rumi-the-book-of-rumi",
+      "title": "The Book of Rumi",
+      "type": "book",
+      "author": "Rumi",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "rumi"
+      ]
+    },
+    {
+      "slug": "rumi-the-flame-of-love",
+      "title": "The Flame of Love",
+      "type": "book",
+      "author": "Rumi",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "rumi"
+      ]
+    },
+    {
+      "slug": "rumi-the-masnavi-book-one",
+      "title": "The Masnavi, Book One",
+      "type": "book",
+      "author": "Rumi",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "rumi"
+      ]
+    },
+    {
+      "slug": "rumi-the-mathnawi-ma-navi-of-rumi-book-3",
+      "title": "The Mathnawi Maˈnavi of Rumi, Book-3",
+      "type": "book",
+      "author": "Rumi",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "rumi"
+      ]
+    },
+    {
+      "slug": "rumi-the-mathnawi-masnavi-of-jalaluddin-rumi-the-first-book-persian-english",
+      "title": "THE MATHNAWI (MASNAVI) OF JALALUDDIN RUMI THE FIRST BOOK Persian- English مثنوی معنوی دوزبانه",
+      "type": "book",
+      "author": "Rumi",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "rumi"
+      ]
+    },
+    {
+      "slug": "rumi-the-mathnawi-of-jalalu-din-rumi-book-3",
+      "title": "The Mathnawi of Jalalu'din Rumi Book 3",
+      "type": "book",
+      "author": "Rumi",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "rumi"
+      ]
+    },
+    {
+      "slug": "rumi-the-pocket-rumi",
+      "title": "The Pocket Rumi",
+      "type": "book",
+      "author": "Rumi",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "rumi"
+      ]
+    },
+    {
+      "slug": "rumi-the-rumi-collection",
+      "title": "The Rumi Collection",
+      "type": "book",
+      "author": "Rumi",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "rumi"
+      ]
+    },
+    {
+      "slug": "rumi-water",
+      "title": "Water",
+      "type": "book",
+      "author": "Rumi",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "rumi"
+      ]
+    },
+    {
+      "slug": "rupert-spira-the-nature-of-experience",
+      "title": "Rupert Spira: The Nature of Experience",
+      "type": "video",
+      "author": "Rupert Spira",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "rupert-spira"
+      ]
+    },
+    {
+      "slug": "ryokan-between-the-floating-mist",
+      "title": "Between the Floating Mist",
+      "type": "book",
+      "author": "Ryōkan",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "ryokan"
+      ]
+    },
+    {
+      "slug": "sacred-texts-hinduism",
+      "title": "Sacred Texts: Hinduism",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "advaita-vedanta",
+        "vedanta",
+        "bhakti",
+        "classical-yoga",
+        "kashmir-shaivism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "sacred-texts-islam",
+      "title": "Sacred Texts: Islam",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "sacred-texts-taoism",
+      "title": "Sacred Texts: Taoism",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "taoism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "sacred-texts-yoga",
+      "title": "Sacred Texts: Yoga",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "sadhguru-a-guru-always-takes-you-for-a-ride",
+      "title": "A Guru Always Takes You for a Ride",
+      "type": "book",
+      "author": "Sadhguru",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "sadhguru"
+      ]
+    },
+    {
+      "slug": "sadhguru-adiyogi",
+      "title": "Adiyogi",
+      "type": "book",
+      "author": "Sadhguru",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "sadhguru"
+      ]
+    },
+    {
+      "slug": "sadhguru-death-an-inside-story",
+      "title": "Death; An Inside Story",
+      "type": "book",
+      "author": "Sadhguru",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "sadhguru"
+      ]
+    },
+    {
+      "slug": "sadhguru-death",
+      "title": "Death",
+      "type": "book",
+      "author": "Sadhguru",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "sadhguru"
+      ]
+    },
+    {
+      "slug": "sadhguru-emotion-relationships-2-books-in-1",
+      "title": "Emotion & Relationships (2 Books in 1)",
+      "type": "book",
+      "author": "Sadhguru",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "sadhguru"
+      ]
+    },
+    {
+      "slug": "sadhguru-enlightenment",
+      "title": "Enlightenment",
+      "type": "book",
+      "author": "Sadhguru",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "sadhguru"
+      ]
+    },
+    {
+      "slug": "sadhguru-eternal-echoes-the-sacred-sounds-through-the-mystic",
+      "title": "Eternal Echoes: The Sacred Sounds Through the Mystic",
+      "type": "book",
+      "author": "Sadhguru",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "sadhguru"
+      ]
+    },
+    {
+      "slug": "sadhguru-inner-engineering",
+      "title": "Inner Engineering",
+      "type": "book",
+      "author": "Sadhguru",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "sadhguru"
+      ]
+    },
+    {
+      "slug": "sadhguru-life-and-death-in-one-breath",
+      "title": "Life and Death in One Breath",
+      "type": "book",
+      "author": "Sadhguru",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "sadhguru"
+      ]
+    },
+    {
+      "slug": "sadhguru-midnights-with-the-mystic",
+      "title": "Midnights with the Mystic",
+      "type": "book",
+      "author": "Sadhguru",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "sadhguru"
+      ]
+    },
+    {
+      "slug": "sadhguru-of-mystics-mistakes",
+      "title": "Of Mystics & Mistakes",
+      "type": "book",
+      "author": "Sadhguru",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "sadhguru"
+      ]
+    },
+    {
+      "slug": "salzberg-a-heart-as-wide-as-the-world",
+      "title": "A Heart as Wide as the World",
+      "type": "book",
+      "author": "Sharon Salzberg",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "sharon-salzberg"
+      ]
+    },
+    {
+      "slug": "salzberg-faith",
+      "title": "Faith",
+      "type": "book",
+      "author": "Sharon Salzberg",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "sharon-salzberg"
+      ]
+    },
+    {
+      "slug": "salzberg-finding-your-way",
+      "title": "Finding Your Way",
+      "type": "book",
+      "author": "Sharon Salzberg",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "sharon-salzberg"
+      ]
+    },
+    {
+      "slug": "salzberg-lovingkindness",
+      "title": "Lovingkindness",
+      "type": "book",
+      "author": "Sharon Salzberg",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "sharon-salzberg"
+      ]
+    },
+    {
+      "slug": "salzberg-real-change",
+      "title": "Real Change",
+      "type": "book",
+      "author": "Sharon Salzberg",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "sharon-salzberg"
+      ]
+    },
+    {
+      "slug": "salzberg-real-happiness-at-work",
+      "title": "Real Happiness at Work",
+      "type": "book",
+      "author": "Sharon Salzberg",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "sharon-salzberg"
+      ]
+    },
+    {
+      "slug": "salzberg-real-happiness",
+      "title": "Real Happiness",
+      "type": "book",
+      "author": "Sharon Salzberg",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "sharon-salzberg"
+      ]
+    },
+    {
+      "slug": "salzberg-real-life",
+      "title": "Real Life",
+      "type": "book",
+      "author": "Sharon Salzberg",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "sharon-salzberg"
+      ]
+    },
+    {
+      "slug": "salzberg-real-love",
+      "title": "Real Love",
+      "type": "book",
+      "author": "Sharon Salzberg",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "sharon-salzberg"
+      ]
+    },
+    {
+      "slug": "salzberg-the-force-of-kindness",
+      "title": "The Force of Kindness",
+      "type": "book",
+      "author": "Sharon Salzberg",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "sharon-salzberg"
+      ]
+    },
+    {
+      "slug": "salzberg-voices-of-insight",
+      "title": "Voices of Insight",
+      "type": "book",
+      "author": "Sharon Salzberg",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "sharon-salzberg"
+      ]
+    },
+    {
+      "slug": "satipatthana-direct-path",
+      "title": "Satipatthana: The Direct Path to Realization",
+      "type": "book",
+      "author": "Bhikkhu Analayo",
+      "traditions": [
+        "theravada",
+        "vipassana-movement",
+        "early-buddhism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "sefaria",
+      "title": "Sefaria",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "kabbalah"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "sefer-yetzirah-book-of-formation",
+      "title": "Sefer Yetzirah (Book of Formation)",
+      "type": "book",
+      "author": "Aryeh Kaplan (trans.)",
+      "traditions": [
+        "kabbalah"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "self-liberation-through-seeing-with-naked-awareness",
+      "title": "Self-Liberation Through Seeing with Naked Awareness",
+      "type": "book",
+      "author": "Padmasambhava / John Reynolds (trans.)",
+      "traditions": [
+        "dzogchen"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "shankar-an-intimate-note-to-the-sincere-seeker",
+      "title": "An Intimate Note to the Sincere Seeker",
+      "type": "book",
+      "author": "Ravi Shankar",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "ravi-shankar"
+      ]
+    },
+    {
+      "slug": "shankar-bang-on-the-door",
+      "title": "Bang on the Door",
+      "type": "book",
+      "author": "Ravi Shankar",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "ravi-shankar"
+      ]
+    },
+    {
+      "slug": "shankar-buddha-the-manifestation-of-silence",
+      "title": "Buddha - The Manifestation of Silence",
+      "type": "book",
+      "author": "Ravi Shankar",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "ravi-shankar"
+      ]
+    },
+    {
+      "slug": "shankar-celebrating-love",
+      "title": "Celebrating Love",
+      "type": "book",
+      "author": "Ravi Shankar",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "ravi-shankar"
+      ]
+    },
+    {
+      "slug": "shankar-celebrating-silence",
+      "title": "Celebrating Silence",
+      "type": "book",
+      "author": "Ravi Shankar",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "ravi-shankar"
+      ]
+    },
+    {
+      "slug": "shankar-god-s-council",
+      "title": "God’s Council",
+      "type": "book",
+      "author": "Ravi Shankar",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "ravi-shankar"
+      ]
+    },
+    {
+      "slug": "shankar-know-your-child",
+      "title": "Know Your Child",
+      "type": "book",
+      "author": "Ravi Shankar",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "ravi-shankar"
+      ]
+    },
+    {
+      "slug": "shankar-my-music-my-life",
+      "title": "My Music, My Life",
+      "type": "book",
+      "author": "Ravi Shankar",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "ravi-shankar"
+      ]
+    },
+    {
+      "slug": "shankar-notes-for-the-journey-within",
+      "title": "Notes for the Journey Within",
+      "type": "book",
+      "author": "Ravi Shankar",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "ravi-shankar"
+      ]
+    },
+    {
+      "slug": "shankar-patanjali-yoga-sutras",
+      "title": "Patanjali Yoga Sutras",
+      "type": "book",
+      "author": "Ravi Shankar",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "ravi-shankar"
+      ]
+    },
+    {
+      "slug": "shankar-pro-html5-games",
+      "title": "Pro HTML5 Games",
+      "type": "book",
+      "author": "Ravi Shankar",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "ravi-shankar"
+      ]
+    },
+    {
+      "slug": "shankar-raga-mala",
+      "title": "Raga Mala",
+      "type": "book",
+      "author": "Ravi Shankar",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "ravi-shankar"
+      ]
+    },
+    {
+      "slug": "shankar-secrets-of-relationships",
+      "title": "Secrets of Relationships",
+      "type": "book",
+      "author": "Ravi Shankar",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "ravi-shankar"
+      ]
+    },
+    {
+      "slug": "shankar-source-of-life",
+      "title": "Source of Life",
+      "type": "book",
+      "author": "Ravi Shankar",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "ravi-shankar"
+      ]
+    },
+    {
+      "slug": "shankar-the-little-book-of-goodbyes",
+      "title": "The Little Book of Goodbyes",
+      "type": "book",
+      "author": "Ravi Shankar",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "ravi-shankar"
+      ]
+    },
+    {
+      "slug": "shankar-the-tiger-by-the-river",
+      "title": "The Tiger by the River",
+      "type": "book",
+      "author": "Ravi Shankar",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "ravi-shankar"
+      ]
+    },
+    {
+      "slug": "shiva-sutras",
+      "title": "Shiva Sutras: The Supreme Awakening",
+      "type": "book",
+      "author": "Swami Lakshmanjoo",
+      "traditions": [
+        "kashmir-shaivism"
+      ],
+      "teachers": [
+        "sally-kempton"
+      ]
+    },
+    {
+      "slug": "singer-christianity-in-jewish-terms",
+      "title": "Christianity In Jewish Terms",
+      "type": "book",
+      "author": "Michael Singer",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "michael-singer"
+      ]
+    },
+    {
+      "slug": "singer-gemini-man-the-art-and-making-of-the-film",
+      "title": "Gemini Man - The Art and Making of the Film",
+      "type": "book",
+      "author": "Michael Singer",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "michael-singer"
+      ]
+    },
+    {
+      "slug": "singer-how-to-get-into-a-military-service-academy",
+      "title": "How to Get Into a Military Service Academy",
+      "type": "book",
+      "author": "Michael Singer",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "michael-singer"
+      ]
+    },
+    {
+      "slug": "singer-living-untethered",
+      "title": "Living Untethered",
+      "type": "book",
+      "author": "Michael Singer",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "michael-singer"
+      ]
+    },
+    {
+      "slug": "singer-the-legacy-of-positivism",
+      "title": "The Legacy of Positivism",
+      "type": "book",
+      "author": "Michael Singer",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "michael-singer"
+      ]
+    },
+    {
+      "slug": "singer-the-surrender-experiment",
+      "title": "The Surrender Experiment",
+      "type": "book",
+      "author": "Michael Singer",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "michael-singer"
+      ]
+    },
+    {
+      "slug": "singer-the-untethered-soul-easyread-large-bold-edition",
+      "title": "The Untethered Soul (EasyRead Large Bold Edition)",
+      "type": "book",
+      "author": "Michael Singer",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "michael-singer"
+      ]
+    },
+    {
+      "slug": "singer-the-untethered-soul",
+      "title": "The Untethered Soul",
+      "type": "book",
+      "author": "Michael Singer",
+      "traditions": [
+        "classical-yoga",
+        "vedanta"
+      ],
+      "teachers": [
+        "michael-singer"
+      ]
+    },
+    {
+      "slug": "sivananda-hatha-yoga",
+      "title": "Hatha Yoga",
+      "type": "book",
+      "author": "Swami Sivananda",
+      "traditions": [
+        "vedanta",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "swami-sivananda"
+      ]
+    },
+    {
+      "slug": "sivananda-kundalini-yoga-by-sri-swami-sivananda",
+      "title": "KUNDALINI YOGA By SRI SWAMI SIVANANDA",
+      "type": "book",
+      "author": "Swami Sivananda",
+      "traditions": [
+        "vedanta",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "swami-sivananda"
+      ]
+    },
+    {
+      "slug": "sivananda-kundalini-yoga-for-the-west",
+      "title": "Kundalini, Yoga for the West",
+      "type": "book",
+      "author": "Swami Sivananda",
+      "traditions": [
+        "vedanta",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "swami-sivananda"
+      ]
+    },
+    {
+      "slug": "sivananda-kundalini-yoga",
+      "title": "Kundalini Yoga",
+      "type": "book",
+      "author": "Swami Sivananda",
+      "traditions": [
+        "vedanta",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "swami-sivananda"
+      ]
+    },
+    {
+      "slug": "sivananda-life-and-works-of-swami-sivananda",
+      "title": "Life and works of Swami Sivananda",
+      "type": "book",
+      "author": "Swami Sivananda",
+      "traditions": [
+        "vedanta",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "swami-sivananda"
+      ]
+    },
+    {
+      "slug": "sivananda-mantras",
+      "title": "Mantras",
+      "type": "book",
+      "author": "Swami Sivananda",
+      "traditions": [
+        "vedanta",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "swami-sivananda"
+      ]
+    },
+    {
+      "slug": "sivananda-the-call",
+      "title": "The Call",
+      "type": "book",
+      "author": "Swami Sivananda",
+      "traditions": [
+        "vedanta",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "swami-sivananda"
+      ]
+    },
+    {
+      "slug": "sivananda-the-divine-light-invocation",
+      "title": "The Divine Light Invocation",
+      "type": "book",
+      "author": "Swami Sivananda",
+      "traditions": [
+        "vedanta",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "swami-sivananda"
+      ]
+    },
+    {
+      "slug": "sivananda-thought-power",
+      "title": "Thought power",
+      "type": "book",
+      "author": "Swami Sivananda",
+      "traditions": [
+        "vedanta",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "swami-sivananda"
+      ]
+    },
+    {
+      "slug": "smith-101-great-tramps-in-new-zealand",
+      "title": "101 Great Tramps in New Zealand",
+      "type": "book",
+      "author": "Rodney Smith",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "rodney-smith"
+      ]
+    },
+    {
+      "slug": "smith-awakening",
+      "title": "Awakening",
+      "type": "book",
+      "author": "Rodney Smith",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "rodney-smith"
+      ]
+    },
+    {
+      "slug": "smith-gipsy-smith",
+      "title": "GIPSY SMITH",
+      "type": "book",
+      "author": "Rodney Smith",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "rodney-smith"
+      ]
+    },
+    {
+      "slug": "smith-lessons-from-the-dying",
+      "title": "Lessons from the Dying",
+      "type": "book",
+      "author": "Rodney Smith",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "rodney-smith"
+      ]
+    },
+    {
+      "slug": "smith-operative-surgery",
+      "title": "Operative Surgery",
+      "type": "book",
+      "author": "Rodney Smith",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "rodney-smith"
+      ]
+    },
+    {
+      "slug": "smith-stepping-out-of-self-deception",
+      "title": "Stepping Out of Self-Deception",
+      "type": "book",
+      "author": "Rodney Smith",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "rodney-smith"
+      ]
+    },
+    {
+      "slug": "smith-touching-the-infinite",
+      "title": "Touching the Infinite",
+      "type": "book",
+      "author": "Rodney Smith",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "rodney-smith"
+      ]
+    },
+    {
+      "slug": "smith-touching-the-void",
+      "title": "Touching the Void",
+      "type": "book",
+      "author": "Rodney Smith",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "rodney-smith"
+      ]
+    },
+    {
+      "slug": "sofer-di-lo-que-quieres-decir",
+      "title": "Di lo que quieres decir",
+      "type": "book",
+      "author": "Oren Jay Sofer",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "oren-jay-sofer"
+      ]
+    },
+    {
+      "slug": "sofer-mindful-communiceren",
+      "title": "Mindful communiceren",
+      "type": "book",
+      "author": "Oren Jay Sofer",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "oren-jay-sofer"
+      ]
+    },
+    {
+      "slug": "sofer-mindfullness-nonviolent-communication",
+      "title": "Mindfullness & Nonviolent Communication",
+      "type": "book",
+      "author": "Oren Jay Sofer",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "oren-jay-sofer"
+      ]
+    },
+    {
+      "slug": "sofer-sag-mir-was-du-wirklich-meinst",
+      "title": "Sag mir, was du wirklich meinst",
+      "type": "book",
+      "author": "Oren Jay Sofer",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "oren-jay-sofer"
+      ]
+    },
+    {
+      "slug": "sofer-say-what-you-mean",
+      "title": "Say What You Mean",
+      "type": "book",
+      "author": "Oren Jay Sofer",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "oren-jay-sofer"
+      ]
+    },
+    {
+      "slug": "sofer-teaching-mindfulness-to-empower-adolescents",
+      "title": "Teaching Mindfulness to Empower Adolescents",
+      "type": "book",
+      "author": "Oren Jay Sofer",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "oren-jay-sofer"
+      ]
+    },
+    {
+      "slug": "sofer-the-mindful-schools-curriculum-and-teacher-s-guide",
+      "title": "The Mindful Schools Curriculum and Teacher's Guide",
+      "type": "book",
+      "author": "Oren Jay Sofer",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "oren-jay-sofer"
+      ]
+    },
+    {
+      "slug": "sofer-the-mindful-schools-curriculum-for-adolescents",
+      "title": "The Mindful Schools Curriculum for Adolescents",
+      "type": "book",
+      "author": "Oren Jay Sofer",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "oren-jay-sofer"
+      ]
+    },
+    {
+      "slug": "sofer-the-mindfulness-schools-curriculum-for-adolescents",
+      "title": "The Mindfulness Schools Curriculum for Adolescents",
+      "type": "book",
+      "author": "Oren Jay Sofer",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "oren-jay-sofer"
+      ]
+    },
+    {
+      "slug": "sofer-your-heart-was-made-for-this",
+      "title": "Your Heart Was Made for This",
+      "type": "book",
+      "author": "Oren Jay Sofer",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "oren-jay-sofer"
+      ]
+    },
+    {
+      "slug": "sofer",
+      "title": "正念溝通：在衝突、委屈、情緒勒索場景下說出真心話",
+      "type": "book",
+      "author": "Oren Jay Sofer",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "oren-jay-sofer"
+      ]
+    },
+    {
+      "slug": "songs-of-the-saints-of-india",
+      "title": "Songs of the Saints of India",
+      "type": "book",
+      "author": "John Stratton Hawley & Mark Juergensmeyer",
+      "traditions": [
+        "bhakti"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "spira-a-meditation-on-i-am",
+      "title": "A Meditation on I Am",
+      "type": "book",
+      "author": "Rupert Spira",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "rupert-spira"
+      ]
+    },
+    {
+      "slug": "spira-ashes-of-love",
+      "title": "Ashes of Love",
+      "type": "book",
+      "author": "Rupert Spira",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "rupert-spira"
+      ]
+    },
+    {
+      "slug": "spira-being-aware-of-being-aware",
+      "title": "Being Aware of Being Aware",
+      "type": "book",
+      "author": "Rupert Spira",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "rupert-spira"
+      ]
+    },
+    {
+      "slug": "spira-being-myself",
+      "title": "Being Myself",
+      "type": "book",
+      "author": "Rupert Spira",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "rupert-spira"
+      ]
+    },
+    {
+      "slug": "spira-i-am-always-i",
+      "title": "I Am Always I",
+      "type": "book",
+      "author": "Rupert Spira",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "rupert-spira"
+      ]
+    },
+    {
+      "slug": "spira-presence-volume-i",
+      "title": "Presence, Volume I",
+      "type": "book",
+      "author": "Rupert Spira",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "rupert-spira"
+      ]
+    },
+    {
+      "slug": "spira-presence-volume-ii",
+      "title": "Presence, Volume II",
+      "type": "book",
+      "author": "Rupert Spira",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "rupert-spira"
+      ]
+    },
+    {
+      "slug": "spira-presence",
+      "title": "Presence",
+      "type": "book",
+      "author": "Rupert Spira",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "rupert-spira"
+      ]
+    },
+    {
+      "slug": "spira-the-ashes-of-love",
+      "title": "The Ashes of Love",
+      "type": "book",
+      "author": "Rupert Spira",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "rupert-spira"
+      ]
+    },
+    {
+      "slug": "spira-the-heart-of-prayer",
+      "title": "The Heart of Prayer",
+      "type": "book",
+      "author": "Rupert Spira",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "rupert-spira"
+      ]
+    },
+    {
+      "slug": "spira-the-light-of-pure-knowing",
+      "title": "The Light of Pure Knowing",
+      "type": "book",
+      "author": "Rupert Spira",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "rupert-spira"
+      ]
+    },
+    {
+      "slug": "spira-the-shining-of-being-the-essence-of-meditation-series",
+      "title": "The Shining of Being (The Essence of Meditation Series)",
+      "type": "book",
+      "author": "Rupert Spira",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "rupert-spira"
+      ]
+    },
+    {
+      "slug": "spira-you-are-the-happiness-you-seek",
+      "title": "You Are the Happiness You Seek",
+      "type": "book",
+      "author": "Rupert Spira",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "rupert-spira"
+      ]
+    },
+    {
+      "slug": "starr-caravan-of-no-despair",
+      "title": "Caravan of No Despair",
+      "type": "book",
+      "author": "Mirabai Starr",
+      "traditions": [
+        "christian-mysticism",
+        "sufism"
+      ],
+      "teachers": [
+        "mirabai-starr"
+      ]
+    },
+    {
+      "slug": "starr-god-of-love",
+      "title": "God of Love",
+      "type": "book",
+      "author": "Mirabai Starr",
+      "traditions": [
+        "christian-mysticism",
+        "sufism"
+      ],
+      "teachers": [
+        "mirabai-starr"
+      ]
+    },
+    {
+      "slug": "starr-hildegard-of-bingen",
+      "title": "Hildegard of Bingen",
+      "type": "book",
+      "author": "Mirabai Starr",
+      "traditions": [
+        "christian-mysticism",
+        "sufism"
+      ],
+      "teachers": [
+        "mirabai-starr"
+      ]
+    },
+    {
+      "slug": "starr-julian-of-norwich-the-showings",
+      "title": "Julian of Norwich: The Showings",
+      "type": "book",
+      "author": "Mirabai Starr",
+      "traditions": [
+        "christian-mysticism",
+        "sufism"
+      ],
+      "teachers": [
+        "mirabai-starr"
+      ]
+    },
+    {
+      "slug": "starr-mother-of-god-similar-to-fire",
+      "title": "Mother of God Similar to Fire",
+      "type": "book",
+      "author": "Mirabai Starr",
+      "traditions": [
+        "christian-mysticism",
+        "sufism"
+      ],
+      "teachers": [
+        "mirabai-starr"
+      ]
+    },
+    {
+      "slug": "starr-ordinary-mysticism",
+      "title": "Ordinary Mysticism",
+      "type": "book",
+      "author": "Mirabai Starr",
+      "traditions": [
+        "christian-mysticism",
+        "sufism"
+      ],
+      "teachers": [
+        "mirabai-starr"
+      ]
+    },
+    {
+      "slug": "starr-our-lady-of-guadalupe",
+      "title": "Our Lady of Guadalupe",
+      "type": "book",
+      "author": "Mirabai Starr",
+      "traditions": [
+        "christian-mysticism",
+        "sufism"
+      ],
+      "teachers": [
+        "mirabai-starr"
+      ]
+    },
+    {
+      "slug": "starr-saint-francis-of-assisi-devotions-prayers-living-wisdom",
+      "title": "Saint Francis of Assisi : Devotions, Prayers, & Living Wisdom",
+      "type": "book",
+      "author": "Mirabai Starr",
+      "traditions": [
+        "christian-mysticism",
+        "sufism"
+      ],
+      "teachers": [
+        "mirabai-starr"
+      ]
+    },
+    {
+      "slug": "starr-saint-francis-of-assisi",
+      "title": "Saint Francis of Assisi",
+      "type": "book",
+      "author": "Mirabai Starr",
+      "traditions": [
+        "christian-mysticism",
+        "sufism"
+      ],
+      "teachers": [
+        "mirabai-starr"
+      ]
+    },
+    {
+      "slug": "starr-saint-michael-the-archangel",
+      "title": "Saint Michael the Archangel",
+      "type": "book",
+      "author": "Mirabai Starr",
+      "traditions": [
+        "christian-mysticism",
+        "sufism"
+      ],
+      "teachers": [
+        "mirabai-starr"
+      ]
+    },
+    {
+      "slug": "starr-saint-michael",
+      "title": "Saint Michael",
+      "type": "book",
+      "author": "Mirabai Starr",
+      "traditions": [
+        "christian-mysticism",
+        "sufism"
+      ],
+      "teachers": [
+        "mirabai-starr"
+      ]
+    },
+    {
+      "slug": "starr-saint-teresa-of-avila-devotions-prayers-living-wisdom",
+      "title": "Saint Teresa of Avila: Devotions, Prayers, & Living Wisdom",
+      "type": "book",
+      "author": "Mirabai Starr",
+      "traditions": [
+        "christian-mysticism",
+        "sufism"
+      ],
+      "teachers": [
+        "mirabai-starr"
+      ]
+    },
+    {
+      "slug": "starr-saint-teresa-of-avila",
+      "title": "Saint Teresa of Avila",
+      "type": "book",
+      "author": "Mirabai Starr",
+      "traditions": [
+        "christian-mysticism",
+        "sufism"
+      ],
+      "teachers": [
+        "mirabai-starr"
+      ]
+    },
+    {
+      "slug": "starr-showings-of-julian-of-norwich",
+      "title": "Showings of Julian of Norwich",
+      "type": "book",
+      "author": "Mirabai Starr",
+      "traditions": [
+        "christian-mysticism",
+        "sufism"
+      ],
+      "teachers": [
+        "mirabai-starr"
+      ]
+    },
+    {
+      "slug": "starr-teresa-of-avila",
+      "title": "Teresa of Avila",
+      "type": "book",
+      "author": "Mirabai Starr",
+      "traditions": [
+        "christian-mysticism",
+        "sufism"
+      ],
+      "teachers": [
+        "mirabai-starr"
+      ]
+    },
+    {
+      "slug": "starr-wild-mercy",
+      "title": "Wild Mercy",
+      "type": "book",
+      "author": "Mirabai Starr",
+      "traditions": [
+        "christian-mysticism",
+        "sufism"
+      ],
+      "teachers": [
+        "mirabai-starr"
+      ]
+    },
+    {
+      "slug": "steindl-rast-i-am-through-you-so-i",
+      "title": "i am through you so i",
+      "type": "book",
+      "author": "Brother David Steindl-Rast",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "brother-david-steindl-rast"
+      ]
+    },
+    {
+      "slug": "steindl-rast-music-of-silence",
+      "title": "Music of Silence",
+      "type": "book",
+      "author": "Brother David Steindl-Rast",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "brother-david-steindl-rast"
+      ]
+    },
+    {
+      "slug": "steindl-rast-words-of-common-sense",
+      "title": "Words Of Common Sense",
+      "type": "book",
+      "author": "Brother David Steindl-Rast",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "brother-david-steindl-rast"
+      ]
+    },
+    {
+      "slug": "sufism-stanford-encyclopedia-of-philosophy",
+      "title": "Sufism (Stanford Encyclopedia of Philosophy)",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "sumedho-ajahn-sumedho-seeds-of-understanding",
+      "title": "Ajahn Sumedho: Seeds of understanding",
+      "type": "book",
+      "author": "Ajahn Sumedho",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ajahn-sumedho"
+      ]
+    },
+    {
+      "slug": "sumedho-don-t-take-your-life-personally",
+      "title": "Don't Take Your Life Personally",
+      "type": "book",
+      "author": "Ajahn Sumedho",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ajahn-sumedho"
+      ]
+    },
+    {
+      "slug": "sumedho-intuitive-awareness",
+      "title": "Intuitive awareness",
+      "type": "book",
+      "author": "Ajahn Sumedho",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ajahn-sumedho"
+      ]
+    },
+    {
+      "slug": "sumedho-teachings-of-a-buddhist-monk",
+      "title": "Teachings of a Buddhist Monk",
+      "type": "book",
+      "author": "Ajahn Sumedho",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ajahn-sumedho"
+      ]
+    },
+    {
+      "slug": "sumedho-the-mind-and-the-way",
+      "title": "The Mind and the Way",
+      "type": "book",
+      "author": "Ajahn Sumedho",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ajahn-sumedho"
+      ]
+    },
+    {
+      "slug": "sutta-central",
+      "title": "Sutta Central",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "theravada",
+        "early-buddhism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "suzuki-becoming-yourself",
+      "title": "Becoming Yourself",
+      "type": "book",
+      "author": "Shunryu Suzuki",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "shunryu-suzuki"
+      ]
+    },
+    {
+      "slug": "suzuki-branching-streams-flow-in-the-darkness",
+      "title": "Branching Streams Flow in the Darkness",
+      "type": "book",
+      "author": "Shunryu Suzuki",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "shunryu-suzuki"
+      ]
+    },
+    {
+      "slug": "suzuki-duh-zena-duh-zacetnistva",
+      "title": "Duh zena, duh začetništva",
+      "type": "book",
+      "author": "Shunryu Suzuki",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "shunryu-suzuki"
+      ]
+    },
+    {
+      "slug": "suzuki-esprit-zen-esprit-neuf",
+      "title": "Esprit zen, esprit neuf",
+      "type": "book",
+      "author": "Shunryu Suzuki",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "shunryu-suzuki"
+      ]
+    },
+    {
+      "slug": "suzuki-ment-zen-ment-de-principiant",
+      "title": "Ment zen, ment de principiant",
+      "type": "book",
+      "author": "Shunryu Suzuki",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "shunryu-suzuki"
+      ]
+    },
+    {
+      "slug": "suzuki-mente-zen-mente-de-principiante-zen-mind-beginner-s-mind",
+      "title": "Mente Zen, mente de principiante (Zen Mind, Beginner's Mind)",
+      "type": "book",
+      "author": "Shunryu Suzuki",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "shunryu-suzuki"
+      ]
+    },
+    {
+      "slug": "suzuki-mente-zen-mente-de-principiante",
+      "title": "Mente Zen, Mente de Principiante",
+      "type": "book",
+      "author": "Shunryu Suzuki",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "shunryu-suzuki"
+      ]
+    },
+    {
+      "slug": "suzuki-met-zen-beginnen",
+      "title": "Met zen beginnen",
+      "type": "book",
+      "author": "Shunryu Suzuki",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "shunryu-suzuki"
+      ]
+    },
+    {
+      "slug": "suzuki-not-always-so",
+      "title": "Not Always So",
+      "type": "book",
+      "author": "Shunryu Suzuki",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "shunryu-suzuki"
+      ]
+    },
+    {
+      "slug": "suzuki-zen-geist-anfanger-geist",
+      "title": "Zen-Geist - Anfänger-Geist",
+      "type": "book",
+      "author": "Shunryu Suzuki",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "shunryu-suzuki"
+      ]
+    },
+    {
+      "slug": "suzuki-zen-is-right-here",
+      "title": "Zen Is Right Here",
+      "type": "book",
+      "author": "Shunryu Suzuki",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "shunryu-suzuki"
+      ]
+    },
+    {
+      "slug": "suzuki-zen-is-right-now",
+      "title": "Zen Is Right Now",
+      "type": "book",
+      "author": "Shunryu Suzuki",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "shunryu-suzuki"
+      ]
+    },
+    {
+      "slug": "suzuki-zen-leben-im-hier-jetzt",
+      "title": "Zen – Leben im Hier & Jetzt",
+      "type": "book",
+      "author": "Shunryu Suzuki",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "shunryu-suzuki"
+      ]
+    },
+    {
+      "slug": "suzuki-zen-mind-beginner-s-mind-informal-talks-on-zen-meditation-and-practice",
+      "title": "Zen Mind, Beginner's Mind--Informal Talks on Zen Meditation and Practice",
+      "type": "book",
+      "author": "Shunryu Suzuki",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "shunryu-suzuki"
+      ]
+    },
+    {
+      "slug": "svoboda-aghora-ii",
+      "title": "Aghora II",
+      "type": "book",
+      "author": "Robert Svoboda",
+      "traditions": [
+        "tantra",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "robert-svoboda"
+      ]
+    },
+    {
+      "slug": "svoboda-aghora-iii",
+      "title": "Aghora III",
+      "type": "book",
+      "author": "Robert Svoboda",
+      "traditions": [
+        "tantra",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "robert-svoboda"
+      ]
+    },
+    {
+      "slug": "svoboda-aghora",
+      "title": "Aghora",
+      "type": "book",
+      "author": "Robert Svoboda",
+      "traditions": [
+        "tantra",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "robert-svoboda"
+      ]
+    },
+    {
+      "slug": "svoboda-ayurveda-for-women",
+      "title": "Ayurveda for Women",
+      "type": "book",
+      "author": "Robert Svoboda",
+      "traditions": [
+        "tantra",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "robert-svoboda"
+      ]
+    },
+    {
+      "slug": "svoboda-ayurveda",
+      "title": "Ayurveda",
+      "type": "book",
+      "author": "Robert Svoboda",
+      "traditions": [
+        "tantra",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "robert-svoboda"
+      ]
+    },
+    {
+      "slug": "svoboda-chinese-medicine-and-ayurveda",
+      "title": "Chinese Medicine and Ayurveda",
+      "type": "book",
+      "author": "Robert Svoboda",
+      "traditions": [
+        "tantra",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "robert-svoboda"
+      ]
+    },
+    {
+      "slug": "svoboda-light-on-relationships",
+      "title": "Light on Relationships",
+      "type": "book",
+      "author": "Robert Svoboda",
+      "traditions": [
+        "tantra",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "robert-svoboda"
+      ]
+    },
+    {
+      "slug": "svoboda-prakriti",
+      "title": "Prakriti",
+      "type": "book",
+      "author": "Robert Svoboda",
+      "traditions": [
+        "tantra",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "robert-svoboda"
+      ]
+    },
+    {
+      "slug": "svoboda-tao-and-dharma",
+      "title": "Tao and Dharma",
+      "type": "book",
+      "author": "Robert Svoboda",
+      "traditions": [
+        "tantra",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "robert-svoboda"
+      ]
+    },
+    {
+      "slug": "svoboda-the-greatness-of-saturn",
+      "title": "The Greatness of Saturn",
+      "type": "book",
+      "author": "Robert Svoboda",
+      "traditions": [
+        "tantra",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "robert-svoboda"
+      ]
+    },
+    {
+      "slug": "svoboda-the-hidden-secret-of-ayurveda",
+      "title": "The Hidden Secret of Ayurveda",
+      "type": "book",
+      "author": "Robert Svoboda",
+      "traditions": [
+        "tantra",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "robert-svoboda"
+      ]
+    },
+    {
+      "slug": "svoboda-vastu",
+      "title": "Vāstu",
+      "type": "book",
+      "author": "Robert Svoboda",
+      "traditions": [
+        "tantra",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "robert-svoboda"
+      ]
+    },
+    {
+      "slug": "swami-conversazioni-con-ramana-maharshi-dal-diario-di-annamalai-swami",
+      "title": "Conversazioni con Ramana Maharshi. Dal diario di Annamalai Swami",
+      "type": "book",
+      "author": "Annamalai Swami",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "annamalai-swami"
+      ]
+    },
+    {
+      "slug": "swami-derniers-entretiens-sri-annamalai-swami",
+      "title": "Derniers entretiens - Sri Annamalai Swami",
+      "type": "book",
+      "author": "Annamalai Swami",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "annamalai-swami"
+      ]
+    },
+    {
+      "slug": "swami-i-miei-giorni-con-bhagavan-memorie-di-annamalai-swami",
+      "title": "I miei giorni con Bhagavan. Memorie di Annamalai Swami",
+      "type": "book",
+      "author": "Annamalai Swami",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "annamalai-swami"
+      ]
+    },
+    {
+      "slug": "swami-leben-nach-den-worten-bhagavans",
+      "title": "Leben nach den Worten Bhagavans",
+      "type": "book",
+      "author": "Annamalai Swami",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "annamalai-swami"
+      ]
+    },
+    {
+      "slug": "swami-living-by-the-words-of-bhagavan",
+      "title": "Living by the Words of Bhagavan",
+      "type": "book",
+      "author": "Annamalai Swami",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "annamalai-swami"
+      ]
+    },
+    {
+      "slug": "swami-nectar-drops",
+      "title": "Nectar Drops",
+      "type": "book",
+      "author": "Annamalai Swami",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "annamalai-swami"
+      ]
+    },
+    {
+      "slug": "taft-a-folk-tale-journey-through-the-maritimes",
+      "title": "A Folk Tale Journey Through the Maritimes",
+      "type": "book",
+      "author": "Michael Taft",
+      "traditions": [
+        "modern-non-dual",
+        "zen",
+        "tantra"
+      ],
+      "teachers": [
+        "michael-taft"
+      ]
+    },
+    {
+      "slug": "taft-ego",
+      "title": "Ego",
+      "type": "book",
+      "author": "Michael Taft",
+      "traditions": [
+        "modern-non-dual",
+        "zen",
+        "tantra"
+      ],
+      "teachers": [
+        "michael-taft"
+      ]
+    },
+    {
+      "slug": "taft-nondualism",
+      "title": "Nondualism",
+      "type": "book",
+      "author": "Michael Taft",
+      "traditions": [
+        "modern-non-dual",
+        "zen",
+        "tantra"
+      ],
+      "teachers": [
+        "michael-taft"
+      ]
+    },
+    {
+      "slug": "taft-talkin-to-myself",
+      "title": "Talkin' to Myself",
+      "type": "book",
+      "author": "Michael Taft",
+      "traditions": [
+        "modern-non-dual",
+        "zen",
+        "tantra"
+      ],
+      "teachers": [
+        "michael-taft"
+      ]
+    },
+    {
+      "slug": "taft-the-blues-lyric-formula",
+      "title": "The Blues Lyric Formula",
+      "type": "book",
+      "author": "Michael Taft",
+      "traditions": [
+        "modern-non-dual",
+        "zen",
+        "tantra"
+      ],
+      "teachers": [
+        "michael-taft"
+      ]
+    },
+    {
+      "slug": "taft-the-mindful-geek",
+      "title": "The Mindful Geek",
+      "type": "book",
+      "author": "Michael Taft",
+      "traditions": [
+        "modern-non-dual",
+        "zen",
+        "tantra"
+      ],
+      "teachers": [
+        "michael-taft"
+      ]
+    },
+    {
+      "slug": "tai-chi-classics",
+      "title": "Tai Chi Classics",
+      "type": "book",
+      "author": "Waysun Liao",
+      "traditions": [
+        "tai-chi-qigong",
+        "taoism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "tai-chi-national-center-for-complementary-and-integrative-health",
+      "title": "Tai Chi (National Center for Complementary and Integrative Health)",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "tai-chi-qigong"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "tantra-encyclopaedia-britannica",
+      "title": "Tantra (Encyclopaedia Britannica)",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "tantra",
+        "kashmir-shaivism",
+        "vajrayana"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "tantra-illuminated",
+      "title": "Tantra Illuminated",
+      "type": "book",
+      "author": "Christopher D. Wallis",
+      "traditions": [
+        "tantra",
+        "kashmir-shaivism"
+      ],
+      "teachers": [
+        "christopher-hareesh-wallis"
+      ]
+    },
+    {
+      "slug": "tao-te-ching",
+      "title": "Tao Te Ching",
+      "type": "book",
+      "author": "Laozi",
+      "traditions": [
+        "taoism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "taoism-stanford-encyclopedia-of-philosophy",
+      "title": "Taoism (Stanford Encyclopedia of Philosophy)",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "taoism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "tattvartha-sutra-that-which-is",
+      "title": "Tattvartha Sutra (That Which Is)",
+      "type": "book",
+      "author": "Umasvati / Nathmal Tatia (trans.)",
+      "traditions": [
+        "jainism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "terebess-asia-online",
+      "title": "Terebess Asia Online",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "zen",
+        "chan-buddhism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "that-which-is",
+      "title": "That Which Is: Tattvartha Sutra",
+      "type": "book",
+      "author": "Umasvati",
+      "traditions": [
+        "jainism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-art-of-living-vipassana-meditation",
+      "title": "The Art of Living: Vipassana Meditation",
+      "type": "book",
+      "author": "William Hart / S.N. Goenka",
+      "traditions": [
+        "vipassana-movement",
+        "theravada"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-complete-book-of-tai-chi-chuan",
+      "title": "The Complete Book of Tai Chi Chuan",
+      "type": "book",
+      "author": "Wong Kiew Kit",
+      "traditions": [
+        "tai-chi-qigong",
+        "taoism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-conference-of-the-birds",
+      "title": "The Conference of the Birds",
+      "type": "book",
+      "author": "Farid ud-Din Attar",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-crystal-and-the-way-of-light",
+      "title": "The Crystal and the Way of Light",
+      "type": "book",
+      "author": "Chogyal Namkhai Norbu",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-end-of-your-world",
+      "title": "The End of Your World",
+      "type": "book",
+      "author": "Adyashanti",
+      "traditions": [
+        "zen",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "adyashanti"
+      ]
+    },
+    {
+      "slug": "the-enneads-penguin-classics",
+      "title": "The Enneads (Penguin Classics)",
+      "type": "book",
+      "author": "Plotinus / Stephen MacKenna (trans.)",
+      "traditions": [
+        "neoplatonism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-essential-kabbalah",
+      "title": "The Essential Kabbalah",
+      "type": "book",
+      "author": "Daniel C. Matt",
+      "traditions": [
+        "kabbalah"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-flight-of-the-garuda",
+      "title": "The Flight of the Garuda",
+      "type": "book",
+      "author": "Keith Dowman (trans.)",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-gateless-gate-mumonkan",
+      "title": "The Gateless Gate (Mumonkan)",
+      "type": "book",
+      "author": "Robert Aitken (trans.)",
+      "traditions": [
+        "zen",
+        "chan-buddhism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-gnostic-gospels",
+      "title": "The Gnostic Gospels",
+      "type": "book",
+      "author": "Elaine Pagels",
+      "traditions": [
+        "gnosticism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-gnostic-society-library",
+      "title": "The Gnostic Society Library",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "gnosticism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-gospel-of-thomas",
+      "title": "The Gospel of Thomas: The Gnostic Wisdom of Jesus",
+      "type": "book",
+      "author": "Jean-Yves Leloup",
+      "traditions": [
+        "gnosticism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-great-treatise-on-the-stages-of-the-path-to-enlightenment-lamrim-chenmo",
+      "title": "The Great Treatise on the Stages of the Path to Enlightenment (Lamrim Chenmo)",
+      "type": "book",
+      "author": "Tsongkhapa",
+      "traditions": [
+        "tibetan-buddhism-gelug"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-harvard-medical-school-guide-to-tai-chi",
+      "title": "The Harvard Medical School Guide to Tai Chi",
+      "type": "book",
+      "author": "Peter Wayne",
+      "traditions": [
+        "tai-chi-qigong"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-heart-of-sufism",
+      "title": "The Heart of Sufism",
+      "type": "book",
+      "author": "Hazrat Inayat Khan",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-heart-sutra",
+      "title": "The Heart Sutra",
+      "type": "book",
+      "author": "Kazuaki Tanahashi",
+      "traditions": [
+        "mahayana",
+        "zen"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-journal-of-george-fox",
+      "title": "The Journal of George Fox",
+      "type": "book",
+      "author": "George Fox",
+      "traditions": [
+        "quaker-inner-light"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-kularnava-tantra",
+      "title": "The Kularnava Tantra",
+      "type": "book",
+      "author": "Arthur Avalon (trans.)",
+      "traditions": [
+        "tantra"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-long-discourses-of-the-buddha-digha-nikaya",
+      "title": "The Long Discourses of the Buddha (Digha Nikaya)",
+      "type": "book",
+      "author": "Maurice Walshe (trans.)",
+      "traditions": [
+        "theravada",
+        "early-buddhism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-mind-illuminated",
+      "title": "The Mind Illuminated",
+      "type": "book",
+      "author": "Culadasa (John Yates)",
+      "traditions": [
+        "secular-mindfulness",
+        "theravada"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-miracle-of-mindfulness",
+      "title": "The Miracle of Mindfulness",
+      "type": "book",
+      "author": "Thich Nhat Hanh",
+      "traditions": [
+        "zen",
+        "mahayana"
+      ],
+      "teachers": [
+        "thich-nhat-hanh"
+      ]
+    },
+    {
+      "slug": "the-nag-hammadi-scriptures",
+      "title": "The Nag Hammadi Scriptures",
+      "type": "book",
+      "author": "Marvin W. Meyer (ed.)",
+      "traditions": [
+        "gnosticism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-philokalia-selections",
+      "title": "The Philokalia: The Eastern Christian Spiritual Texts",
+      "type": "book",
+      "author": "Allyne Smith",
+      "traditions": [
+        "hesychasm",
+        "christian-mysticism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-places-that-scare-you",
+      "title": "The Places That Scare You",
+      "type": "book",
+      "author": "Pema Chödrön",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu"
+      ],
+      "teachers": [
+        "pema-chodron"
+      ]
+    },
+    {
+      "slug": "the-platform-sutra-red-pine",
+      "title": "The Platform Sutra: The Zen Teaching of Hui-neng",
+      "type": "book",
+      "author": "Red Pine",
+      "traditions": [
+        "chan-buddhism",
+        "zen"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-platform-sutra",
+      "title": "The Platform Sutra of the Sixth Patriarch",
+      "type": "book",
+      "author": "Huineng",
+      "traditions": [
+        "chan-buddhism",
+        "zen"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-recognition-sutras-pratyabhijna-hridayam",
+      "title": "The Recognition Sutras (Pratyabhijna Hridayam)",
+      "type": "book",
+      "author": "Christopher Wallis",
+      "traditions": [
+        "kashmir-shaivism",
+        "tantra"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-sayings-of-layman-pang",
+      "title": "The Sayings of Layman Pang",
+      "type": "book",
+      "author": "James Green (trans.)",
+      "traditions": [
+        "chan-buddhism",
+        "zen"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-secret-of-the-golden-flower",
+      "title": "The Secret of the Golden Flower",
+      "type": "book",
+      "author": "Thomas Cleary (trans.)",
+      "traditions": [
+        "taoism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-serpent-power",
+      "title": "The Serpent Power",
+      "type": "book",
+      "author": "Sir John Woodroffe (Arthur Avalon)",
+      "traditions": [
+        "tantra",
+        "classical-yoga"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-tao-of-pooh",
+      "title": "The Tao of Pooh",
+      "type": "book",
+      "author": "Benjamin Hoff",
+      "traditions": [
+        "taoism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-tibetan-yogas-of-dream-and-sleep",
+      "title": "The Tibetan Yogas of Dream and Sleep",
+      "type": "book",
+      "author": "Tenzin Wangyal Rinpoche",
+      "traditions": [
+        "dzogchen",
+        "vajrayana",
+        "tantra"
+      ],
+      "teachers": [
+        "tenzin-wangyal-rinpoche"
+      ]
+    },
+    {
+      "slug": "the-transparency-of-things",
+      "title": "The Transparency of Things",
+      "type": "book",
+      "author": "Rupert Spira",
+      "traditions": [
+        "modern-non-dual",
+        "advaita-vedanta"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-upanishads",
+      "title": "The Upanishads",
+      "type": "book",
+      "author": "Eknath Easwaran",
+      "traditions": [
+        "vedanta",
+        "classical-yoga"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-way-of-a-pilgrim",
+      "title": "The Way of a Pilgrim",
+      "type": "book",
+      "author": "Anonymous",
+      "traditions": [
+        "hesychasm",
+        "christian-mysticism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-way-of-qigong",
+      "title": "The Way of Qigong",
+      "type": "book",
+      "author": "Kenneth S. Cohen",
+      "traditions": [
+        "tai-chi-qigong",
+        "taoism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "the-way-of-the-bodhisattva",
+      "title": "The Way of the Bodhisattva",
+      "type": "book",
+      "author": "Shantideva",
+      "traditions": [
+        "mahayana",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma",
+        "tibetan-buddhism-gelug"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "theravada-buddhism-stanford-encyclopedia-of-philosophy",
+      "title": "Theravada Buddhism (Stanford Encyclopedia of Philosophy)",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "thubten-a-sacred-compass",
+      "title": "A Sacred Compass",
+      "type": "book",
+      "author": "Anam Thubten",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "anam-thubten"
+      ]
+    },
+    {
+      "slug": "thubten-all-is-well",
+      "title": "All Is Well",
+      "type": "book",
+      "author": "Anam Thubten",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "anam-thubten"
+      ]
+    },
+    {
+      "slug": "thubten-big-sky",
+      "title": "Big Sky",
+      "type": "book",
+      "author": "Anam Thubten",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "anam-thubten"
+      ]
+    },
+    {
+      "slug": "thubten-choosing-compassion",
+      "title": "Choosing Compassion",
+      "type": "book",
+      "author": "Anam Thubten",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "anam-thubten"
+      ]
+    },
+    {
+      "slug": "thubten-embracing-each-moment",
+      "title": "Embracing Each Moment",
+      "type": "book",
+      "author": "Anam Thubten",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "anam-thubten"
+      ]
+    },
+    {
+      "slug": "thubten-into-the-haunted-ground",
+      "title": "Into the Haunted Ground",
+      "type": "book",
+      "author": "Anam Thubten",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "anam-thubten"
+      ]
+    },
+    {
+      "slug": "thubten-la-citadelle-de-la-conscience-un-commentaire-de-la-priere-d-aspiration-d",
+      "title": "La citadelle de la conscience - Un commentaire de la prière d'aspiration Dzogchen de Jigmé Lingpa",
+      "type": "book",
+      "author": "Anam Thubten",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "anam-thubten"
+      ]
+    },
+    {
+      "slug": "thubten-la-magia-de-la-conciencia",
+      "title": "La Magia de la Conciencia",
+      "type": "book",
+      "author": "Anam Thubten",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "anam-thubten"
+      ]
+    },
+    {
+      "slug": "thubten-no-self-no-problem",
+      "title": "No Self, No Problem",
+      "type": "book",
+      "author": "Anam Thubten",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "anam-thubten"
+      ]
+    },
+    {
+      "slug": "thubten-releasing-the-knot-of-the-mind",
+      "title": "Releasing the Knot of the Mind",
+      "type": "book",
+      "author": "Anam Thubten",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "anam-thubten"
+      ]
+    },
+    {
+      "slug": "thubten-sin-yo-no-hay-problemas",
+      "title": "Sin yo no hay problemas",
+      "type": "book",
+      "author": "Anam Thubten",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "anam-thubten"
+      ]
+    },
+    {
+      "slug": "thubten-the-citadel-of-awareness",
+      "title": "The Citadel of Awareness",
+      "type": "book",
+      "author": "Anam Thubten",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "anam-thubten"
+      ]
+    },
+    {
+      "slug": "thubten-the-fragrance-of-emptiness",
+      "title": "The Fragrance of Emptiness",
+      "type": "book",
+      "author": "Anam Thubten",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "anam-thubten"
+      ]
+    },
+    {
+      "slug": "thubten-timeless-offerings",
+      "title": "Timeless Offerings",
+      "type": "book",
+      "author": "Anam Thubten",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "anam-thubten"
+      ]
+    },
+    {
+      "slug": "thubten-voice-of-the-primordial-buddha-a-commentary-on-dudjom-lingpa-s-sharp-vaj",
+      "title": "Voice of the Primordial Buddha: A Commentary on Dudjom Lingpa's Sharp Vajra of Awareness Tantra",
+      "type": "book",
+      "author": "Anam Thubten",
+      "traditions": [
+        "dzogchen",
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": [
+        "anam-thubten"
+      ]
+    },
+    {
+      "slug": "thurman-anger",
+      "title": "Anger",
+      "type": "book",
+      "author": "Robert Thurman",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-gelug"
+      ],
+      "teachers": [
+        "robert-thurman"
+      ]
+    },
+    {
+      "slug": "thurman-bla-ma-i-mchod-pa",
+      "title": "Bla Ma'i Mchod Pa",
+      "type": "book",
+      "author": "Robert Thurman",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-gelug"
+      ],
+      "teachers": [
+        "robert-thurman"
+      ]
+    },
+    {
+      "slug": "thurman-essential-tibetan-buddhism",
+      "title": "Essential Tibetan Buddhism",
+      "type": "book",
+      "author": "Robert Thurman",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-gelug"
+      ],
+      "teachers": [
+        "robert-thurman"
+      ]
+    },
+    {
+      "slug": "thurman-infinite-life",
+      "title": "Infinite Life",
+      "type": "book",
+      "author": "Robert Thurman",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-gelug"
+      ],
+      "teachers": [
+        "robert-thurman"
+      ]
+    },
+    {
+      "slug": "thurman-inner-revolution",
+      "title": "Inner Revolution",
+      "type": "book",
+      "author": "Robert Thurman",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-gelug"
+      ],
+      "teachers": [
+        "robert-thurman"
+      ]
+    },
+    {
+      "slug": "thurman-love-your-enemies",
+      "title": "Love Your Enemies",
+      "type": "book",
+      "author": "Robert Thurman",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-gelug"
+      ],
+      "teachers": [
+        "robert-thurman"
+      ]
+    },
+    {
+      "slug": "thurman-mindscience",
+      "title": "MindScience",
+      "type": "book",
+      "author": "Robert Thurman",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-gelug"
+      ],
+      "teachers": [
+        "robert-thurman"
+      ]
+    },
+    {
+      "slug": "thurman-the-central-philosophy-of-tibet",
+      "title": "The Central Philosophy of Tibet",
+      "type": "book",
+      "author": "Robert Thurman",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-gelug"
+      ],
+      "teachers": [
+        "robert-thurman"
+      ]
+    },
+    {
+      "slug": "thurman-the-jewel-tree-of-tibet",
+      "title": "The Jewel Tree of Tibet",
+      "type": "book",
+      "author": "Robert Thurman",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-gelug"
+      ],
+      "teachers": [
+        "robert-thurman"
+      ]
+    },
+    {
+      "slug": "thurman-why-the-dalai-lama-matters",
+      "title": "Why the Dalai Lama Matters",
+      "type": "book",
+      "author": "Robert Thurman",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-gelug"
+      ],
+      "teachers": [
+        "robert-thurman"
+      ]
+    },
+    {
+      "slug": "thurman-wisdom-is-bliss",
+      "title": "Wisdom Is Bliss",
+      "type": "book",
+      "author": "Robert Thurman",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-gelug"
+      ],
+      "teachers": [
+        "robert-thurman"
+      ]
+    },
+    {
+      "slug": "tibetan-book-of-living-and-dying",
+      "title": "The Tibetan Book of Living and Dying",
+      "type": "book",
+      "author": "Sogyal Rinpoche",
+      "traditions": [
+        "tibetan-buddhism-nyingma",
+        "vajrayana"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "tibetan-buddhism-stanford-encyclopedia-of-philosophy",
+      "title": "Tibetan Buddhism (Stanford Encyclopedia of Philosophy)",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "tibetan-buddhism-nyingma",
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-gelug",
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "tokusho-mud-and-water",
+      "title": "Mud and Water",
+      "type": "book",
+      "author": "Bassui Tokushō",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "bassui"
+      ]
+    },
+    {
+      "slug": "tolle-a-new-earth-oprah-s-book-club",
+      "title": "A New Earth: Oprah's Book Club",
+      "type": "book",
+      "author": "Eckhart Tolle",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "eckhart-tolle"
+      ]
+    },
+    {
+      "slug": "tolle-a-new-earth",
+      "title": "A New Earth",
+      "type": "book",
+      "author": "Eckhart Tolle",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "eckhart-tolle"
+      ]
+    },
+    {
+      "slug": "tolle-guardians-of-being",
+      "title": "Guardians of Being",
+      "type": "book",
+      "author": "Eckhart Tolle",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "eckhart-tolle"
+      ]
+    },
+    {
+      "slug": "tolle-oneness-with-all-life",
+      "title": "Oneness with All Life",
+      "type": "book",
+      "author": "Eckhart Tolle",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "eckhart-tolle"
+      ]
+    },
+    {
+      "slug": "tolle-practicing-the-power-of-now-easyread-large-bold-edition",
+      "title": "Practicing the Power of Now (EasyRead Large Bold Edition)",
+      "type": "book",
+      "author": "Eckhart Tolle",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "eckhart-tolle"
+      ]
+    },
+    {
+      "slug": "tolle-practicing-the-power-of-now",
+      "title": "Practicing the Power of Now",
+      "type": "book",
+      "author": "Eckhart Tolle",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "eckhart-tolle"
+      ]
+    },
+    {
+      "slug": "tolle-practising-the-power-of-now-ssb",
+      "title": "Practising the Power of Now - Ssb",
+      "type": "book",
+      "author": "Eckhart Tolle",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "eckhart-tolle"
+      ]
+    },
+    {
+      "slug": "tolle-stillness-speaks-easyread-super-large-24pt-edition",
+      "title": "Stillness Speaks (EasyRead Super Large 24pt Edition)",
+      "type": "book",
+      "author": "Eckhart Tolle",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "eckhart-tolle"
+      ]
+    },
+    {
+      "slug": "tolle-stillness-speaks",
+      "title": "Stillness Speaks",
+      "type": "book",
+      "author": "Eckhart Tolle",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "eckhart-tolle"
+      ]
+    },
+    {
+      "slug": "tolle-the-power-of-now",
+      "title": "The Power of Now",
+      "type": "book",
+      "author": "Eckhart Tolle",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "eckhart-tolle"
+      ]
+    },
+    {
+      "slug": "treasury-of-dharma-fpmt",
+      "title": "Treasury of Dharma (FPMT)",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "tibetan-buddhism-gelug"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "vajrayana-encyclopaedia-britannica",
+      "title": "Vajrayana (Encyclopaedia Britannica)",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "vaughan-lee-darkening-of-the-light",
+      "title": "Darkening of the Light",
+      "type": "book",
+      "author": "Llewellyn Vaughan-Lee",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "llewellyn-vaughan-lee"
+      ]
+    },
+    {
+      "slug": "vaughan-lee-for-love-of-the-real",
+      "title": "For Love of the Real",
+      "type": "book",
+      "author": "Llewellyn Vaughan-Lee",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "llewellyn-vaughan-lee"
+      ]
+    },
+    {
+      "slug": "vaughan-lee-fragments-of-a-love-story",
+      "title": "Fragments of a Love Story",
+      "type": "book",
+      "author": "Llewellyn Vaughan-Lee",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "llewellyn-vaughan-lee"
+      ]
+    },
+    {
+      "slug": "vaughan-lee-in-the-company-of-friends",
+      "title": "In the Company of Friends",
+      "type": "book",
+      "author": "Llewellyn Vaughan-Lee",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "llewellyn-vaughan-lee"
+      ]
+    },
+    {
+      "slug": "vaughan-lee-light-of-oneness",
+      "title": "Light of Oneness",
+      "type": "book",
+      "author": "Llewellyn Vaughan-Lee",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "llewellyn-vaughan-lee"
+      ]
+    },
+    {
+      "slug": "vaughan-lee-love-is-a-fire",
+      "title": "Love Is a Fire",
+      "type": "book",
+      "author": "Llewellyn Vaughan-Lee",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "llewellyn-vaughan-lee"
+      ]
+    },
+    {
+      "slug": "vaughan-lee-seasons-of-the-sacred",
+      "title": "Seasons of the Sacred",
+      "type": "book",
+      "author": "Llewellyn Vaughan-Lee",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "llewellyn-vaughan-lee"
+      ]
+    },
+    {
+      "slug": "vaughan-lee-spiritual-ecology",
+      "title": "Spiritual Ecology",
+      "type": "book",
+      "author": "Llewellyn Vaughan-Lee",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "llewellyn-vaughan-lee"
+      ]
+    },
+    {
+      "slug": "vaughan-lee-spiritual-power",
+      "title": "Spiritual Power",
+      "type": "book",
+      "author": "Llewellyn Vaughan-Lee",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "llewellyn-vaughan-lee"
+      ]
+    },
+    {
+      "slug": "vaughan-lee-sufism",
+      "title": "Sufism",
+      "type": "book",
+      "author": "Llewellyn Vaughan-Lee",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "llewellyn-vaughan-lee"
+      ]
+    },
+    {
+      "slug": "vaughan-lee-the-circle-of-love",
+      "title": "The Circle of Love",
+      "type": "book",
+      "author": "Llewellyn Vaughan-Lee",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "llewellyn-vaughan-lee"
+      ]
+    },
+    {
+      "slug": "vaughan-lee-the-return-of-the-feminine-and-the-world-soul",
+      "title": "The Return of the Feminine and the World Soul",
+      "type": "book",
+      "author": "Llewellyn Vaughan-Lee",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "llewellyn-vaughan-lee"
+      ]
+    },
+    {
+      "slug": "vaughan-lee-the-signs-of-god",
+      "title": "The Signs of God",
+      "type": "book",
+      "author": "Llewellyn Vaughan-Lee",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "llewellyn-vaughan-lee"
+      ]
+    },
+    {
+      "slug": "vaughan-lee-within-the-heart-of-hearts",
+      "title": "Within the Heart of Hearts",
+      "type": "book",
+      "author": "Llewellyn Vaughan-Lee",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "llewellyn-vaughan-lee"
+      ]
+    },
+    {
+      "slug": "vaughan-lee-words-from-the-water-s-edge",
+      "title": "Words from the Water's Edge",
+      "type": "book",
+      "author": "Llewellyn Vaughan-Lee",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "llewellyn-vaughan-lee"
+      ]
+    },
+    {
+      "slug": "vedanta-society",
+      "title": "Vedanta Society",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "vedanta",
+        "advaita-vedanta",
+        "bhakti"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "vedanta-stanford-encyclopedia-of-philosophy",
+      "title": "Vedanta (Stanford Encyclopedia of Philosophy)",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "vedanta",
+        "advaita-vedanta"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "vijnana-bhairava-tantra",
+      "title": "Vijnana Bhairava Tantra",
+      "type": "book",
+      "author": "Lorin Roche (trans.)",
+      "traditions": [
+        "kashmir-shaivism",
+        "tantra"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "vipassana-research-institute",
+      "title": "Vipassana Research Institute",
+      "type": "website",
+      "author": null,
+      "traditions": [
+        "vipassana-movement",
+        "theravada"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "vivekachudamani-crest-jewel-of-discrimination",
+      "title": "Vivekachudamani (Crest-Jewel of Discrimination)",
+      "type": "book",
+      "author": "Adi Shankara",
+      "traditions": [
+        "advaita-vedanta",
+        "vedanta"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "vivekananda-addresses-on-bhakti-yoga",
+      "title": "Addresses On Bhakti-Yoga",
+      "type": "book",
+      "author": "Swami Vivekananda",
+      "traditions": [
+        "vedanta",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "swami-vivekananda"
+      ]
+    },
+    {
+      "slug": "vivekananda-inspired-talks",
+      "title": "Inspired Talks",
+      "type": "book",
+      "author": "Swami Vivekananda",
+      "traditions": [
+        "vedanta",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "swami-vivekananda"
+      ]
+    },
+    {
+      "slug": "vivekananda-meditation-and-its-methods",
+      "title": "Meditation and Its Methods",
+      "type": "book",
+      "author": "Swami Vivekananda",
+      "traditions": [
+        "vedanta",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "swami-vivekananda"
+      ]
+    },
+    {
+      "slug": "vivekananda-newspaper-reports",
+      "title": "Newspaper Reports",
+      "type": "book",
+      "author": "Swami Vivekananda",
+      "traditions": [
+        "vedanta",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "swami-vivekananda"
+      ]
+    },
+    {
+      "slug": "vivekananda-notes-from-lectures-and-discourses",
+      "title": "Notes From Lectures And Discourses",
+      "type": "book",
+      "author": "Swami Vivekananda",
+      "traditions": [
+        "vedanta",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "swami-vivekananda"
+      ]
+    },
+    {
+      "slug": "vivekananda-sisters-and-brothers-of-america",
+      "title": "Sisters and Brothers of America",
+      "type": "book",
+      "author": "Swami Vivekananda",
+      "traditions": [
+        "vedanta",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "swami-vivekananda"
+      ]
+    },
+    {
+      "slug": "vivekananda-the-complete-works-of-swami-vivekananda-volume-2",
+      "title": "The Complete Works of Swami Vivekananda - Volume 2",
+      "type": "book",
+      "author": "Swami Vivekananda",
+      "traditions": [
+        "vedanta",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "swami-vivekananda"
+      ]
+    },
+    {
+      "slug": "vivekananda-the-complete-works-of-swami-vivekananda-volume-3",
+      "title": "The Complete Works of Swami Vivekananda - Volume 3",
+      "type": "book",
+      "author": "Swami Vivekananda",
+      "traditions": [
+        "vedanta",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "swami-vivekananda"
+      ]
+    },
+    {
+      "slug": "vivekananda-what-religion-is",
+      "title": "What Religion Is",
+      "type": "book",
+      "author": "Swami Vivekananda",
+      "traditions": [
+        "vedanta",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "swami-vivekananda"
+      ]
+    },
+    {
+      "slug": "vivekananda-works-of-swami-vivekananda-vol-v",
+      "title": "Works Of Swami Vivekananda Vol. V",
+      "type": "book",
+      "author": "Swami Vivekananda",
+      "traditions": [
+        "vedanta",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "swami-vivekananda"
+      ]
+    },
+    {
+      "slug": "waking-up-app",
+      "title": "Waking Up with Sam Harris",
+      "type": "podcast",
+      "author": "Sam Harris",
+      "traditions": [
+        "secular-mindfulness",
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "rupert-spira"
+      ]
+    },
+    {
+      "slug": "wallace-dreaming-yourself-awake",
+      "title": "Dreaming Yourself Awake",
+      "type": "book",
+      "author": "B. Alan Wallace",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "b-alan-wallace"
+      ]
+    },
+    {
+      "slug": "wallace-embracing-mind",
+      "title": "Embracing Mind",
+      "type": "book",
+      "author": "B. Alan Wallace",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "b-alan-wallace"
+      ]
+    },
+    {
+      "slug": "wallace-genuine-happiness",
+      "title": "Genuine Happiness",
+      "type": "book",
+      "author": "B. Alan Wallace",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "b-alan-wallace"
+      ]
+    },
+    {
+      "slug": "wallace-meditations-of-a-buddhist-skeptic",
+      "title": "Meditations of a Buddhist Skeptic",
+      "type": "book",
+      "author": "B. Alan Wallace",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "b-alan-wallace"
+      ]
+    },
+    {
+      "slug": "wallace-mind-in-the-balance",
+      "title": "Mind in the Balance",
+      "type": "book",
+      "author": "B. Alan Wallace",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "b-alan-wallace"
+      ]
+    },
+    {
+      "slug": "wallace-minding-closely",
+      "title": "Minding Closely",
+      "type": "book",
+      "author": "B. Alan Wallace",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "b-alan-wallace"
+      ]
+    },
+    {
+      "slug": "wallace-the-art-of-transforming-the-mind",
+      "title": "The Art of Transforming the Mind",
+      "type": "book",
+      "author": "B. Alan Wallace",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "b-alan-wallace"
+      ]
+    },
+    {
+      "slug": "wallace-the-attention-revolution",
+      "title": "The Attention Revolution",
+      "type": "book",
+      "author": "B. Alan Wallace",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "b-alan-wallace"
+      ]
+    },
+    {
+      "slug": "wallace-the-four-immeasurables",
+      "title": "The Four Immeasurables",
+      "type": "book",
+      "author": "B. Alan Wallace",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "b-alan-wallace"
+      ]
+    },
+    {
+      "slug": "wallace-the-seven-point-mind-training",
+      "title": "The Seven-Point Mind Training",
+      "type": "book",
+      "author": "B. Alan Wallace",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "b-alan-wallace"
+      ]
+    },
+    {
+      "slug": "wallace-the-vital-essence-of-dzogchen",
+      "title": "The Vital Essence of Dzogchen",
+      "type": "book",
+      "author": "B. Alan Wallace",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "b-alan-wallace"
+      ]
+    },
+    {
+      "slug": "wallace-tibetan-buddhism-from-the-ground-up",
+      "title": "Tibetan Buddhism from the Ground Up",
+      "type": "book",
+      "author": "B. Alan Wallace",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "b-alan-wallace"
+      ]
+    },
+    {
+      "slug": "washam-a-fierce-heart",
+      "title": "A Fierce Heart",
+      "type": "book",
+      "author": "Spring Washam",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "spring-washam"
+      ]
+    },
+    {
+      "slug": "washam-the-spirit-of-harriet-tubman",
+      "title": "The Spirit of Harriet Tubman",
+      "type": "book",
+      "author": "Spring Washam",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "teachers": [
+        "spring-washam"
+      ]
+    },
+    {
+      "slug": "way-of-zen",
+      "title": "The Way of Zen",
+      "type": "book",
+      "author": "Alan Watts",
+      "traditions": [
+        "zen",
+        "chan-buddhism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "what-the-buddha-taught",
+      "title": "What the Buddha Taught",
+      "type": "book",
+      "author": "Walpola Rahula",
+      "traditions": [
+        "early-buddhism",
+        "theravada"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "when-things-fall-apart",
+      "title": "When Things Fall Apart",
+      "type": "book",
+      "author": "Pema Chödrön",
+      "traditions": [
+        "vajrayana",
+        "tibetan-buddhism-kagyu"
+      ],
+      "teachers": [
+        "pema-chodron"
+      ]
+    },
+    {
+      "slug": "wherever-you-go-there-you-are",
+      "title": "Wherever You Go, There You Are",
+      "type": "book",
+      "author": "Jon Kabat-Zinn",
+      "traditions": [
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "jon-kabat-zinn"
+      ]
+    },
+    {
+      "slug": "williams-being-black",
+      "title": "Being Black",
+      "type": "book",
+      "author": "angel Kyodo williams",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "angel-kyodo-williams"
+      ]
+    },
+    {
+      "slug": "williams-radical-dharma",
+      "title": "Radical Dharma",
+      "type": "book",
+      "author": "angel Kyodo williams",
+      "traditions": [
+        "zen",
+        "tibetan-buddhism-kagyu"
+      ],
+      "teachers": [
+        "angel-kyodo-williams",
+        "lama-rod-owens"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-ajahn-chah",
+      "title": "Ajahn Chah — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ajahn-chah"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-ajahn-lee",
+      "title": "Ajahn Lee — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "theravada"
+      ],
+      "teachers": [
+        "ajahn-lee"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-annamalai-swami",
+      "title": "Annamalai Swami — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "annamalai-swami"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-ayu-khandro",
+      "title": "Ayu Khandro — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "ayu-khandro"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-baizhang-huaihai",
+      "title": "Baizhang Huaihai — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "zen",
+        "chan-buddhism"
+      ],
+      "teachers": [
+        "baizhang-huaihai"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-bassui",
+      "title": "Bassui — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "bassui"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-dilgo-khyentse-rinpoche",
+      "title": "Dilgo Khyentse Rinpoche — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "dilgo-khyentse-rinpoche"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-dudjom-rinpoche",
+      "title": "Dudjom Rinpoche — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "dudjom-rinpoche"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-father-thomas-keating",
+      "title": "Thomas Keating — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "father-thomas-keating"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-hafiz",
+      "title": "Hafiz — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "hafiz"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-hongzhi",
+      "title": "Hongzhi — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "zen",
+        "chan-buddhism"
+      ],
+      "teachers": [
+        "hongzhi"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-ilie-cioara",
+      "title": "Ilie Cioara — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "ilie-cioara"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-jean-klein",
+      "title": "Jean Klein — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "advaita-vedanta",
+        "modern-non-dual"
+      ],
+      "teachers": [
+        "jean-klein"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-lama-shabkar",
+      "title": "Lama Shabkar — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "lama-shabkar"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-longchenpa",
+      "title": "Longchenpa — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "dzogchen",
+        "vajrayana"
+      ],
+      "teachers": [
+        "longchenpa"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-meister-eckhart",
+      "title": "Meister Eckhart — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "meister-eckhart"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-naropa",
+      "title": "Naropa — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "naropa"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-nisargadatta-maharaj",
+      "title": "Nisargadatta Maharaj — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "nisargadatta-maharaj"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-padmasambhava",
+      "title": "Padmasambhava — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "padmasambhava"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-patanjali",
+      "title": "Patanjali — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": [
+        "patanjali"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-patrul-rinpoche",
+      "title": "Patrul Rinpoche — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "patrul-rinpoche"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-ramana-maharshi",
+      "title": "Ramana Maharshi — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "teachers": [
+        "ramana-maharshi"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-rumi",
+      "title": "Rumi — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "sufism"
+      ],
+      "teachers": [
+        "rumi"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-ryokan",
+      "title": "Ryokan — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "ryokan"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-seng-tsan",
+      "title": "Seng T'san — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "zen",
+        "chan-buddhism"
+      ],
+      "teachers": [
+        "seng-tsan"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-st-teresa-of-avila",
+      "title": "St. Teresa of Avila — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "teachers": [
+        "st-teresa-of-avila"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-tilopa",
+      "title": "Tilopa — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "vajrayana"
+      ],
+      "teachers": [
+        "tilopa"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-tulku-urgyen-rinpoche",
+      "title": "Tulku Urgyen Rinpoche — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "vajrayana",
+        "dzogchen"
+      ],
+      "teachers": [
+        "tulku-urgyen-rinpoche"
+      ]
+    },
+    {
+      "slug": "wisdom-masters-vivekananda",
+      "title": "Swami Vivekananda — Wisdom of the Masters",
+      "type": "video",
+      "author": "Samaneri Jayasāra",
+      "traditions": [
+        "vedanta",
+        "classical-yoga"
+      ],
+      "teachers": [
+        "swami-vivekananda"
+      ]
+    },
+    {
+      "slug": "wolf-a-clinician-s-guide-to-teaching-mindfulness",
+      "title": "A Clinician's Guide to Teaching Mindfulness",
+      "type": "book",
+      "author": "Christiane Wolf",
+      "traditions": [
+        "vipassana-movement",
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "christiane-wolf"
+      ]
+    },
+    {
+      "slug": "wolf-gauforen",
+      "title": "Gauforen",
+      "type": "book",
+      "author": "Christiane Wolf",
+      "traditions": [
+        "vipassana-movement",
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "christiane-wolf"
+      ]
+    },
+    {
+      "slug": "wolf-mindfulness-and-self-compassion-for-chronic-pain",
+      "title": "Mindfulness and Self-Compassion for Chronic Pain",
+      "type": "book",
+      "author": "Christiane Wolf",
+      "traditions": [
+        "vipassana-movement",
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "christiane-wolf"
+      ]
+    },
+    {
+      "slug": "wolf-outsmart-your-pain",
+      "title": "Outsmart Your Pain",
+      "type": "book",
+      "author": "Christiane Wolf",
+      "traditions": [
+        "vipassana-movement",
+        "secular-mindfulness"
+      ],
+      "teachers": [
+        "christiane-wolf"
+      ]
+    },
+    {
+      "slug": "yoga-stanford-encyclopedia-of-philosophy",
+      "title": "Yoga (Stanford Encyclopedia of Philosophy)",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "yoga-sutras-of-patanjali",
+      "title": "The Yoga Sutras of Patanjali",
+      "type": "book",
+      "author": "Patanjali",
+      "traditions": [
+        "classical-yoga"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "young-break-through-pain",
+      "title": "Break Through Pain",
+      "type": "book",
+      "author": "Shinzen Young",
+      "traditions": [
+        "vipassana-movement",
+        "secular-mindfulness",
+        "zen"
+      ],
+      "teachers": [
+        "shinzen-young"
+      ]
+    },
+    {
+      "slug": "young-la-ciencia-de-la-iluminacion",
+      "title": "La ciencia de la iluminación",
+      "type": "book",
+      "author": "Shinzen Young",
+      "traditions": [
+        "vipassana-movement",
+        "secular-mindfulness",
+        "zen"
+      ],
+      "teachers": [
+        "shinzen-young"
+      ]
+    },
+    {
+      "slug": "young-mindful-woot-bundle",
+      "title": "Mindful Woot Bundle",
+      "type": "book",
+      "author": "Shinzen Young",
+      "traditions": [
+        "vipassana-movement",
+        "secular-mindfulness",
+        "zen"
+      ],
+      "teachers": [
+        "shinzen-young"
+      ]
+    },
+    {
+      "slug": "young-natural-pain-relief",
+      "title": "Natural Pain Relief",
+      "type": "book",
+      "author": "Shinzen Young",
+      "traditions": [
+        "vipassana-movement",
+        "secular-mindfulness",
+        "zen"
+      ],
+      "teachers": [
+        "shinzen-young"
+      ]
+    },
+    {
+      "slug": "young-the-science-of-enlightenment",
+      "title": "The Science of Enlightenment",
+      "type": "book",
+      "author": "Shinzen Young",
+      "traditions": [
+        "vipassana-movement",
+        "secular-mindfulness",
+        "zen"
+      ],
+      "teachers": [
+        "shinzen-young"
+      ]
+    },
+    {
+      "slug": "young-when-therapy-doesn-t-work",
+      "title": "When Therapy Doesn't Work",
+      "type": "book",
+      "author": "Shinzen Young",
+      "traditions": [
+        "vipassana-movement",
+        "secular-mindfulness",
+        "zen"
+      ],
+      "teachers": [
+        "shinzen-young"
+      ]
+    },
+    {
+      "slug": "zen-buddhism-stanford-encyclopedia-of-philosophy",
+      "title": "Zen Buddhism (Stanford Encyclopedia of Philosophy)",
+      "type": "article",
+      "author": null,
+      "traditions": [
+        "zen"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "zen-mind-beginners-mind",
+      "title": "Zen Mind, Beginner's Mind",
+      "type": "book",
+      "author": "Shunryu Suzuki",
+      "traditions": [
+        "zen"
+      ],
+      "teachers": [
+        "shunryu-suzuki"
+      ]
+    },
+    {
+      "slug": "zhengjue-mester-hongzhis-veileder-til-praktisk-zen",
+      "title": "Mester Hongzhis Veileder til praktisk zen",
+      "type": "book",
+      "author": "Hongzhi Zhengjue",
+      "traditions": [
+        "zen",
+        "chan-buddhism"
+      ],
+      "teachers": [
+        "hongzhi"
+      ]
+    },
+    {
+      "slug": "zhuangzi-the-complete-writings",
+      "title": "Zhuangzi: The Complete Writings",
+      "type": "book",
+      "author": "Brook Ziporyn (trans.)",
+      "traditions": [
+        "taoism"
+      ],
+      "teachers": []
+    },
+    {
+      "slug": "zohar",
+      "title": "The Zohar: Pritzker Edition",
+      "type": "book",
+      "author": "Daniel C. Matt",
+      "traditions": [
+        "kabbalah"
+      ],
+      "teachers": []
+    }
+  ],
+  "paths": [
+    {
+      "slug": "advaita-and-self-inquiry",
+      "title": "Advaita and Self-Inquiry",
+      "type": "tradition",
+      "tradition": "advaita-vedanta",
+      "resource_count": 5
+    },
+    {
+      "slug": "exploring-zen",
+      "title": "Exploring Zen",
+      "type": "tradition",
+      "tradition": "zen",
+      "resource_count": 4
+    },
+    {
+      "slug": "the-christian-contemplative-way",
+      "title": "The Christian Contemplative Way",
+      "type": "tradition",
+      "tradition": "christian-mysticism",
+      "resource_count": 4
+    },
+    {
+      "slug": "the-sufi-heart",
+      "title": "The Sufi Heart",
+      "type": "tradition",
+      "tradition": "sufism",
+      "resource_count": 4
+    },
+    {
+      "slug": "the-tao-in-motion",
+      "title": "The Tao in Motion",
+      "type": "tradition",
+      "tradition": "taoism",
+      "resource_count": 4
+    },
+    {
+      "slug": "the-vipassana-path",
+      "title": "The Vipassana Path",
+      "type": "tradition",
+      "tradition": "vipassana-movement",
+      "resource_count": 5
+    },
+    {
+      "slug": "tibetan-heart-practices",
+      "title": "Tibetan Heart Practices",
+      "type": "tradition",
+      "tradition": "vajrayana",
+      "resource_count": 4
+    },
+    {
+      "slug": "yoga-beyond-asana",
+      "title": "Yoga Beyond Asana",
+      "type": "tradition",
+      "tradition": "classical-yoga",
+      "resource_count": 4
+    },
+    {
+      "slug": "contemplation-and-daily-life",
+      "title": "Contemplation and Daily Life",
+      "type": "thematic",
+      "tradition": null,
+      "resource_count": 4
+    },
+    {
+      "slug": "the-hidden-traditions",
+      "title": "The Hidden Traditions",
+      "type": "thematic",
+      "tradition": null,
+      "resource_count": 5
+    },
+    {
+      "slug": "where-traditions-meet",
+      "title": "Where Traditions Meet",
+      "type": "thematic",
+      "tradition": null,
+      "resource_count": 4
+    }
+  ]
+}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "scripts": {
     "dev": "next dev",
-    "prebuild": "npx tsx scripts/compute-layout.ts",
+    "prebuild": "npx tsx scripts/generate-manifest.ts && npx tsx scripts/compute-layout.ts",
     "build": "npm run prebuild && next build",
     "start": "npx serve out",
     "lint": "eslint",

--- a/scripts/generate-manifest.ts
+++ b/scripts/generate-manifest.ts
@@ -1,0 +1,158 @@
+#!/usr/bin/env tsx
+/**
+ * Build-time script: generates data/manifest.json — a single-file content
+ * registry designed for agent consumption.
+ *
+ * An agent can read this one file to answer:
+ *   - "Is X on the site?" (search names, alternate names, key figures)
+ *   - "What do we have about tradition Y?" (entity counts, connections)
+ *   - "Which teachers are associated with Z center?"
+ *
+ * Usage: tsx scripts/generate-manifest.ts
+ * Output: data/manifest.json
+ */
+import { readdirSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+import matter from "gray-matter";
+import { getAllTeachers, getAllCenters, getAllResources, getAllPaths } from "../src/lib/data";
+
+const ROOT = process.cwd();
+const OUTPUT_FILE = join(ROOT, "data", "manifest.json");
+
+interface ManifestTradition {
+  slug: string;
+  name: string;
+  family: string;
+  alternate_names: string[];
+  key_figures: string[];
+  key_texts: string[];
+  related_practices: string[];
+  connected_traditions: string[];
+}
+
+interface ManifestTeacher {
+  slug: string;
+  name: string;
+  traditions: string[];
+  centers: string[];
+  living: boolean;
+  location: string;
+}
+
+interface ManifestCenter {
+  slug: string;
+  name: string;
+  traditions: string[];
+  teachers: string[];
+  location: string;
+}
+
+interface ManifestResource {
+  slug: string;
+  title: string;
+  type: string;
+  author: string | null;
+  traditions: string[];
+  teachers: string[];
+}
+
+interface ManifestPath {
+  slug: string;
+  title: string;
+  type: string;
+  tradition: string | null;
+  resource_count: number;
+}
+
+interface Manifest {
+  generated_at: string;
+  counts: Record<string, number>;
+  traditions: ManifestTradition[];
+  teachers: ManifestTeacher[];
+  centers: ManifestCenter[];
+  resources: ManifestResource[];
+  paths: ManifestPath[];
+}
+
+function formatLocation(city: string, state: string, country: string): string {
+  return [city, state, country].filter(Boolean).join(", ");
+}
+
+function main() {
+  console.log("Generating content manifest...");
+
+  const traditionsDir = join(ROOT, "data", "traditions");
+  const traditionFiles = readdirSync(traditionsDir).filter((f) => f.endsWith(".mdx"));
+  const traditions = traditionFiles.map((f) => {
+    const raw = readFileSync(join(traditionsDir, f), "utf-8");
+    return matter(raw).data as Record<string, unknown>;
+  });
+  const teachers = getAllTeachers();
+  const centers = getAllCenters();
+  const resources = getAllResources();
+  const paths = getAllPaths();
+
+  const manifest: Manifest = {
+    generated_at: new Date().toISOString(),
+    counts: {
+      traditions: traditions.length,
+      teachers: teachers.length,
+      centers: centers.length,
+      resources: resources.length,
+      paths: paths.length,
+    },
+    traditions: traditions.map((t) => ({
+      slug: t.slug as string,
+      name: t.name as string,
+      family: t.family as string,
+      alternate_names: (t.alternate_names as string[]) || [],
+      key_figures: (t.key_figures as string[]) || [],
+      key_texts: (t.key_texts as string[]) || [],
+      related_practices: (t.related_practices as string[]) || [],
+      connected_traditions: ((t.connections as Array<{ tradition_slug: string }>) || []).map(
+        (c) => c.tradition_slug
+      ),
+    })),
+    teachers: teachers.map((t) => ({
+      slug: t.slug,
+      name: t.name,
+      traditions: t.traditions,
+      centers: t.centers,
+      living: t.death_year === null,
+      location: formatLocation(t.city, t.state, t.country),
+    })),
+    centers: centers.map((c) => ({
+      slug: c.slug,
+      name: c.name,
+      traditions: c.traditions,
+      teachers: c.teachers,
+      location: formatLocation(c.city, c.state, c.country),
+    })),
+    resources: resources.map((r) => ({
+      slug: r.slug,
+      title: r.title,
+      type: r.type,
+      author: r.author,
+      traditions: r.traditions,
+      teachers: r.teachers,
+    })),
+    paths: paths.map((p) => ({
+      slug: p.slug,
+      title: p.title,
+      type: p.type,
+      tradition: p.tradition,
+      resource_count: p.resources.length,
+    })),
+  };
+
+  writeFileSync(OUTPUT_FILE, JSON.stringify(manifest, null, 2) + "\n");
+
+  console.log(`Manifest written to ${OUTPUT_FILE}`);
+  console.log(`  ${manifest.counts.traditions} traditions`);
+  console.log(`  ${manifest.counts.teachers} teachers`);
+  console.log(`  ${manifest.counts.centers} centers`);
+  console.log(`  ${manifest.counts.resources} resources`);
+  console.log(`  ${manifest.counts.paths} paths`);
+}
+
+main();


### PR DESCRIPTION
## Summary
- Adds `scripts/generate-manifest.ts` — generates `data/manifest.json` at prebuild with every entity's slug, name, and searchable metadata (alternate names, key figures, key texts, related practices)
- Adds `.claude/commands/lookup.md` — `/lookup Bodhidharma` instantly searches the manifest across all entity types
- Wires into existing prebuild step alongside `compute-layout.ts`

## Why
Agents currently have to grep 1,400+ files to check if a teacher/tradition/concept exists on the site. The manifest gives them one 400K JSON file to search — includes fuzzy-matchable fields like alternate names and key figures that grep would miss.

## Test plan
- [x] `npm run prebuild` succeeds, generates both `manifest.json` and `map-layout.json`
- [x] Manifest includes rich frontmatter fields (verified Chan Buddhism has alternate_names, key_figures, key_texts)
- [ ] `/lookup` command works in Claude Code sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)