### PR TITLE
feat: contextual suggest-a-resource form on teacher and tradition pages (#279)

### DIFF
--- a/src/app/teachers/[slug]/page.tsx
+++ b/src/app/teachers/[slug]/page.tsx
@@ -7,6 +7,7 @@ import { Badge } from "@/components/ui/badge";
 import { Card, CardHeader, CardTitle, CardDescription } from "@/components/ui/card";
 import { JsonLd } from "@/components/json-ld";
 import { TeachingsList } from "@/components/teachings-list";
+import { SuggestResourceForm } from "@/components/suggest-resource-form";
 import { getAllTeachers, getTeacher, getCenter, getTradition, getResourcesByTeacher, getStudentsOf } from "@/lib/data";
 import { teacherJsonLd, SITE_URL } from "@/lib/seo";
 import { TeacherLineageCard } from "@/components/teacher-lineage-card";
@@ -150,6 +151,9 @@ export default async function TeacherPage({ params }: { params: Promise<{ slug: 
 
         {/* Teachings */}
         <TeachingsList resources={resources} teacherName={teacher.name} teacherSlug={slug} />
+
+        {/* Suggest a resource */}
+        <SuggestResourceForm contextType="teacher" contextName={teacher.name} prefilledValue={teacher.name} />
 
         {/* Centers */}
         {centers.length > 0 && (

--- a/src/app/traditions/[slug]/page.tsx
+++ b/src/app/traditions/[slug]/page.tsx
@@ -16,7 +16,7 @@ import {
 } from "@/lib/data";
 import { CitationLinks } from "@/components/citation-links";
 import { ResourceList } from "@/components/resource-list";
-import { SuggestEditLink } from "@/components/suggest-edit-link";
+import { SuggestResourceForm } from "@/components/suggest-resource-form";
 import { traditionJsonLd, SITE_URL } from "@/lib/seo";
 
 export function generateStaticParams() {
@@ -152,7 +152,7 @@ export default async function TraditionPage({ params }: { params: Promise<{ slug
 
       <ResourceList resources={resources} />
 
-      <SuggestEditLink traditionName={tradition.name} />
+      <SuggestResourceForm contextType="tradition" contextName={tradition.name} prefilledValue={tradition.name} />
     </PageLayout>
   );
 }

--- a/src/components/suggest-resource-form.tsx
+++ b/src/components/suggest-resource-form.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useState } from "react";
+
+const FORMSPREE_ID = "mbdpjqyb";
+
+interface Props {
+  contextType: "teacher" | "tradition";
+  contextName: string;
+  prefilledValue?: string;
+}
+
+export function SuggestResourceForm({ contextType, contextName, prefilledValue = "" }: Props) {
+  const [open, setOpen] = useState(false);
+  const [submitted, setSubmitted] = useState(false);
+  const [submitting, setSubmitting] = useState(false);
+
+  const prompt =
+    contextType === "teacher"
+      ? `Know a video or talk by ${contextName} we should add?`
+      : `Know a great resource on ${contextName}?`;
+
+  async function handleSubmit(e: React.FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setSubmitting(true);
+    try {
+      const res = await fetch(`https://formspree.io/f/${FORMSPREE_ID}`, {
+        method: "POST",
+        headers: { Accept: "application/json" },
+        body: new FormData(e.currentTarget),
+      });
+      if (res.ok) setSubmitted(true);
+    } catch {
+      // form remains visible on network error
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  if (!open) {
+    return (
+      <section id="suggest" className="mb-12">
+        <p className="font-sans text-sm text-muted-foreground">
+          {prompt}{" "}
+          <button
+            onClick={() => setOpen(true)}
+            className="text-primary underline underline-offset-2 hover:text-primary/80 transition-colors"
+          >
+            Suggest one &rarr;
+          </button>
+        </p>
+      </section>
+    );
+  }
+
+  if (submitted) {
+    return (
+      <section id="suggest" className="mb-12">
+        <div className="rounded-lg border border-border/50 bg-card p-6">
+          <p className="font-sans text-sm text-muted-foreground">
+            Thanks for the suggestion — we&rsquo;ll take a look.
+          </p>
+        </div>
+      </section>
+    );
+  }
+
+  return (
+    <section id="suggest" className="mb-12">
+      <form onSubmit={handleSubmit} className="rounded-lg border border-border/50 bg-card p-6 space-y-4">
+        <input type="hidden" name="_subject" value={`Resource suggestion: ${contextName}`} />
+        <input type="hidden" name="context_type" value={contextType} />
+        <input type="hidden" name="context_name" value={contextName} />
+
+        <p className="font-sans text-sm font-medium text-foreground">{prompt}</p>
+
+        <div className="space-y-3">
+          <div>
+            <label className="font-sans text-xs text-muted-foreground block mb-1">
+              URL <span className="text-primary">*</span>
+            </label>
+            <input
+              type="url"
+              name="url"
+              required
+              placeholder="https://…"
+              className="w-full font-sans text-sm border border-border rounded px-3 py-2 bg-background focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+
+          <div>
+            <label className="font-sans text-xs text-muted-foreground block mb-1">Type</label>
+            <select
+              name="type"
+              className="font-sans text-sm border border-border rounded px-3 py-2 bg-background focus:outline-none focus:ring-1 focus:ring-primary"
+            >
+              <option value="">— select —</option>
+              <option value="video">Video</option>
+              <option value="podcast">Podcast</option>
+              <option value="book">Book</option>
+            </select>
+          </div>
+
+          <div>
+            <label className="font-sans text-xs text-muted-foreground block mb-1">
+              {contextType === "teacher" ? "Teacher" : "Tradition"}
+            </label>
+            <input
+              type="text"
+              name={contextType === "teacher" ? "teacher" : "tradition"}
+              defaultValue={prefilledValue}
+              className="w-full font-sans text-sm border border-border rounded px-3 py-2 bg-background focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+
+          <div>
+            <label className="font-sans text-xs text-muted-foreground block mb-1">
+              Why include this? (optional)
+            </label>
+            <textarea
+              name="why"
+              rows={2}
+              placeholder="1–2 sentences…"
+              className="w-full font-sans text-sm border border-border rounded px-3 py-2 bg-background resize-none focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+
+          <div>
+            <label className="font-sans text-xs text-muted-foreground block mb-1">
+              Your name (optional)
+            </label>
+            <input
+              type="text"
+              name="name"
+              className="w-full font-sans text-sm border border-border rounded px-3 py-2 bg-background focus:outline-none focus:ring-1 focus:ring-primary"
+            />
+          </div>
+        </div>
+
+        <div className="flex items-center gap-3 pt-1">
+          <button
+            type="submit"
+            disabled={submitting}
+            className="font-sans text-sm font-medium bg-primary text-primary-foreground rounded px-4 py-2 hover:bg-primary/90 disabled:opacity-50 transition-colors"
+          >
+            {submitting ? "Sending…" : "Submit"}
+          </button>
+          <button
+            type="button"
+            onClick={() => setOpen(false)}
+            className="font-sans text-sm text-muted-foreground hover:text-foreground transition-colors"
+          >
+            Cancel
+          </button>
+        </div>
+      </form>
+    </section>
+  );
+}


### PR DESCRIPTION
## Summary

- New `SuggestResourceForm` client component with progressive disclosure (collapsed by default, expands inline on click)
- Teacher pages: "Know a video or talk by [Name] we should add?" prompt with pre-filled teacher name
- Tradition pages: "Know a great resource on [Name]?" prompt replaces the old `SuggestEditLink`
- Submits to existing Formspree `mbdpjqyb` with `_subject`, `context_type`, `context_name` hidden fields
- Success state shown after submission; no page navigation required
- URL is the only required field; teacher/tradition pre-filled but editable

## Test plan

- [ ] Visit a teacher page — "Know a video or talk by…" prompt visible below resources
- [ ] Click "Suggest one →" — form expands inline, no navigation
- [ ] Fill URL + submit — success message appears
- [ ] Visit a tradition page — "Know a great resource on…" prompt at bottom
- [ ] Cancel collapses form back to teaser
- [ ] Mobile layout clean at 375px

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)