### PR TITLE
content: backfill teacher-to-teacher relationships (#267)

### DIFF
--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,8 +1,8 @@
 {
-  "generated_at": "2026-04-24T08:22:00.985Z",
+  "generated_at": "2026-04-24T08:21:23.589Z",
   "counts": {
-    "traditions": 30,
-    "teachers": 142,
+    "traditions": 29,
+    "teachers": 149,
     "centers": 80,
     "resources": 1156,
     "paths": 11
@@ -74,41 +74,6 @@
       "connected_traditions": [
         "advaita-vedanta",
         "sufism"
-      ]
-    },
-    {
-      "slug": "bon",
-      "name": "Bön",
-      "family": "Buddhist",
-      "alternate_names": [
-        "Yungdrung Bön",
-        "Eternal Bön",
-        "Bon"
-      ],
-      "key_figures": [
-        "Tönpa Shenrab Miwoche (legendary founder)",
-        "Drenpa Namkha (8th c.)",
-        "Shardza Tashi Gyaltsen (1859–1934)",
-        "Lopon Tenzin Namdak (b. 1926)",
-        "Tenzin Wangyal Rinpoche (b. 1961)"
-      ],
-      "key_texts": [
-        "Zhang Zhung Nyengyud (Oral Transmission of Zhang Zhung)",
-        "Ziji (The Glorious)",
-        "Mother Tantra (Ma Gyud)"
-      ],
-      "related_practices": [
-        "Bön Dzogchen",
-        "Chöd (cutting through fear and attachment)",
-        "tsa lung (channels and winds)",
-        "dream yoga and sleep yoga",
-        "sound healing (five warrior syllables)"
-      ],
-      "connected_traditions": [
-        "dzogchen",
-        "tibetan-buddhism-nyingma",
-        "vajrayana",
-        "tibetan-buddhism-kagyu"
       ]
     },
     {
@@ -233,8 +198,7 @@
         "tantra",
         "tibetan-buddhism-nyingma",
         "tibetan-buddhism-kagyu",
-        "tibetan-buddhism-gelug",
-        "bon"
+        "tibetan-buddhism-gelug"
       ]
     },
     {
@@ -740,7 +704,6 @@
         "Naropa (1016–1100)",
         "Marpa (1012–1097)",
         "Milarepa (1052–1135)",
-        "Machig Labdrön (1055–1149)",
         "Gampopa (1079–1153)",
         "First Karmapa, Düsum Khyenpa (1110–1193)"
       ],
@@ -752,7 +715,6 @@
       "related_practices": [
         "Mahamudra",
         "Six Yogas of Naropa (tummo, illusory body, dream yoga, clear light, bardo, phowa)",
-        "Chöd (cutting through ego-clinging)",
         "guru yoga",
         "ngöndro (preliminary practices)"
       ],
@@ -789,7 +751,6 @@
       ],
       "related_practices": [
         "Dzogchen (trekchö and tögal)",
-        "Chöd (cutting through ego-clinging)",
         "deity yoga",
         "terma (treasure-teaching) revelation",
         "ngöndro (preliminary practices)",
@@ -801,8 +762,7 @@
         "dzogchen",
         "tibetan-buddhism-kagyu",
         "tibetan-buddhism-gelug",
-        "tantra",
-        "bon"
+        "tantra"
       ]
     },
     {
@@ -1020,6 +980,17 @@
       ],
       "living": true,
       "location": "Hemel Hempstead, England, UK"
