### PR TITLE
feat: add app as resource type and 10 meditation apps

### DIFF
--- a/data/resources/balance-meditation.json
+++ b/data/resources/balance-meditation.json
@@ -1,0 +1,13 @@
+{
+  "title": "Balance",
+  "slug": "balance-meditation",
+  "type": "app",
+  "category": "popular",
+  "url": "https://www.balanceapp.com",
+  "author": null,
+  "year": 2021,
+  "description": "A personalized meditation app that adapts its program to the user's experience level and goals. Winner of Google Play App of the Year 2021. Focuses on secular mindfulness with structured progression.",
+  "traditions": ["secular-mindfulness"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/calm.json
+++ b/data/resources/calm.json
@@ -1,0 +1,13 @@
+{
+  "title": "Calm",
+  "slug": "calm",
+  "type": "app",
+  "category": "popular",
+  "url": "https://www.calm.com",
+  "author": null,
+  "year": 2012,
+  "description": "A widely used wellness app featuring guided meditations, sleep stories, breathwork, and relaxation music. Accessible entry point for secular mindfulness without strong tradition affiliation.",
+  "traditions": ["secular-mindfulness"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/headspace.json
+++ b/data/resources/headspace.json
@@ -1,0 +1,13 @@
+{
+  "title": "Headspace",
+  "slug": "headspace",
+  "type": "app",
+  "category": "popular",
+  "url": "https://www.headspace.com",
+  "author": null,
+  "year": 2010,
+  "description": "One of the most widely used meditation apps, founded by former Buddhist monk Andy Puddicombe. Offers structured beginner courses and themed sessions on stress, sleep, and focus, with a playful animated style.",
+  "traditions": ["secular-mindfulness"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/insight-timer.json
+++ b/data/resources/insight-timer.json
@@ -1,0 +1,13 @@
+{
+  "title": "Insight Timer",
+  "slug": "insight-timer",
+  "type": "app",
+  "category": "web_resource",
+  "url": "https://insighttimer.com",
+  "author": null,
+  "year": 2009,
+  "description": "The world's largest free meditation app with over 150,000 guided meditations from teachers across traditions including Theravada, Vipassana, and secular mindfulness. Features a community timer and live events.",
+  "traditions": ["secular-mindfulness", "theravada", "vipassana-movement"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/luminous-rupert-spira.json
+++ b/data/resources/luminous-rupert-spira.json
@@ -1,0 +1,13 @@
+{
+  "title": "Luminous",
+  "slug": "luminous-rupert-spira",
+  "type": "app",
+  "category": "popular",
+  "url": "https://rupertspira.com/luminous",
+  "author": "Rupert Spira",
+  "year": 2022,
+  "description": "A meditation and inquiry app by Rupert Spira featuring guided meditations, contemplative music, and teachings on the nature of awareness in the Advaita Vedanta and Modern Non-Dual tradition.",
+  "traditions": ["advaita-vedanta", "modern-non-dual"],
+  "teachers": ["rupert-spira"],
+  "centers": []
+}

--- a/data/resources/medito.json
+++ b/data/resources/medito.json
@@ -1,0 +1,13 @@
+{
+  "title": "Medito",
+  "slug": "medito",
+  "type": "app",
+  "category": "popular",
+  "url": "https://meditofoundation.org",
+  "author": null,
+  "year": 2019,
+  "description": "A completely free, open-source meditation app with no ads or subscriptions, run by a nonprofit. Offers beginner courses, sleep meditations, and breathing exercises rooted in secular mindfulness and Theravada tradition.",
+  "traditions": ["secular-mindfulness", "theravada"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/plum-village-app.json
+++ b/data/resources/plum-village-app.json
@@ -1,0 +1,13 @@
+{
+  "title": "Plum Village",
+  "slug": "plum-village-app",
+  "type": "app",
+  "category": "popular",
+  "url": "https://plumvillage.app",
+  "author": "Thich Nhat Hanh",
+  "year": 2020,
+  "description": "The official meditation app of Thich Nhat Hanh's Plum Village community, offering guided meditations, dharma talks, and mindfulness bells in the Zen and Engaged Buddhism tradition. Available in multiple languages.",
+  "traditions": ["zen", "mahayana"],
+  "teachers": ["thich-nhat-hanh"],
+  "centers": []
+}

--- a/data/resources/pray-as-you-go.json
+++ b/data/resources/pray-as-you-go.json
@@ -1,0 +1,13 @@
+{
+  "title": "Pray As You Go",
+  "slug": "pray-as-you-go",
+  "type": "app",
+  "category": "popular",
+  "url": "https://pray-as-you-go.org",
+  "author": null,
+  "year": 2007,
+  "description": "A daily prayer app from the Jesuits featuring music, Scripture, and contemplative reflection in the Ignatian tradition. Each session is 10–13 minutes and follows the Lectio Divina and Ignatian examination of conscience practices.",
+  "traditions": ["christian-mysticism"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/ten-percent-happier.json
+++ b/data/resources/ten-percent-happier.json
@@ -1,0 +1,13 @@
+{
+  "title": "Ten Percent Happier",
+  "slug": "ten-percent-happier",
+  "type": "app",
+  "category": "popular",
+  "url": "https://www.tenpercent.com",
+  "author": "Dan Harris",
+  "year": 2017,
+  "description": "A meditation app for skeptics, founded by ABC journalist Dan Harris after a panic attack on live TV. Features courses from Vipassana and secular mindfulness teachers, with an emphasis on pragmatic, no-fluff instruction.",
+  "traditions": ["vipassana-movement", "secular-mindfulness"],
+  "teachers": [],
+  "centers": []
+}

--- a/data/resources/waking-up.json
+++ b/data/resources/waking-up.json
@@ -1,0 +1,13 @@
+{
+  "title": "Waking Up",
+  "slug": "waking-up",
+  "type": "app",
+  "category": "popular",
+  "url": "https://www.wakingup.com",
+  "author": "Sam Harris",
+  "year": 2018,
+  "description": "A secular meditation app offering guided meditations, courses, and conversations on mindfulness and consciousness. Covers Dzogchen, Advaita Vedanta, and secular mindfulness traditions. Known for its intellectual rigor and lack of spiritual jargon.",
+  "traditions": ["secular-mindfulness", "dzogchen", "advaita-vedanta"],
+  "teachers": ["sam-harris"],
+  "centers": []
+}

--- a/src/components/discover-client.tsx
+++ b/src/components/discover-client.tsx
@@ -48,6 +48,7 @@ const RESOURCE_TYPES = [
   { value: "podcast", label: "Podcast" },
   { value: "article", label: "Article" },
   { value: "website", label: "Website" },
+  { value: "app", label: "App" },
 ];
 
 const EXPERIENCE_LEVELS = [
@@ -65,6 +66,7 @@ const LEVEL_STYLES: Record<string, string> = {
 const TYPE_ICONS: Record<string, string> = {
   video: "▶",
   podcast: "◉",
+  app: "◈",
 };
 
 const ALL_TOPICS = [

--- a/src/components/resource-list.tsx
+++ b/src/components/resource-list.tsx
@@ -19,7 +19,7 @@ const CATEGORY_LABELS: Record<ResourceCategory, string> = {
   web_resource: "Web Resources",
 };
 
-const TYPE_ORDER: ResourceType[] = ["book", "video", "podcast", "article", "website"];
+const TYPE_ORDER: ResourceType[] = ["book", "video", "podcast", "article", "website", "app"];
 
 const TYPE_LABELS: Record<ResourceType, string> = {
   book: "Books",
@@ -27,6 +27,7 @@ const TYPE_LABELS: Record<ResourceType, string> = {
   podcast: "Podcasts",
   article: "Articles",
   website: "Websites",
+  app: "Apps",
 };
 
 interface ResourceListProps {

--- a/src/components/resources-client.tsx
+++ b/src/components/resources-client.tsx
@@ -9,7 +9,7 @@ import { Select } from "@/components/ui/select";
 import { Badge } from "@/components/ui/badge";
 import Link from "next/link";
 
-const RESOURCE_TYPES = ["book", "podcast", "video", "article", "website"] as const;
+const RESOURCE_TYPES = ["book", "podcast", "video", "article", "website", "app"] as const;
 
 function typeLabel(type: string): string {
   return type.charAt(0).toUpperCase() + type.slice(1);

--- a/src/components/teachings-list.tsx
+++ b/src/components/teachings-list.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { getTradition } from "@/lib/data";
 import type { Resource, ResourceType } from "@/lib/types";
 
-const TYPE_ORDER: ResourceType[] = ["video", "podcast", "book", "article", "website"];
+const TYPE_ORDER: ResourceType[] = ["video", "podcast", "book", "article", "website", "app"];
 
 const TYPE_LABELS: Record<ResourceType, string> = {
   video: "Videos",
@@ -10,6 +10,7 @@ const TYPE_LABELS: Record<ResourceType, string> = {
   book: "Books",
   article: "Articles",
   website: "Websites",
+  app: "Apps",
 };
 
 const TYPE_BADGE: Record<ResourceType, string> = {
@@ -18,6 +19,7 @@ const TYPE_BADGE: Record<ResourceType, string> = {
   book: "Book",
   article: "Article",
   website: "Website",
+  app: "App",
 };
 
 interface Props {

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -43,7 +43,7 @@ export interface Teacher {
   teachers: string[];
 }
 
-export type ResourceType = "book" | "podcast" | "video" | "article" | "website";
+export type ResourceType = "book" | "podcast" | "video" | "article" | "website" | "app";
 
 export type ResourceCategory =
   | "primary_text"


### PR DESCRIPTION
## Summary
- Adds `"app"` to `ResourceType` union in `types.ts`
- Updates all type filter arrays, label maps, and badge maps in `resource-list.tsx`, `teachings-list.tsx`, `resources-client.tsx`, `discover-client.tsx`
- Creates 10 meditation app resource files: Waking Up, Headspace, Insight Timer, Ten Percent Happier, Plum Village, Luminous, Calm, Balance, Medito, Pray As You Go

## Test plan
- [ ] "App" appears in /resources type filter dropdown
- [ ] "App" appears in /discover type filter
- [ ] App resources display with correct type label
- [ ] `npm run build` passes

Closes #137

🤖 Generated with [Claude Code](https://claude.com/claude-code)