### PR TITLE
feat: add teachers field to Teacher schema (#266)

### DIFF
--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,8 +1,8 @@
 {
-  "generated_at": "2026-04-22T21:30:25.028Z",
+  "generated_at": "2026-04-24T08:18:35.810Z",
   "counts": {
     "traditions": 29,
-    "teachers": 137,
+    "teachers": 143,
     "centers": 80,
     "resources": 1156,
     "paths": 11
@@ -948,6 +948,16 @@
       "location": "Bangkok, Bangkok, TH"
     },
     {
+      "slug": "ajahn-mun",
+      "name": "Ajahn Mun",
+      "traditions": [
+        "theravada"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "TH"
+    },
+    {
       "slug": "ajahn-pasanno",
       "name": "Ajahn Pasanno",
       "traditions": [
@@ -1048,6 +1058,16 @@
       "centers": [],
       "living": true,
       "location": "US"
+    },
+    {
+      "slug": "arvis-joen-justi",
+      "name": "Arvis Joen Justi",
+      "traditions": [
+        "zen"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "Los Gatos, California, US"
     },
     {
       "slug": "av-neryah",
@@ -1166,6 +1186,17 @@
       "centers": [],
       "living": true,
       "location": "Portland, Oregon, US"
+    },
+    {
+      "slug": "chogyam-trungpa",
+      "name": "Chögyam Trungpa",
+      "traditions": [
+        "tibetan-buddhism-kagyu",
+        "tibetan-buddhism-nyingma"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Boulder, Colorado, US"
     },
     {
       "slug": "christiane-wolf",
@@ -1406,6 +1437,16 @@
       "centers": [],
       "living": false,
       "location": "Shiraz, Fars, IR"
+    },
+    {
+      "slug": "hakuun-yasutani",
+      "name": "Hakuun Yasutani",
+      "traditions": [
+        "zen"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "JP"
     },
     {
       "slug": "hazrat-inayat-khan",
@@ -1712,6 +1753,17 @@
       ],
       "living": true,
       "location": "Cambridge, Massachusetts, US"
+    },
+    {
+      "slug": "mahasi-sayadaw",
+      "name": "Mahasi Sayadaw",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Rangoon, MM"
     },
     {
       "slug": "matthew-fox",
@@ -2299,6 +2351,16 @@
       "centers": [],
       "living": false,
       "location": "Mysore, Karnataka, IN"
+    },
+    {
+      "slug": "taizan-maezumi",
+      "name": "Taizan Maezumi",
+      "traditions": [
+        "zen"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Los Angeles, California, US"
     },
     {
       "slug": "tara-brach",

--- a/data/teachers/adyashanti.json
+++ b/data/teachers/adyashanti.json
@@ -16,5 +16,6 @@
     "modern-non-dual",
     "advaita-vedanta"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/ah-almaas.json
+++ b/data/teachers/ah-almaas.json
@@ -16,5 +16,6 @@
     "modern-non-dual",
     "sufism"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/ajahn-chah.json
+++ b/data/teachers/ajahn-chah.json
@@ -14,5 +14,6 @@
   "traditions": [
     "theravada"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/ajahn-lee.json
+++ b/data/teachers/ajahn-lee.json
@@ -14,5 +14,6 @@
   "traditions": [
     "theravada"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/ajahn-mun.json
+++ b/data/teachers/ajahn-mun.json
@@ -1,0 +1,19 @@
+{
+  "name": "Ajahn Mun",
+  "slug": "ajahn-mun",
+  "bio": "Ajahn Mun Bhuridatta (1870–1949) was a Thai Theravada monk who revived the forest-dwelling ascetic tradition in Southeast Asia and founded the Thai Forest Tradition. He is considered one of the most revered Buddhist masters of the twentieth century. His students included Ajahn Chah, Ajahn Lee, and Ajahn Fun, whose own students spread the forest tradition to the West.",
+  "photo": null,
+  "website": null,
+  "birth_year": 1870,
+  "death_year": 1949,
+  "city": "",
+  "state": "",
+  "country": "TH",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "theravada"
+  ],
+  "centers": [],
+  "teachers": []
+}

--- a/data/teachers/ajahn-pasanno.json
+++ b/data/teachers/ajahn-pasanno.json
@@ -16,5 +16,6 @@
   ],
   "centers": [
     "abhayagiri-buddhist-monastery"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/ajahn-sumedho.json
+++ b/data/teachers/ajahn-sumedho.json
@@ -16,5 +16,6 @@
   ],
   "centers": [
     "abhayagiri-buddhist-monastery"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/anam-thubten.json
+++ b/data/teachers/anam-thubten.json
@@ -16,5 +16,6 @@
     "tibetan-buddhism-nyingma",
     "vajrayana"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/andrew-holecek.json
+++ b/data/teachers/andrew-holecek.json
@@ -11,6 +11,11 @@
   "country": "US",
   "latitude": null,
   "longitude": null,
-  "traditions": ["vajrayana", "tibetan-buddhism-kagyu", "tibetan-buddhism-nyingma"],
-  "centers": []
+  "traditions": [
+    "vajrayana",
+    "tibetan-buddhism-kagyu",
+    "tibetan-buddhism-nyingma"
+  ],
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/angel-kyodo-williams.json
+++ b/data/teachers/angel-kyodo-williams.json
@@ -14,5 +14,6 @@
   "traditions": [
     "zen"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/anna-douglas.json
+++ b/data/teachers/anna-douglas.json
@@ -18,5 +18,6 @@
   ],
   "centers": [
     "spirit-rock"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/annamalai-swami.json
+++ b/data/teachers/annamalai-swami.json
@@ -14,5 +14,6 @@
   "traditions": [
     "advaita-vedanta"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/anthony-de-mello.json
+++ b/data/teachers/anthony-de-mello.json
@@ -11,6 +11,9 @@
   "country": "India",
   "latitude": 18.5204,
   "longitude": 73.8567,
-  "traditions": ["christian-mysticism"],
-  "centers": []
+  "traditions": [
+    "christian-mysticism"
+  ],
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/artur-appazov.json
+++ b/data/teachers/artur-appazov.json
@@ -11,6 +11,9 @@
   "country": "US",
   "latitude": null,
   "longitude": null,
-  "traditions": ["modern-non-dual"],
-  "centers": []
+  "traditions": [
+    "modern-non-dual"
+  ],
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/arvis-joen-justi.json
+++ b/data/teachers/arvis-joen-justi.json
@@ -1,0 +1,21 @@
+{
+  "name": "Arvis Joen Justi",
+  "slug": "arvis-joen-justi",
+  "bio": "Arvis Joen Justi was an American Zen teacher and student of Taizan Maezumi Roshi. She taught in the Bay Area and is best known as the primary teacher of Adyashanti, who studied under her for fourteen years before his awakening in the mid-1990s.",
+  "photo": null,
+  "website": null,
+  "birth_year": null,
+  "death_year": null,
+  "city": "Los Gatos",
+  "state": "California",
+  "country": "US",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "zen"
+  ],
+  "centers": [],
+  "teachers": [
+    "taizan-maezumi"
+  ]
+}

--- a/data/teachers/av-neryah.json
+++ b/data/teachers/av-neryah.json
@@ -14,5 +14,6 @@
   "traditions": [
     "modern-non-dual"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/ayu-khandro.json
+++ b/data/teachers/ayu-khandro.json
@@ -15,5 +15,6 @@
     "vajrayana",
     "dzogchen"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/ayya-khema.json
+++ b/data/teachers/ayya-khema.json
@@ -14,5 +14,6 @@
   "traditions": [
     "theravada"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/b-alan-wallace.json
+++ b/data/teachers/b-alan-wallace.json
@@ -15,5 +15,6 @@
     "vajrayana",
     "dzogchen"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/baizhang-huaihai.json
+++ b/data/teachers/baizhang-huaihai.json
@@ -15,5 +15,6 @@
     "zen",
     "chan-buddhism"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/bassui.json
+++ b/data/teachers/bassui.json
@@ -14,5 +14,6 @@
   "traditions": [
     "zen"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/bernie-glassman.json
+++ b/data/teachers/bernie-glassman.json
@@ -16,5 +16,6 @@
   ],
   "centers": [
     "zen-peacemakers"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/bhikkhu-bodhi.json
+++ b/data/teachers/bhikkhu-bodhi.json
@@ -17,5 +17,6 @@
   ],
   "centers": [
     "chuang-yen-monastery"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/bks-iyengar.json
+++ b/data/teachers/bks-iyengar.json
@@ -14,5 +14,6 @@
   "traditions": [
     "classical-yoga"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/brother-david-steindl-rast.json
+++ b/data/teachers/brother-david-steindl-rast.json
@@ -14,5 +14,6 @@
   "traditions": [
     "christian-mysticism"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/caverly-morgan.json
+++ b/data/teachers/caverly-morgan.json
@@ -14,5 +14,6 @@
   "traditions": [
     "zen"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/chogyam-trungpa.json
+++ b/data/teachers/chogyam-trungpa.json
@@ -1,0 +1,20 @@
+{
+  "name": "Chögyam Trungpa",
+  "slug": "chogyam-trungpa",
+  "bio": "Chögyam Trungpa Rinpoche (1939–1987) was a Tibetan Buddhist master in the Kagyu and Nyingma lineages who became one of the most influential figures in bringing Vajrayana Buddhism to the West. He founded Shambhala International and Naropa University in Boulder, Colorado. His students include Pema Chödrön, Sakyong Mipham, David Nichtern, and many others who became important teachers in their own right. He developed the secular framework of Shambhala Training alongside traditional dharma teachings.",
+  "photo": null,
+  "website": null,
+  "birth_year": 1939,
+  "death_year": 1987,
+  "city": "Boulder",
+  "state": "Colorado",
+  "country": "US",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "tibetan-buddhism-kagyu",
+    "tibetan-buddhism-nyingma"
+  ],
+  "centers": [],
+  "teachers": []
+}

--- a/data/teachers/christiane-wolf.json
+++ b/data/teachers/christiane-wolf.json
@@ -17,5 +17,6 @@
   ],
   "centers": [
     "insightla"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/christopher-hareesh-wallis.json
+++ b/data/teachers/christopher-hareesh-wallis.json
@@ -15,5 +15,6 @@
     "tantra",
     "kashmir-shaivism"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/cynthia-bourgeault.json
+++ b/data/teachers/cynthia-bourgeault.json
@@ -16,5 +16,6 @@
   ],
   "centers": [
     "center-for-action-and-contemplation"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/dan-harris.json
+++ b/data/teachers/dan-harris.json
@@ -15,5 +15,6 @@
     "secular-mindfulness",
     "vipassana-movement"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/daniel-brown.json
+++ b/data/teachers/daniel-brown.json
@@ -15,5 +15,6 @@
     "vajrayana",
     "dzogchen"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/david-nichtern.json
+++ b/data/teachers/david-nichtern.json
@@ -16,5 +16,6 @@
   ],
   "centers": [
     "shambhala-mountain-center"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/diane-musho-hamilton.json
+++ b/data/teachers/diane-musho-hamilton.json
@@ -14,5 +14,6 @@
   "traditions": [
     "zen"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/dilgo-khyentse-rinpoche.json
+++ b/data/teachers/dilgo-khyentse-rinpoche.json
@@ -15,5 +15,6 @@
     "vajrayana",
     "dzogchen"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/donald-rothberg.json
+++ b/data/teachers/donald-rothberg.json
@@ -17,5 +17,6 @@
   ],
   "centers": [
     "spirit-rock"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/dudjom-rinpoche.json
+++ b/data/teachers/dudjom-rinpoche.json
@@ -15,5 +15,6 @@
     "vajrayana",
     "dzogchen"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/dzigar-kongtrul-rinpoche.json
+++ b/data/teachers/dzigar-kongtrul-rinpoche.json
@@ -17,5 +17,6 @@
   ],
   "centers": [
     "naropa-university"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/eckhart-tolle.json
+++ b/data/teachers/eckhart-tolle.json
@@ -14,5 +14,6 @@
   "traditions": [
     "modern-non-dual"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/eshwar-segobind.json
+++ b/data/teachers/eshwar-segobind.json
@@ -11,6 +11,9 @@
   "country": "US",
   "latitude": null,
   "longitude": null,
-  "traditions": ["modern-non-dual"],
-  "centers": []
+  "traditions": [
+    "modern-non-dual"
+  ],
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/father-thomas-keating.json
+++ b/data/teachers/father-thomas-keating.json
@@ -17,5 +17,6 @@
   "centers": [
     "st-benedicts-monastery-snowmass",
     "st-josephs-abbey"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/fleet-maull.json
+++ b/data/teachers/fleet-maull.json
@@ -14,5 +14,6 @@
   "traditions": [
     "zen"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/gabor-mate.json
+++ b/data/teachers/gabor-mate.json
@@ -16,5 +16,6 @@
   ],
   "centers": [
     "upaya-zen-center"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/gangaji.json
+++ b/data/teachers/gangaji.json
@@ -15,5 +15,6 @@
     "advaita-vedanta",
     "modern-non-dual"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/geoffrey-shugen-arnold.json
+++ b/data/teachers/geoffrey-shugen-arnold.json
@@ -16,5 +16,6 @@
   ],
   "centers": [
     "zen-mountain-monastery"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/george-mumford.json
+++ b/data/teachers/george-mumford.json
@@ -15,5 +15,6 @@
     "vipassana-movement",
     "secular-mindfulness"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/gil-fronsdal.json
+++ b/data/teachers/gil-fronsdal.json
@@ -11,6 +11,12 @@
   "country": "US",
   "latitude": 37.4852,
   "longitude": -122.2364,
-  "traditions": ["theravada", "zen"],
-  "centers": ["insight-meditation-center"]
+  "traditions": [
+    "theravada",
+    "zen"
+  ],
+  "centers": [
+    "insight-meditation-center"
+  ],
+  "teachers": []
 }

--- a/data/teachers/hafiz.json
+++ b/data/teachers/hafiz.json
@@ -14,5 +14,6 @@
   "traditions": [
     "sufism"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/hakuun-yasutani.json
+++ b/data/teachers/hakuun-yasutani.json
@@ -1,0 +1,19 @@
+{
+  "name": "Hakuun Yasutani",
+  "slug": "hakuun-yasutani",
+  "bio": "Hakuun Yasutani Roshi (1885–1973) was a Japanese Zen master in the Soto and Rinzai traditions. He founded the Sanbo Kyodan school, which became a major vehicle for bringing Zen practice to Western practitioners. His American students included Philip Kapleau and Taizan Maezumi, whose lineages subsequently spread throughout North America and Europe.",
+  "photo": null,
+  "website": null,
+  "birth_year": 1885,
+  "death_year": 1973,
+  "city": "",
+  "state": "",
+  "country": "JP",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "zen"
+  ],
+  "centers": [],
+  "teachers": []
+}

--- a/data/teachers/hazrat-inayat-khan.json
+++ b/data/teachers/hazrat-inayat-khan.json
@@ -14,5 +14,6 @@
   "traditions": [
     "sufism"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/hongzhi.json
+++ b/data/teachers/hongzhi.json
@@ -15,5 +15,6 @@
     "zen",
     "chan-buddhism"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/ilie-cioara.json
+++ b/data/teachers/ilie-cioara.json
@@ -14,5 +14,6 @@
   "traditions": [
     "modern-non-dual"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/jack-engler.json
+++ b/data/teachers/jack-engler.json
@@ -17,5 +17,6 @@
   ],
   "centers": [
     "insight-meditation-society"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/jack-kornfield.json
+++ b/data/teachers/jack-kornfield.json
@@ -18,5 +18,6 @@
   "centers": [
     "spirit-rock",
     "insight-meditation-society"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/james-finley.json
+++ b/data/teachers/james-finley.json
@@ -17,5 +17,6 @@
   "centers": [
     "center-for-action-and-contemplation",
     "abbey-of-gethsemani"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/jan-chozen-bays.json
+++ b/data/teachers/jan-chozen-bays.json
@@ -16,5 +16,6 @@
   ],
   "centers": [
     "great-vow-zen-monastery"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/jean-klein.json
+++ b/data/teachers/jean-klein.json
@@ -15,5 +15,6 @@
     "advaita-vedanta",
     "modern-non-dual"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/jody-hojin-kimmel.json
+++ b/data/teachers/jody-hojin-kimmel.json
@@ -16,5 +16,6 @@
   ],
   "centers": [
     "zen-mountain-monastery"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/jon-kabat-zinn.json
+++ b/data/teachers/jon-kabat-zinn.json
@@ -16,5 +16,6 @@
     "vipassana-movement",
     "zen"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/joseph-goldstein.json
+++ b/data/teachers/joseph-goldstein.json
@@ -17,5 +17,6 @@
   ],
   "centers": [
     "insight-meditation-society"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/judith-blackstone.json
+++ b/data/teachers/judith-blackstone.json
@@ -11,6 +11,12 @@
   "country": "US",
   "latitude": null,
   "longitude": null,
-  "traditions": ["modern-non-dual", "advaita-vedanta", "kashmir-shaivism", "zen"],
-  "centers": []
+  "traditions": [
+    "modern-non-dual",
+    "advaita-vedanta",
+    "kashmir-shaivism",
+    "zen"
+  ],
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/kabir-helminski.json
+++ b/data/teachers/kabir-helminski.json
@@ -14,5 +14,6 @@
   "traditions": [
     "sufism"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/kaira-jewel-lingo.json
+++ b/data/teachers/kaira-jewel-lingo.json
@@ -15,5 +15,6 @@
     "vipassana-movement",
     "zen"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/kavitha-chinnaiyan.json
+++ b/data/teachers/kavitha-chinnaiyan.json
@@ -16,5 +16,6 @@
     "kashmir-shaivism",
     "vedanta"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/kiran-trace.json
+++ b/data/teachers/kiran-trace.json
@@ -11,6 +11,9 @@
   "country": "US",
   "latitude": null,
   "longitude": null,
-  "traditions": ["modern-non-dual"],
-  "centers": []
+  "traditions": [
+    "modern-non-dual"
+  ],
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/krishna-das.json
+++ b/data/teachers/krishna-das.json
@@ -14,5 +14,6 @@
   "traditions": [
     "bhakti"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/lama-rod-owens.json
+++ b/data/teachers/lama-rod-owens.json
@@ -15,5 +15,6 @@
     "vajrayana",
     "tibetan-buddhism-kagyu"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/lama-shabkar.json
+++ b/data/teachers/lama-shabkar.json
@@ -11,6 +11,10 @@
   "country": "CN",
   "latitude": null,
   "longitude": null,
-  "traditions": ["vajrayana", "dzogchen"],
-  "centers": []
+  "traditions": [
+    "vajrayana",
+    "dzogchen"
+  ],
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/lama-surya-das.json
+++ b/data/teachers/lama-surya-das.json
@@ -11,6 +11,11 @@
   "country": "US",
   "latitude": 42.3736,
   "longitude": -71.1097,
-  "traditions": ["dzogchen"],
-  "centers": ["dzogchen-center"]
+  "traditions": [
+    "dzogchen"
+  ],
+  "centers": [
+    "dzogchen-center"
+  ],
+  "teachers": []
 }

--- a/data/teachers/lama-tsultrim-allione.json
+++ b/data/teachers/lama-tsultrim-allione.json
@@ -18,5 +18,6 @@
   ],
   "centers": [
     "tara-mandala"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/larry-rosenberg.json
+++ b/data/teachers/larry-rosenberg.json
@@ -19,5 +19,6 @@
     "cambridge-insight-meditation-center",
     "insight-meditation-society",
     "insight-meditation-center"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/llewellyn-vaughan-lee.json
+++ b/data/teachers/llewellyn-vaughan-lee.json
@@ -14,5 +14,6 @@
   "traditions": [
     "sufism"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/loch-kelly.json
+++ b/data/teachers/loch-kelly.json
@@ -15,5 +15,6 @@
     "dzogchen",
     "modern-non-dual"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/longchenpa.json
+++ b/data/teachers/longchenpa.json
@@ -15,5 +15,6 @@
     "dzogchen",
     "vajrayana"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/madeline-klyne.json
+++ b/data/teachers/madeline-klyne.json
@@ -18,5 +18,6 @@
   "centers": [
     "cambridge-insight-meditation-center",
     "insight-meditation-center"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/mahasi-sayadaw.json
+++ b/data/teachers/mahasi-sayadaw.json
@@ -1,0 +1,20 @@
+{
+  "name": "Mahasi Sayadaw",
+  "slug": "mahasi-sayadaw",
+  "bio": "Mahasi Sayadaw (1904–1982) was a Burmese Theravada monk and one of the most influential meditation teachers of the twentieth century. He systematized the Satipatthana Vipassana technique, emphasizing noting practice, and trained thousands of students at his Thathana Yeiktha center in Rangoon. Western dharma teachers including Joseph Goldstein, Sharon Salzberg, and Jack Kornfield trained in his tradition, bringing vipassana practice to the West.",
+  "photo": null,
+  "website": null,
+  "birth_year": 1904,
+  "death_year": 1982,
+  "city": "Rangoon",
+  "state": "",
+  "country": "MM",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "theravada",
+    "vipassana-movement"
+  ],
+  "centers": [],
+  "teachers": []
+}

--- a/data/teachers/matthew-fox.json
+++ b/data/teachers/matthew-fox.json
@@ -14,5 +14,6 @@
   "traditions": [
     "christian-mysticism"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/meister-eckhart.json
+++ b/data/teachers/meister-eckhart.json
@@ -14,5 +14,6 @@
   "traditions": [
     "christian-mysticism"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/michael-singer.json
+++ b/data/teachers/michael-singer.json
@@ -17,5 +17,6 @@
   ],
   "centers": [
     "temple-of-the-universe"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/michael-taft.json
+++ b/data/teachers/michael-taft.json
@@ -16,5 +16,6 @@
     "zen",
     "tantra"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/mingyur-rinpoche.json
+++ b/data/teachers/mingyur-rinpoche.json
@@ -19,5 +19,6 @@
   ],
   "centers": [
     "tergar-meditation-community"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/mirabai-starr.json
+++ b/data/teachers/mirabai-starr.json
@@ -15,5 +15,6 @@
     "christian-mysticism",
     "sufism"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/monshin-nannette-overley.json
+++ b/data/teachers/monshin-nannette-overley.json
@@ -16,5 +16,6 @@
   ],
   "centers": [
     "upaya-zen-center"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/mooji.json
+++ b/data/teachers/mooji.json
@@ -15,5 +15,6 @@
     "advaita-vedanta",
     "modern-non-dual"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/narayan-helen-liebenson.json
+++ b/data/teachers/narayan-helen-liebenson.json
@@ -19,5 +19,6 @@
     "cambridge-insight-meditation-center",
     "insight-meditation-center",
     "insight-meditation-society"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/naropa.json
+++ b/data/teachers/naropa.json
@@ -14,5 +14,6 @@
   "traditions": [
     "vajrayana"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/nisargadatta-maharaj.json
+++ b/data/teachers/nisargadatta-maharaj.json
@@ -14,5 +14,6 @@
   "traditions": [
     "advaita-vedanta"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/noah-levine.json
+++ b/data/teachers/noah-levine.json
@@ -15,5 +15,6 @@
     "theravada",
     "vipassana-movement"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/norman-fischer.json
+++ b/data/teachers/norman-fischer.json
@@ -17,5 +17,6 @@
   "centers": [
     "san-francisco-zen-center",
     "green-gulch-farm"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/oren-jay-sofer.json
+++ b/data/teachers/oren-jay-sofer.json
@@ -15,5 +15,6 @@
     "theravada",
     "vipassana-movement"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/pablo-das.json
+++ b/data/teachers/pablo-das.json
@@ -16,5 +16,6 @@
   ],
   "centers": [
     "insightla"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/padmasambhava.json
+++ b/data/teachers/padmasambhava.json
@@ -15,5 +15,6 @@
     "vajrayana",
     "dzogchen"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/patanjali.json
+++ b/data/teachers/patanjali.json
@@ -14,5 +14,6 @@
   "traditions": [
     "classical-yoga"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/patrul-rinpoche.json
+++ b/data/teachers/patrul-rinpoche.json
@@ -15,5 +15,6 @@
     "vajrayana",
     "dzogchen"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/pema-chodron.json
+++ b/data/teachers/pema-chodron.json
@@ -17,5 +17,6 @@
   ],
   "centers": [
     "gampo-abbey"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/phillip-moffitt.json
+++ b/data/teachers/phillip-moffitt.json
@@ -17,5 +17,6 @@
   ],
   "centers": [
     "spirit-rock"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/ponlop-rinpoche.json
+++ b/data/teachers/ponlop-rinpoche.json
@@ -17,5 +17,6 @@
     "tibetan-buddhism-nyingma",
     "vajrayana"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/ram-dass.json
+++ b/data/teachers/ram-dass.json
@@ -15,5 +15,6 @@
     "bhakti",
     "vedanta"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/ramana-maharshi.json
+++ b/data/teachers/ramana-maharshi.json
@@ -14,5 +14,6 @@
   "traditions": [
     "advaita-vedanta"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/ravi-shankar.json
+++ b/data/teachers/ravi-shankar.json
@@ -15,5 +15,6 @@
     "classical-yoga",
     "vedanta"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/richard-rohr.json
+++ b/data/teachers/richard-rohr.json
@@ -16,5 +16,6 @@
   ],
   "centers": [
     "center-for-action-and-contemplation"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/rob-burbea.json
+++ b/data/teachers/rob-burbea.json
@@ -1,7 +1,7 @@
 {
   "name": "Rob Burbea",
   "slug": "rob-burbea",
-  "bio": "Rob Burbea (1965\u20132020) was a meditation teacher who served as resident teacher at Gaia House in Devon, England. He was known for his innovative and deep teachings on emptiness, the imaginal, and what he called 'soulmaking dharma.' His book 'Seeing That Frees' is considered one of the most important modern works on emptiness practice. He taught widely in the Insight Meditation tradition and was a guiding teacher at Insight Meditation Society.",
+  "bio": "Rob Burbea (1965–2020) was a meditation teacher who served as resident teacher at Gaia House in Devon, England. He was known for his innovative and deep teachings on emptiness, the imaginal, and what he called 'soulmaking dharma.' His book 'Seeing That Frees' is considered one of the most important modern works on emptiness practice. He taught widely in the Insight Meditation tradition and was a guiding teacher at Insight Meditation Society.",
   "photo": null,
   "website": null,
   "birth_year": 1965,
@@ -17,5 +17,6 @@
   ],
   "centers": [
     "insight-meditation-society"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/robert-svoboda.json
+++ b/data/teachers/robert-svoboda.json
@@ -15,5 +15,6 @@
     "tantra",
     "classical-yoga"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/robert-thurman.json
+++ b/data/teachers/robert-thurman.json
@@ -17,5 +17,6 @@
   ],
   "centers": [
     "tibet-house-us"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/rodney-smith.json
+++ b/data/teachers/rodney-smith.json
@@ -18,5 +18,6 @@
   "centers": [
     "seattle-insight-meditation-society",
     "insight-meditation-society"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/rolf-gates.json
+++ b/data/teachers/rolf-gates.json
@@ -16,5 +16,6 @@
   ],
   "centers": [
     "kripalu-center"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/roshi-enkyo-ohara.json
+++ b/data/teachers/roshi-enkyo-ohara.json
@@ -16,5 +16,6 @@
   ],
   "centers": [
     "village-zendo"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/roshi-joan-halifax.json
+++ b/data/teachers/roshi-joan-halifax.json
@@ -17,5 +17,6 @@
   ],
   "centers": [
     "upaya-zen-center"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/roshi-robert-kennedy.json
+++ b/data/teachers/roshi-robert-kennedy.json
@@ -15,5 +15,6 @@
     "zen",
     "christian-mysticism"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/rumi.json
+++ b/data/teachers/rumi.json
@@ -14,5 +14,6 @@
   "traditions": [
     "sufism"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/rupert-spira.json
+++ b/data/teachers/rupert-spira.json
@@ -11,6 +11,10 @@
   "country": "UK",
   "latitude": 51.752,
   "longitude": -1.2577,
-  "traditions": ["advaita-vedanta", "modern-non-dual"],
-  "centers": []
+  "traditions": [
+    "advaita-vedanta",
+    "modern-non-dual"
+  ],
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/ryokan.json
+++ b/data/teachers/ryokan.json
@@ -14,5 +14,6 @@
   "traditions": [
     "zen"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/sadhguru.json
+++ b/data/teachers/sadhguru.json
@@ -1,7 +1,7 @@
 {
   "name": "Sadhguru",
   "slug": "sadhguru",
-  "bio": "Jaggi Vasudev, known as Sadhguru, is an Indian yogi, author, and founder of the Isha Foundation. He teaches classical yoga practices including kriya yoga, meditation, and inner engineering \u2014 a program that has reached millions worldwide. A prominent public figure, he advocates for environmental causes, particularly soil conservation, alongside his spiritual teaching. His approach draws on yogic and Shaivite traditions while emphasizing direct experience over scriptural authority.",
+  "bio": "Jaggi Vasudev, known as Sadhguru, is an Indian yogi, author, and founder of the Isha Foundation. He teaches classical yoga practices including kriya yoga, meditation, and inner engineering — a program that has reached millions worldwide. A prominent public figure, he advocates for environmental causes, particularly soil conservation, alongside his spiritual teaching. His approach draws on yogic and Shaivite traditions while emphasizing direct experience over scriptural authority.",
   "photo": null,
   "website": "https://isha.sadhguru.org",
   "birth_year": 1957,
@@ -16,5 +16,6 @@
   ],
   "centers": [
     "isha-institute-of-inner-sciences"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/sakyong-mipham.json
+++ b/data/teachers/sakyong-mipham.json
@@ -16,5 +16,6 @@
   ],
   "centers": [
     "shambhala-mountain-center"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/sally-kempton.json
+++ b/data/teachers/sally-kempton.json
@@ -11,6 +11,9 @@
   "country": "US",
   "latitude": 36.4166,
   "longitude": -121.7327,
-  "traditions": ["kashmir-shaivism"],
-  "centers": []
+  "traditions": [
+    "kashmir-shaivism"
+  ],
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/seng-tsan.json
+++ b/data/teachers/seng-tsan.json
@@ -11,6 +11,10 @@
   "country": "CN",
   "latitude": null,
   "longitude": null,
-  "traditions": ["zen", "chan-buddhism"],
-  "centers": []
+  "traditions": [
+    "zen",
+    "chan-buddhism"
+  ],
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/sharon-salzberg.json
+++ b/data/teachers/sharon-salzberg.json
@@ -17,5 +17,6 @@
   ],
   "centers": [
     "insight-meditation-society"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/shinzen-young.json
+++ b/data/teachers/shinzen-young.json
@@ -16,5 +16,6 @@
     "secular-mindfulness",
     "zen"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/shunryu-suzuki.json
+++ b/data/teachers/shunryu-suzuki.json
@@ -17,5 +17,6 @@
   "centers": [
     "san-francisco-zen-center",
     "tassajara-zen-mountain-center"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/spring-washam.json
+++ b/data/teachers/spring-washam.json
@@ -18,5 +18,6 @@
   "centers": [
     "east-bay-meditation-center",
     "spirit-rock"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/st-teresa-of-avila.json
+++ b/data/teachers/st-teresa-of-avila.json
@@ -14,5 +14,6 @@
   "traditions": [
     "christian-mysticism"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/stephen-batchelor.json
+++ b/data/teachers/stephen-batchelor.json
@@ -17,5 +17,6 @@
   ],
   "centers": [
     "barre-center-for-buddhist-studies"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/swami-sivananda.json
+++ b/data/teachers/swami-sivananda.json
@@ -15,5 +15,6 @@
     "vedanta",
     "classical-yoga"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/swami-vivekananda.json
+++ b/data/teachers/swami-vivekananda.json
@@ -15,5 +15,6 @@
     "vedanta",
     "classical-yoga"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/sylvia-boorstein.json
+++ b/data/teachers/sylvia-boorstein.json
@@ -18,5 +18,6 @@
   "centers": [
     "spirit-rock",
     "insight-meditation-society"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/t-krishnamacharya.json
+++ b/data/teachers/t-krishnamacharya.json
@@ -14,5 +14,6 @@
   "traditions": [
     "classical-yoga"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/taizan-maezumi.json
+++ b/data/teachers/taizan-maezumi.json
@@ -1,0 +1,21 @@
+{
+  "name": "Taizan Maezumi",
+  "slug": "taizan-maezumi",
+  "bio": "Taizan Maezumi Roshi (1931–1995) was a Japanese Zen master who became one of the most influential figures in bringing Zen to the West. He founded the Zen Center of Los Angeles and transmitted the dharma to twelve successors, including Bernie Glassman and Jan Chozen Bays. He held transmission in three Zen lineages: Soto, Rinzai, and Sanbo Kyodan. His students went on to found numerous Zen centers across North America and Europe.",
+  "photo": null,
+  "website": null,
+  "birth_year": 1931,
+  "death_year": 1995,
+  "city": "Los Angeles",
+  "state": "California",
+  "country": "US",
+  "latitude": null,
+  "longitude": null,
+  "traditions": [
+    "zen"
+  ],
+  "centers": [],
+  "teachers": [
+    "hakuun-yasutani"
+  ]
+}

--- a/data/teachers/tara-brach.json
+++ b/data/teachers/tara-brach.json
@@ -17,5 +17,6 @@
   ],
   "centers": [
     "insight-meditation-community-of-washington"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/tenshin-reb-anderson.json
+++ b/data/teachers/tenshin-reb-anderson.json
@@ -16,5 +16,6 @@
   ],
   "centers": [
     "san-francisco-zen-center"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/tenzin-wangyal-rinpoche.json
+++ b/data/teachers/tenzin-wangyal-rinpoche.json
@@ -17,5 +17,6 @@
   ],
   "centers": [
     "ligmincha-international"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/thich-nhat-hanh.json
+++ b/data/teachers/thich-nhat-hanh.json
@@ -19,5 +19,6 @@
     "deer-park-monastery",
     "blue-cliff-monastery",
     "magnolia-grove-monastery"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/thomas-hubl.json
+++ b/data/teachers/thomas-hubl.json
@@ -14,5 +14,6 @@
   "traditions": [
     "secular-mindfulness"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/tilopa.json
+++ b/data/teachers/tilopa.json
@@ -14,5 +14,6 @@
   "traditions": [
     "vajrayana"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/tina-rasmussen.json
+++ b/data/teachers/tina-rasmussen.json
@@ -11,6 +11,13 @@
   "country": "US",
   "latitude": null,
   "longitude": null,
-  "traditions": ["theravada", "vipassana-movement", "dzogchen"],
-  "centers": ["spirit-rock"]
+  "traditions": [
+    "theravada",
+    "vipassana-movement",
+    "dzogchen"
+  ],
+  "centers": [
+    "spirit-rock"
+  ],
+  "teachers": []
 }

--- a/data/teachers/trudy-goodman.json
+++ b/data/teachers/trudy-goodman.json
@@ -18,5 +18,6 @@
   "centers": [
     "insightla",
     "insight-meditation-society"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/tsoknyi-rinpoche.json
+++ b/data/teachers/tsoknyi-rinpoche.json
@@ -17,5 +17,6 @@
     "tibetan-buddhism-nyingma",
     "vajrayana"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/tsultrim-allione.json
+++ b/data/teachers/tsultrim-allione.json
@@ -16,5 +16,6 @@
   ],
   "centers": [
     "tara-mandala"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/tsultrim-gyamtso-rinpoche.json
+++ b/data/teachers/tsultrim-gyamtso-rinpoche.json
@@ -15,5 +15,6 @@
     "tibetan-buddhism-kagyu",
     "vajrayana"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/tuere-sala.json
+++ b/data/teachers/tuere-sala.json
@@ -20,5 +20,6 @@
     "cambridge-insight-meditation-center",
     "insight-meditation-center",
     "insight-meditation-society"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/tulku-urgyen-rinpoche.json
+++ b/data/teachers/tulku-urgyen-rinpoche.json
@@ -15,5 +15,6 @@
     "vajrayana",
     "dzogchen"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/victoria-cary.json
+++ b/data/teachers/victoria-cary.json
@@ -18,5 +18,6 @@
   "centers": [
     "spirit-rock",
     "insight-meditation-society"
-  ]
+  ],
+  "teachers": []
 }

--- a/data/teachers/wes-nisker.json
+++ b/data/teachers/wes-nisker.json
@@ -16,5 +16,6 @@
     "theravada",
     "vipassana-movement"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/data/teachers/zenju-earthlyn-manuel.json
+++ b/data/teachers/zenju-earthlyn-manuel.json
@@ -14,5 +14,6 @@
   "traditions": [
     "zen"
   ],
-  "centers": []
+  "centers": [],
+  "teachers": []
 }

--- a/scripts/lib/generate-teacher.ts
+++ b/scripts/lib/generate-teacher.ts
@@ -35,5 +35,6 @@ export function generateTeacherJson(candidate: AcceptedCandidate): Teacher {
     longitude: null,
     traditions: candidate.traditions,
     centers: [],
+    teachers: [],
   };
 }

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -40,6 +40,7 @@ export interface Teacher {
   longitude: number | null;
   traditions: string[];
   centers: string[];
+  teachers: string[];
 }
 
 export type ResourceType = "book" | "podcast" | "video" | "article" | "website";


### PR DESCRIPTION
## Summary

- Adds `teachers: string[]` to the `Teacher` interface — slugs of teachers this person studied under
- Backfills all 137 existing teacher JSON files with `teachers: []`
- Adds 6 stub entries for key historical lineage figures: Taizan Maezumi, Hakuun Yasutani, Arvis Joen Justi, Mahasi Sayadaw, Ajahn Mun, Chögyam Trungpa
- Fixes `generate-teacher.ts` script to include the new field

Closes #266

## Test plan
- [x] TypeScript compiles
- [x] Static build passes (1485 pages)
- [x] All existing teacher files still valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)