+    },
+    {
+      "slug": "anagarika-munindra",
+      "name": "Anagarika Munindra",
+      "traditions": [
+        "theravada",
+        "vipassana-movement"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "IN"
     },
     {
       "slug": "anam-thubten",
@@ -1410,6 +1381,16 @@
       "location": ""
     },
     {
+      "slug": "francis-lucille",
+      "name": "Francis Lucille",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "centers": [],
+      "living": true,
+      "location": "FR"
+    },
+    {
       "slug": "gabor-mate",
       "name": "Gabor Maté",
       "traditions": [
@@ -1487,6 +1468,16 @@
       "centers": [],
       "living": false,
       "location": "JP"
+    },
+    {
+      "slug": "hariwansh-poonja",
+      "name": "H.W.L. Poonja (Papaji)",
+      "traditions": [
+        "advaita-vedanta"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "IN"
     },
     {
       "slug": "hazrat-inayat-khan",
@@ -1593,6 +1584,16 @@
       ],
       "living": true,
       "location": "Mt Tremper, New York, US"
+    },
+    {
+      "slug": "john-daido-loori",
+      "name": "John Daido Loori",
+      "traditions": [
+        "zen"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Mt. Tremper, New York, US"
     },
     {
       "slug": "jon-kabat-zinn",
@@ -1718,6 +1719,20 @@
       ],
       "living": true,
       "location": "Cambridge, Massachusetts, US"
+    },
+    {
+      "slug": "lama-tsultrim-allione",
+      "name": "Lama Tsultrim Allione",
+      "traditions": [
+        "tibetan-buddhism-nyingma",
+        "tibetan-buddhism-kagyu",
+        "vajrayana"
+      ],
+      "centers": [
+        "tara-mandala"
+      ],
+      "living": true,
+      "location": ""
     },
     {
       "slug": "larry-rosenberg",
@@ -2048,6 +2063,16 @@
       "centers": [],
       "living": false,
       "location": "Maui, Hawaii, US"
+    },
+    {
+      "slug": "ramakrishna",
+      "name": "Ramakrishna",
+      "traditions": [
+        "vedanta"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "IN"
     },
     {
       "slug": "ramana-maharshi",
@@ -2417,7 +2442,6 @@
       "slug": "tenzin-wangyal-rinpoche",
       "name": "Tenzin Wangyal Rinpoche",
       "traditions": [
-        "bon",
         "dzogchen",
         "vajrayana"
       ],
@@ -2451,6 +2475,16 @@
       "centers": [],
       "living": true,
       "location": ""
+    },
+    {
+      "slug": "thomas-merton",
+      "name": "Thomas Merton",
+      "traditions": [
+        "christian-mysticism"
+      ],
+      "centers": [],
+      "living": false,
+      "location": "Bardstown, Kentucky, US"
     },
     {
       "slug": "tilopa",
@@ -2507,8 +2541,6 @@
       "slug": "tsultrim-allione",
       "name": "Tsultrim Allione",
       "traditions": [
-        "tibetan-buddhism-nyingma",
-        "tibetan-buddhism-kagyu",
         "vajrayana"
       ],
       "centers": [
@@ -3671,7 +3703,7 @@
         "vajrayana"
       ],
       "teachers": [
-        "tsultrim-allione"
+        "lama-tsultrim-allione"
       ]
     },
     {

--- a/data/teachers/adyashanti.json
+++ b/data/teachers/adyashanti.json
@@ -17,5 +17,7 @@
     "advaita-vedanta"
   ],
   "centers": [],
-  "teachers": []
+  "teachers": [
+    "arvis-joen-justi"
+  ]
 }

--- a/data/teachers/ajahn-chah.json
+++ b/data/teachers/ajahn-chah.json
@@ -15,5 +15,7 @@
     "theravada"
   ],
   "centers": [],
-  "teachers": []
+  "teachers": [
+    "ajahn-mun"
+  ]
 }

--- a/data/teachers/ajahn-lee.json
+++ b/data/teachers/ajahn-lee.json
@@ -15,5 +15,7 @@
     "theravada"
   ],
   "centers": [],
-  "teachers": []
+  "teachers": [
+    "ajahn-mun"
+  ]
 }

--- a/data/teachers/ajahn-pasanno.json
+++ b/data/teachers/ajahn-pasanno.json
@@ -17,5 +17,7 @@
   "centers": [
     "abhayagiri-buddhist-monastery"
   ],
-  "teachers": []
+  "teachers": [
+    "ajahn-chah"
+  ]
 }

--- a/data/teachers/ajahn-sumedho.json
+++ b/data/teachers/ajahn-sumedho.json
@@ -17,5 +17,7 @@
   "centers": [
     "abhayagiri-buddhist-monastery"
   ],
-  "teachers": []
+  "teachers": [
+    "ajahn-chah"
+  ]
 }

