### PR TITLE
feat: show lineage sections on teacher profile pages (#268)

### DIFF
--- a/data/manifest.json
+++ b/data/manifest.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-04-24T08:21:23.589Z",
+  "generated_at": "2026-04-24T08:22:52.269Z",
   "counts": {
     "traditions": 29,
     "teachers": 149,

--- a/src/app/teachers/[slug]/page.tsx
+++ b/src/app/teachers/[slug]/page.tsx
@@ -7,8 +7,9 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { JsonLd } from "@/components/json-ld";
 import { ResourceList } from "@/components/resource-list";
-import { getAllTeachers, getTeacher, getCenter, getTradition, getResourcesByTeacher } from "@/lib/data";
+import { getAllTeachers, getTeacher, getCenter, getTradition, getResourcesByTeacher, getStudentsOf } from "@/lib/data";
 import { teacherJsonLd, SITE_URL } from "@/lib/seo";
+import { TeacherLineageCard } from "@/components/teacher-lineage-card";
 import type { Teacher } from "@/lib/types";
 
 function formatYears(teacher: Teacher): string | null {
@@ -54,6 +55,10 @@ export default async function TeacherPage({ params }: { params: Promise<{ slug: 
   const centers = teacher.centers
     .map((s) => getCenter(s))
     .filter((c): c is NonNullable<typeof c> => c != null);
+  const studiedUnder = (teacher.teachers ?? [])
+    .map((s) => getTeacher(s))
+    .filter((t): t is NonNullable<typeof t> => t != null);
+  const students = getStudentsOf(slug);
 
   return (
     <PageLayout>
@@ -119,6 +124,29 @@ export default async function TeacherPage({ params }: { params: Promise<{ slug: 
           <h2 className="mb-4">About</h2>
           <p className="leading-relaxed text-secondary-foreground">{teacher.bio}</p>
         </section>
+
+        {/* Lineage */}
+        {studiedUnder.length > 0 && (
+          <section className="mb-12">
+            <h2 className="mb-4">Studied under</h2>
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {studiedUnder.map((t) => (
+                <TeacherLineageCard key={t.slug} teacher={t} />
+              ))}
+            </div>
+          </section>
+        )}
+
+        {students.length > 0 && (
+          <section className="mb-12">
+            <h2 className="mb-4">Students</h2>
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {students.map((t) => (
+                <TeacherLineageCard key={t.slug} teacher={t} />
+              ))}
+            </div>
+          </section>
+        )}
 
         {/* Resources */}
         <ResourceList resources={resources} />

--- a/src/components/teacher-lineage-card.tsx
+++ b/src/components/teacher-lineage-card.tsx
@@ -1,0 +1,41 @@
+import Image from "next/image";
+import Link from "next/link";
+import type { Teacher } from "@/lib/types";
+
+interface Props {
+  teacher: Teacher;
+}
+
+export function TeacherLineageCard({ teacher }: Props) {
+  const tradition = teacher.traditions[0] ?? null;
+  return (
+    <Link
+      href={`/teachers/${teacher.slug}`}
+      className="group flex items-center gap-3 rounded-lg border border-border bg-card p-3 hover:bg-accent/50 transition-colors"
+    >
+      {teacher.photo ? (
+        <Image
+          src={teacher.photo}
+          alt={teacher.name}
+          width={48}
+          height={48}
+          className="rounded-md object-cover w-12 h-12 shrink-0"
+        />
+      ) : (
+        <div className="w-12 h-12 rounded-md bg-muted shrink-0 flex items-center justify-center text-muted-foreground font-serif text-lg">
+          {teacher.name[0]}
+        </div>
+      )}
+      <div className="min-w-0">
+        <p className="font-serif font-medium text-sm group-hover:text-primary transition-colors truncate">
+          {teacher.name}
+        </p>
+        {tradition && (
+          <p className="font-sans text-xs text-muted-foreground capitalize truncate">
+            {tradition.replace(/-/g, " ")}
+          </p>
+        )}
+      </div>
+    </Link>
+  );
+}

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -280,6 +280,10 @@ export function getPathBySlug(slug: string): ResolvedPath | undefined {
 
 // -- Cross-reference queries --
 
+export function getStudentsOf(teacherSlug: string): Teacher[] {
+  return getAllTeachers().filter((t) => t.teachers.includes(teacherSlug));
+}
+
 export function getTeachersByTradition(traditionSlug: string): Teacher[] {
   return getAllTeachers().filter((t) => t.traditions.includes(traditionSlug));
 }


### PR DESCRIPTION
Adds "Studied under" and "Students" sections to teacher profiles. New `TeacherLineageCard` component and `getStudentsOf()` reverse-lookup helper.

Closes #268

🤖 Generated with [Claude Code](https://claude.com/claude-code)