--- a/data/teachers/anagarika-munindra.json
+++ b/data/teachers/anagarika-munindra.json
@@ -1,0 +1,22 @@
+{
+  "photo": null,
+  "website": null,
+  "city": "",
+  "state": "",
+  "latitude": null,
+  "longitude": null,
+  "centers": [],
+  "slug": "anagarika-munindra",
+  "name": "Anagarika Munindra",
+  "bio": "Anagarika Munindra (1915–2003) was a Bengali lay Buddhist teacher who studied in Burma under Mahasi Sayadaw and became one of the principal transmitters of vipassana meditation to the West. Teaching at the Bodh Gaya Meditation Center in India, he taught Joseph Goldstein, Sharon Salzberg, Larry Rosenberg, and many other Western practitioners who went on to found the Insight Meditation Society and spread Theravada practice in America.",
+  "birth_year": 1915,
+  "death_year": 2003,
+  "country": "IN",
+  "traditions": [
+    "theravada",
+    "vipassana-movement"
+  ],
+  "teachers": [
+    "mahasi-sayadaw"
+  ]
+}

--- a/data/teachers/anna-douglas.json
+++ b/data/teachers/anna-douglas.json
@@ -19,5 +19,8 @@
   "centers": [
     "spirit-rock"
   ],
-  "teachers": []
+  "teachers": [
+    "joseph-goldstein",
+    "jack-kornfield"
+  ]
 }

--- a/data/teachers/annamalai-swami.json
+++ b/data/teachers/annamalai-swami.json
@@ -15,5 +15,7 @@
     "advaita-vedanta"
   ],
   "centers": [],
-  "teachers": []
+  "teachers": [
+    "ramana-maharshi"
+  ]
 }

--- a/data/teachers/bernie-glassman.json
+++ b/data/teachers/bernie-glassman.json
@@ -17,5 +17,7 @@
   "centers": [
     "zen-peacemakers"
   ],
-  "teachers": []
+  "teachers": [
+    "taizan-maezumi"
+  ]
 }

--- a/data/teachers/bks-iyengar.json
+++ b/data/teachers/bks-iyengar.json
@@ -15,5 +15,7 @@
     "classical-yoga"
   ],
   "centers": [],
-  "teachers": []
+  "teachers": [
+    "t-krishnamacharya"
+  ]
 }

--- a/data/teachers/david-nichtern.json
+++ b/data/teachers/david-nichtern.json
@@ -17,5 +17,7 @@
   "centers": [
     "shambhala-mountain-center"
   ],
-  "teachers": []
+  "teachers": [
+    "chogyam-trungpa"
+  ]
 }

--- a/data/teachers/donald-rothberg.json
+++ b/data/teachers/donald-rothberg.json
@@ -18,5 +18,8 @@
   "centers": [
     "spirit-rock"
   ],
-  "teachers": []
+  "teachers": [
+    "joseph-goldstein",
+    "jack-kornfield"
+  ]
 }

--- a/data/teachers/dzigar-kongtrul-rinpoche.json
+++ b/data/teachers/dzigar-kongtrul-rinpoche.json
@@ -18,5 +18,7 @@
   "centers": [
     "naropa-university"
   ],
-  "teachers": []
+  "teachers": [
+    "dilgo-khyentse-rinpoche"
+  ]
 }

--- a/data/teachers/fleet-maull.json
+++ b/data/teachers/fleet-maull.json
@@ -15,5 +15,7 @@
     "zen"
   ],
   "centers": [],
-  "teachers": []
+  "teachers": [
+    "bernie-glassman"
+  ]
 }

--- a/data/teachers/francis-lucille.json
+++ b/data/teachers/francis-lucille.json
@@ -1,0 +1,21 @@
+{
+  "photo": null,
+  "website": null,
+  "city": "",
+  "state": "",
+  "latitude": null,
+  "longitude": null,
+  "centers": [],
+  "slug": "francis-lucille",
+  "name": "Francis Lucille",
+  "bio": "Francis Lucille is a French spiritual teacher of Advaita Vedanta who studied with Jean Klein for many years before beginning to teach in his own right. He is primarily known as the teacher of Rupert Spira, to whom he transmitted the Direct Path approach. He teaches and gives retreats internationally, emphasizing the recognition of awareness as one's true nature.",
+  "birth_year": null,
+  "death_year": null,
+  "country": "FR",
+  "traditions": [
+    "advaita-vedanta"
+  ],
+  "teachers": [
+    "jean-klein"
+  ]
+}

--- a/data/teachers/gangaji.json
+++ b/data/teachers/gangaji.json
@@ -16,5 +16,7 @@
     "modern-non-dual"
   ],
   "centers": [],
-  "teachers": []
+  "teachers": [
+    "hariwansh-poonja"
+  ]
 }

--- a/data/teachers/geoffrey-shugen-arnold.json
+++ b/data/teachers/geoffrey-shugen-arnold.json
@@ -17,5 +17,7 @@
   "centers": [
     "zen-mountain-monastery"
   ],
-  "teachers": []
+  "teachers": [
+    "john-daido-loori"
+  ]
 }

--- a/data/teachers/george-mumford.json
+++ b/data/teachers/george-mumford.json
@@ -16,5 +16,8 @@
     "secular-mindfulness"
   ],
   "centers": [],
-  "teachers": []
+  "teachers": [
+    "jon-kabat-zinn",
+    "sharon-salzberg"
+  ]
 }

--- a/data/teachers/hariwansh-poonja.json
+++ b/data/teachers/hariwansh-poonja.json
@@ -1,0 +1,21 @@
+{
+  "photo": null,
+  "website": null,
+  "city": "",
+  "state": "",
+  "latitude": null,
+  "longitude": null,
+  "centers": [],
+  "slug": "hariwansh-poonja",
+  "name": "H.W.L. Poonja (Papaji)",
+  "bio": "Hariwansh Lal Poonja (1910–1997), universally known as Papaji, was a direct disciple of Ramana Maharshi and one of the most influential Advaita Vedanta teachers of the twentieth century. He lived in Lucknow, India, and gave satsang to thousands of Western seekers, many of whom had permanent awakenings in his presence. Among his students who went on to teach are Gangaji and Mooji.",
+  "birth_year": 1910,
+  "death_year": 1997,
+  "country": "IN",
+  "traditions": [
+    "advaita-vedanta"
+  ],
+  "teachers": [
+    "ramana-maharshi"
+  ]
+}

--- a/data/teachers/jack-kornfield.json
+++ b/data/teachers/jack-kornfield.json
@@ -19,5 +19,8 @@
     "spirit-rock",
     "insight-meditation-society"
   ],
-  "teachers": []
+  "teachers": [
+    "ajahn-chah",
+    "mahasi-sayadaw"
+  ]
 }

--- a/data/teachers/james-finley.json
+++ b/data/teachers/james-finley.json
@@ -18,5 +18,7 @@
     "center-for-action-and-contemplation",
     "abbey-of-gethsemani"
   ],
-  "teachers": []
+  "teachers": [
+    "thomas-merton"
+  ]
 }

--- a/data/teachers/jan-chozen-bays.json
+++ b/data/teachers/jan-chozen-bays.json
@@ -17,5 +17,7 @@
   "centers": [
     "great-vow-zen-monastery"
   ],
-  "teachers": []
+  "teachers": [
+    "taizan-maezumi"
+  ]
 }

--- a/data/teachers/john-daido-loori.json
+++ b/data/teachers/john-daido-loori.json
@@ -1,0 +1,21 @@
+{
+  "photo": null,
+  "website": null,
+  "city": "Mt. Tremper",
+  "state": "New York",
+  "latitude": null,
+  "longitude": null,
+  "centers": [],
+  "slug": "john-daido-loori",
+  "name": "John Daido Loori",
+  "bio": "John Daido Loori (1931–2009) was an American Zen master who founded the Mountains and Rivers Order and Zen Mountain Monastery in Mount Tremper, New York. He received dharma transmission from Taizan Maezumi Roshi and later independently from Soen Nakagawa Roshi. A photographer and artist, he integrated Zen aesthetics and arts practice into his teaching. He transmitted the dharma to Geoffrey Shugen Arnold, who succeeded him as abbot.",
+  "birth_year": 1931,
+  "death_year": 2009,
+  "country": "US",
+  "traditions": [
+    "zen"
+  ],
+  "teachers": [
+    "taizan-maezumi"
+  ]
+}

--- a/data/teachers/joseph-goldstein.json
+++ b/data/teachers/joseph-goldstein.json
@@ -18,5 +18,8 @@
   "centers": [
     "insight-meditation-society"
   ],
-  "teachers": []
+  "teachers": [
+    "anagarika-munindra",
+    "mahasi-sayadaw"
+  ]
 }

--- a/data/teachers/kaira-jewel-lingo.json
+++ b/data/teachers/kaira-jewel-lingo.json
@@ -16,5 +16,7 @@
     "zen"
   ],
   "centers": [],
-  "teachers": []
+  "teachers": [
+    "thich-nhat-hanh"
+  ]
 }

--- a/data/teachers/loch-kelly.json
+++ b/data/teachers/loch-kelly.json
@@ -16,5 +16,8 @@
     "modern-non-dual"
   ],
   "centers": [],
-  "teachers": []
+  "teachers": [
+    "mingyur-rinpoche",
+    "adyashanti"
+  ]
 }

--- a/data/teachers/mingyur-rinpoche.json
+++ b/data/teachers/mingyur-rinpoche.json
@@ -20,5 +20,7 @@
   "centers": [
     "tergar-meditation-community"
   ],
-  "teachers": []
+  "teachers": [
+    "tulku-urgyen-rinpoche"
+  ]
 }

--- a/data/teachers/monshin-nannette-overley.json
+++ b/data/teachers/monshin-nannette-overley.json
@@ -17,5 +17,7 @@
   "centers": [
     "upaya-zen-center"
   ],
-  "teachers": []
+  "teachers": [
+    "roshi-joan-halifax"
+  ]
 }

--- a/data/teachers/mooji.json
+++ b/data/teachers/mooji.json
@@ -16,5 +16,7 @@
     "modern-non-dual"
   ],
   "centers": [],
-  "teachers": []
+  "teachers": [
+    "hariwansh-poonja"
+  ]
 }

--- a/data/teachers/naropa.json
+++ b/data/teachers/naropa.json
@@ -15,5 +15,7 @@
     "vajrayana"
   ],
   "centers": [],
-  "teachers": []
+  "teachers": [
+    "tilopa"
+  ]
 }

--- a/data/teachers/norman-fischer.json
+++ b/data/teachers/norman-fischer.json
@@ -18,5 +18,7 @@
     "san-francisco-zen-center",
     "green-gulch-farm"
   ],
-  "teachers": []
+  "teachers": [
+    "shunryu-suzuki"
+  ]
 }

--- a/data/teachers/pablo-das.json
+++ b/data/teachers/pablo-das.json
@@ -17,5 +17,8 @@
   "centers": [
     "insightla"
   ],
-  "teachers": []
+  "teachers": [
+    "jack-kornfield",
+    "trudy-goodman"
+  ]
 }

--- a/data/teachers/pema-chodron.json
+++ b/data/teachers/pema-chodron.json
@@ -18,5 +18,8 @@
   "centers": [
     "gampo-abbey"
   ],
-  "teachers": []
+  "teachers": [
+    "chogyam-trungpa",
+    "dzigar-kongtrul-rinpoche"
+  ]
 }

--- a/data/teachers/ramakrishna.json
+++ b/data/teachers/ramakrishna.json
@@ -1,0 +1,19 @@
+{
+  "photo": null,
+  "website": null,
+  "city": "",
+  "state": "",
+  "latitude": null,
+  "longitude": null,
+  "centers": [],
+  "slug": "ramakrishna",
+  "name": "Ramakrishna",
+  "bio": "Ramakrishna Paramahamsa (1836–1886) was a Bengali Hindu mystic and saint whose direct experience of the divine across multiple traditions — Vaishnavism, Tantra, Islam, and Christianity — made him one of the seminal religious figures of modern India. He was a priest at the Dakshineswar Kali temple near Calcutta. His chief disciple, Swami Vivekananda, carried his teachings to the West and founded the Ramakrishna Mission.",
+  "birth_year": 1836,
+  "death_year": 1886,
+  "country": "IN",
+  "traditions": [
+    "vedanta"
+  ],
+  "teachers": []
+}

--- a/data/teachers/roshi-enkyo-ohara.json
+++ b/data/teachers/roshi-enkyo-ohara.json
@@ -17,5 +17,7 @@
   "centers": [
     "village-zendo"
   ],
-  "teachers": []
+  "teachers": [
+    "bernie-glassman"
+  ]
 }

--- a/data/teachers/roshi-joan-halifax.json
+++ b/data/teachers/roshi-joan-halifax.json
@@ -18,5 +18,7 @@
   "centers": [
     "upaya-zen-center"
   ],
-  "teachers": []
+  "teachers": [
+    "bernie-glassman"
+  ]
 }

--- a/data/teachers/roshi-robert-kennedy.json
+++ b/data/teachers/roshi-robert-kennedy.json
@@ -16,5 +16,7 @@
     "christian-mysticism"
   ],
   "centers": [],
-  "teachers": []
+  "teachers": [
+    "taizan-maezumi"
+  ]
 }

--- a/data/teachers/rupert-spira.json
+++ b/data/teachers/rupert-spira.json
@@ -16,5 +16,7 @@
     "modern-non-dual"
   ],
   "centers": [],
-  "teachers": []
+  "teachers": [
+    "francis-lucille"
+  ]
 }

--- a/data/teachers/sakyong-mipham.json
+++ b/data/teachers/sakyong-mipham.json
@@ -17,5 +17,7 @@
   "centers": [
     "shambhala-mountain-center"
   ],
-  "teachers": []
+  "teachers": [
+    "chogyam-trungpa"
+  ]
 }

--- a/data/teachers/sharon-salzberg.json
+++ b/data/teachers/sharon-salzberg.json
@@ -18,5 +18,8 @@
   "centers": [
     "insight-meditation-society"
   ],
-  "teachers": []
+  "teachers": [
+    "anagarika-munindra",
+    "mahasi-sayadaw"
+  ]
 }

--- a/data/teachers/spring-washam.json
+++ b/data/teachers/spring-washam.json
@@ -19,5 +19,7 @@
     "east-bay-meditation-center",
     "spirit-rock"
   ],
-  "teachers": []
+  "teachers": [
+    "jack-kornfield"
+  ]
 }

--- a/data/teachers/swami-vivekananda.json
+++ b/data/teachers/swami-vivekananda.json
@@ -16,5 +16,7 @@
     "classical-yoga"
   ],
   "centers": [],
-  "teachers": []
+  "teachers": [
+    "ramakrishna"
+  ]
 }

--- a/data/teachers/sylvia-boorstein.json
+++ b/data/teachers/sylvia-boorstein.json
@@ -19,5 +19,8 @@
     "spirit-rock",
     "insight-meditation-society"
   ],
-  "teachers": []
+  "teachers": [
+    "jack-kornfield",
+    "joseph-goldstein"
+  ]
 }

--- a/data/teachers/tara-brach.json
+++ b/data/teachers/tara-brach.json
@@ -18,5 +18,7 @@
   "centers": [
     "insight-meditation-community-of-washington"
   ],
-  "teachers": []
+  "teachers": [
+    "jack-kornfield"
+  ]
 }

--- a/data/teachers/tenshin-reb-anderson.json
+++ b/data/teachers/tenshin-reb-anderson.json
@@ -17,5 +17,7 @@
   "centers": [
     "san-francisco-zen-center"
   ],
-  "teachers": []
+  "teachers": [
+    "shunryu-suzuki"
+  ]
 }

--- a/data/teachers/thomas-merton.json
+++ b/data/teachers/thomas-merton.json
@@ -1,0 +1,19 @@
+{
+  "photo": null,
+  "website": null,
+  "city": "Bardstown",
+  "state": "Kentucky",
+  "latitude": null,
+  "longitude": null,
+  "centers": [],
+  "slug": "thomas-merton",
+  "name": "Thomas Merton",
+  "bio": "Thomas Merton (1915–1968) was an American Trappist monk, theologian, and writer at the Abbey of Gethsemani in Kentucky. One of the most influential Catholic writers of the twentieth century, his books — including 'The Seven Storey Mountain,' 'New Seeds of Contemplation,' and 'Zen and the Birds of Appetite' — introduced contemplative Christianity to millions. He engaged seriously with Zen, Taoism, and Tibetan Buddhism, pioneering Christian-Buddhist dialogue.",
+  "birth_year": 1915,
+  "death_year": 1968,
+  "country": "US",
+  "traditions": [
+    "christian-mysticism"
+  ],
+  "teachers": []
+}

--- a/data/teachers/trudy-goodman.json
+++ b/data/teachers/trudy-goodman.json
@@ -19,5 +19,8 @@
     "insightla",
     "insight-meditation-society"
   ],
-  "teachers": []
+  "teachers": [
+    "joseph-goldstein",
+    "jack-kornfield"
+  ]
 }

--- a/data/teachers/tsoknyi-rinpoche.json
+++ b/data/teachers/tsoknyi-rinpoche.json
@@ -18,5 +18,7 @@
     "vajrayana"
   ],
   "centers": [],
-  "teachers": []
+  "teachers": [
+    "tulku-urgyen-rinpoche"
+  ]
 }


### PR DESCRIPTION
Backfills `teachers[]` arrays for 47 teachers across all lineages. Adds 6 stubs: H.W.L. Poonja, John Daido Loori, Anagarika Munindra, Ramakrishna, Thomas Merton, Francis Lucille.

Closes #267

🤖 Generated with [Claude Code](https://claude.com/claude-code)