### PR TITLE
feat: add related_resources cross-linking field to resources

### DIFF
--- a/data/resources/SCHEMA.md
+++ b/data/resources/SCHEMA.md
@@ -1,0 +1,49 @@
+# Resource JSON Schema
+
+Each resource in `data/resources/` is a JSON file with the following fields.
+
+## Required fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `title` | string | Display title of the resource |
+| `slug` | string | URL-safe identifier, must match the filename |
+| `type` | enum | One of: `book`, `video`, `podcast`, `article`, `website`, `app` |
+| `category` | enum | One of: `primary_text`, `academic`, `popular`, `encyclopedia`, `web_resource` |
+| `url` | string | External URL (use Bookshop.org affiliate URL for books) |
+| `description` | string | 1–3 sentence description |
+| `traditions` | string[] | Tradition slugs from `data/traditions/` |
+| `teachers` | string[] | Teacher slugs from `data/teachers/` |
+| `centers` | string[] | Center slugs from `data/centers/` |
+
+## Optional fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `author` | string \| null | Author name |
+| `year` | number \| null | Publication or release year |
+| `experience_level` | enum | `beginner`, `intermediate`, or `advanced` |
+| `topics` | string[] | Taxonomy topic slugs (see `data/taxonomy.json`) |
+| `practice_context` | string[] | Practice context slugs (see `data/taxonomy.json`) |
+| `related_resources` | string[] | Slugs of related resources for cross-linking (max 4) |
+
+## `related_resources` field
+
+Slugs of other resources the reader/listener/viewer should explore next. Guidelines:
+
+- **Same author**: always link to other works by the same teacher
+- **Same tradition path**: link to the canonical next step in the tradition
+- **Thematic**: link to resources covering the same practice or concept differently
+- **Max 4**: keep the list curated, not exhaustive
+- **Reciprocal**: if A links to B, B should link to A
+
+Example:
+```json
+{
+  "related_resources": [
+    "be-as-you-are",
+    "adyashanti-true-meditation",
+    "de-mello-awareness"
+  ]
+}
+```

--- a/data/resources/adyashanti-emptiness-dancing.json
+++ b/data/resources/adyashanti-emptiness-dancing.json
@@ -15,5 +15,11 @@
   "teachers": [
     "adyashanti"
   ],
-  "centers": []
+  "centers": [],
+  "related_resources": [
+    "adyashanti-falling-into-grace",
+    "adyashanti-the-direct-way",
+    "adyashanti-true-meditation",
+    "be-as-you-are"
+  ]
 }

--- a/data/resources/adyashanti-falling-into-grace.json
+++ b/data/resources/adyashanti-falling-into-grace.json
@@ -15,5 +15,11 @@
   "teachers": [
     "adyashanti"
   ],
-  "centers": []
+  "centers": [],
+  "related_resources": [
+    "adyashanti-emptiness-dancing",
+    "adyashanti-the-direct-way",
+    "adyashanti-the-most-important-thing",
+    "adyashanti-true-meditation"
+  ]
 }

--- a/data/resources/adyashanti-the-direct-way.json
+++ b/data/resources/adyashanti-the-direct-way.json
@@ -15,5 +15,10 @@
   "teachers": [
     "adyashanti"
   ],
-  "centers": []
+  "centers": [],
+  "related_resources": [
+    "adyashanti-emptiness-dancing",
+    "adyashanti-falling-into-grace",
+    "adyashanti-true-meditation"
+  ]
 }

--- a/data/resources/adyashanti-the-most-important-thing.json
+++ b/data/resources/adyashanti-the-most-important-thing.json
@@ -15,5 +15,10 @@
   "teachers": [
     "adyashanti"
   ],
-  "centers": []
+  "centers": [],
+  "related_resources": [
+    "adyashanti-falling-into-grace",
+    "tolle-practicing-the-power-of-now",
+    "tolle-the-power-of-now"
+  ]
 }

--- a/data/resources/adyashanti-true-meditation.json
+++ b/data/resources/adyashanti-true-meditation.json
@@ -15,5 +15,11 @@
   "teachers": [
     "adyashanti"
   ],
-  "centers": []
+  "centers": [],
+  "related_resources": [
+    "adyashanti-emptiness-dancing",
+    "adyashanti-falling-into-grace",
+    "adyashanti-the-direct-way",
+    "be-as-you-are"
+  ]
 }

--- a/data/resources/be-as-you-are.json
+++ b/data/resources/be-as-you-are.json
@@ -11,5 +11,11 @@
     "advaita-vedanta"
   ],
   "teachers": [],
-  "centers": []
+  "centers": [],
+  "related_resources": [
+    "adyashanti-emptiness-dancing",
+    "adyashanti-true-meditation",
+    "de-mello-awareness",
+    "gangaji-hidden-treasure"
+  ]
 }

--- a/data/resources/das-natural-great-perfection.json
+++ b/data/resources/das-natural-great-perfection.json
@@ -13,5 +13,9 @@
   "teachers": [
     "lama-surya-das"
   ],
-  "centers": []
+  "centers": [],
+  "related_resources": [
+    "padmasambhava-the-tibetan-book-of-the-dead",
+    "self-liberation-through-seeing-with-naked-awareness"
+  ]
 }

--- a/data/resources/de-mello-awareness.json
+++ b/data/resources/de-mello-awareness.json
@@ -7,7 +7,17 @@
   "author": "Anthony de Mello",
   "year": 1990,
   "description": "A transcription of de Mello's final retreat, Awareness is a bracing call to wake up from the sleepwalking of everyday life. Blending Christian mysticism with Eastern insight, de Mello challenges readers to see through their illusions, attachments, and conditioned thinking with humor, directness, and radical honesty.",
-  "traditions": ["christian-mysticism"],
-  "teachers": ["anthony-de-mello"],
-  "centers": []
+  "traditions": [
+    "christian-mysticism"
+  ],
+  "teachers": [
+    "anthony-de-mello"
+  ],
+  "centers": [],
+  "related_resources": [
+    "adyashanti-emptiness-dancing",
+    "adyashanti-true-meditation",
+    "be-as-you-are",
+    "i-am-that"
+  ]
 }

--- a/data/resources/diamond-sutra.json
+++ b/data/resources/diamond-sutra.json
@@ -12,5 +12,9 @@
     "zen"
   ],
   "teachers": [],
-  "centers": []
+  "centers": [],
+  "related_resources": [
+    "mindfulness-in-plain-english",
+    "zen-mind-beginners-mind"
+  ]
 }

--- a/data/resources/full-catastrophe-living.json
+++ b/data/resources/full-catastrophe-living.json
@@ -13,5 +13,10 @@
   "teachers": [
     "jon-kabat-zinn"
   ],
-  "centers": []
+  "centers": [],
+  "related_resources": [
+    "mindfulness-in-plain-english",
+    "the-miracle-of-mindfulness",
+    "wherever-you-go-there-you-are"
+  ]
 }

--- a/data/resources/gangaji-hidden-treasure.json
+++ b/data/resources/gangaji-hidden-treasure.json
@@ -14,5 +14,11 @@
   "teachers": [
     "gangaji"
   ],
-  "centers": []
+  "centers": [],
+  "related_resources": [
+    "be-as-you-are",
+    "gangaji-the-diamond-in-your-pocket",
+    "gangaji-you-are-that",
+    "i-am-that"
+  ]
 }

--- a/data/resources/gangaji-the-diamond-in-your-pocket.json
+++ b/data/resources/gangaji-the-diamond-in-your-pocket.json
@@ -14,5 +14,11 @@
   "teachers": [
     "gangaji"
   ],
-  "centers": []
+  "centers": [],
+  "related_resources": [
+    "be-as-you-are",
+    "gangaji-hidden-treasure",
+    "gangaji-you-are-that",
+    "i-am-that"
+  ]
 }

--- a/data/resources/gangaji-you-are-that.json
+++ b/data/resources/gangaji-you-are-that.json
@@ -14,5 +14,11 @@
   "teachers": [
     "gangaji"
   ],
-  "centers": []
+  "centers": [],
+  "related_resources": [
+    "be-as-you-are",
+    "gangaji-hidden-treasure",
+    "gangaji-the-diamond-in-your-pocket",
+    "i-am-that"
+  ]
 }

--- a/data/resources/i-am-that.json
+++ b/data/resources/i-am-that.json
@@ -12,5 +12,11 @@
     "modern-non-dual"
   ],
   "teachers": [],
-  "centers": []
+  "centers": [],
+  "related_resources": [
+    "adyashanti-emptiness-dancing",
+    "adyashanti-true-meditation",
+    "be-as-you-are",
+    "de-mello-awareness"
+  ]
 }

--- a/data/resources/maharshi-be-as-you-are.json
+++ b/data/resources/maharshi-be-as-you-are.json
@@ -13,5 +13,11 @@
   "teachers": [
     "ramana-maharshi"
   ],
-  "centers": []
+  "centers": [],
+  "related_resources": [
+    "adyashanti-emptiness-dancing",
+    "adyashanti-true-meditation",
+    "be-as-you-are",
+    "de-mello-awareness"
+  ]
 }

--- a/data/resources/mindfulness-in-plain-english.json
+++ b/data/resources/mindfulness-in-plain-english.json
@@ -12,5 +12,11 @@
     "vipassana-movement"
   ],
   "teachers": [],
-  "centers": []
+  "centers": [],
+  "related_resources": [
+    "diamond-sutra",
+    "full-catastrophe-living",
+    "the-miracle-of-mindfulness",
+    "wherever-you-go-there-you-are"
+  ]
 }

--- a/data/resources/non-dual-awareness-science-and-nonduality.json
+++ b/data/resources/non-dual-awareness-science-and-nonduality.json
@@ -12,5 +12,10 @@
   "teachers": [],
   "centers": [],
   "category": "web_resource",
-  "slug": "non-dual-awareness-science-and-nonduality"
+  "slug": "non-dual-awareness-science-and-nonduality",
+  "related_resources": [
+    "de-mello-awareness",
+    "open-awareness-open-mind",
+    "sumedho-intuitive-awareness"
+  ]
 }

--- a/data/resources/open-awareness-open-mind.json
+++ b/data/resources/open-awareness-open-mind.json
@@ -11,5 +11,10 @@
   "teachers": [],
   "centers": [],
   "category": "popular",
-  "slug": "open-awareness-open-mind"
+  "slug": "open-awareness-open-mind",
+  "related_resources": [
+    "de-mello-awareness",
+    "non-dual-awareness-science-and-nonduality",
+    "sumedho-intuitive-awareness"
+  ]
 }

--- a/data/resources/padmasambhava-the-tibetan-book-of-the-dead.json
+++ b/data/resources/padmasambhava-the-tibetan-book-of-the-dead.json
@@ -14,5 +14,9 @@
   "teachers": [
     "padmasambhava"
   ],
-  "centers": []
+  "centers": [],
+  "related_resources": [
+    "das-natural-great-perfection",
+    "self-liberation-through-seeing-with-naked-awareness"
+  ]
 }

--- a/data/resources/self-liberation-through-seeing-with-naked-awareness.json
+++ b/data/resources/self-liberation-through-seeing-with-naked-awareness.json
@@ -11,5 +11,9 @@
   "teachers": [],
   "centers": [],
   "category": "primary_text",
-  "slug": "self-liberation-through-seeing-with-naked-awareness"
+  "slug": "self-liberation-through-seeing-with-naked-awareness",
+  "related_resources": [
+    "das-natural-great-perfection",
+    "padmasambhava-the-tibetan-book-of-the-dead"
+  ]
 }

--- a/data/resources/sumedho-intuitive-awareness.json
+++ b/data/resources/sumedho-intuitive-awareness.json
@@ -13,5 +13,10 @@
   "teachers": [
     "ajahn-sumedho"
   ],
-  "centers": []
+  "centers": [],
+  "related_resources": [
+    "de-mello-awareness",
+    "non-dual-awareness-science-and-nonduality",
+    "open-awareness-open-mind"
+  ]
 }

--- a/data/resources/suzuki-zen-mind-beginner-s-mind-informal-talks-on-zen-meditation-and-practice.json
+++ b/data/resources/suzuki-zen-mind-beginner-s-mind-informal-talks-on-zen-meditation-and-practice.json
@@ -13,5 +13,9 @@
   "teachers": [
     "shunryu-suzuki"
   ],
-  "centers": []
+  "centers": [],
+  "related_resources": [
+    "the-miracle-of-mindfulness",
+    "zen-mind-beginners-mind"
+  ]
 }

--- a/data/resources/the-miracle-of-mindfulness.json
+++ b/data/resources/the-miracle-of-mindfulness.json
@@ -14,5 +14,11 @@
   "teachers": [
     "thich-nhat-hanh"
   ],
-  "centers": []
+  "centers": [],
+  "related_resources": [
+    "full-catastrophe-living",
+    "mindfulness-in-plain-english",
+    "suzuki-zen-mind-beginner-s-mind-informal-talks-on-zen-meditation-and-practice",
+    "wherever-you-go-there-you-are"
+  ]
 }

--- a/data/resources/tolle-practicing-the-power-of-now.json
+++ b/data/resources/tolle-practicing-the-power-of-now.json
@@ -13,5 +13,10 @@
   "teachers": [
     "eckhart-tolle"
   ],
-  "centers": []
+  "centers": [],
+  "related_resources": [
+    "adyashanti-falling-into-grace",
+    "adyashanti-the-most-important-thing",
+    "tolle-the-power-of-now"
+  ]
 }

--- a/data/resources/tolle-the-power-of-now.json
+++ b/data/resources/tolle-the-power-of-now.json
@@ -13,5 +13,10 @@
   "teachers": [
     "eckhart-tolle"
   ],
-  "centers": []
+  "centers": [],
+  "related_resources": [
+    "adyashanti-falling-into-grace",
+    "adyashanti-the-most-important-thing",
+    "tolle-practicing-the-power-of-now"
+  ]
 }

--- a/data/resources/wherever-you-go-there-you-are.json
+++ b/data/resources/wherever-you-go-there-you-are.json
@@ -13,5 +13,10 @@
   "teachers": [
     "jon-kabat-zinn"
   ],
-  "centers": []
+  "centers": [],
+  "related_resources": [
+    "full-catastrophe-living",
+    "mindfulness-in-plain-english",
+    "the-miracle-of-mindfulness"
+  ]
 }

--- a/data/resources/zen-mind-beginners-mind.json
+++ b/data/resources/zen-mind-beginners-mind.json
@@ -13,5 +13,11 @@
   "teachers": [
     "shunryu-suzuki"
   ],
-  "centers": []
+  "centers": [],
+  "related_resources": [
+    "diamond-sutra",
+    "mindfulness-in-plain-english",
+    "suzuki-zen-mind-beginner-s-mind-informal-talks-on-zen-meditation-and-practice",
+    "the-miracle-of-mindfulness"
+  ]
 }

--- a/src/app/resources/[slug]/page.tsx
+++ b/src/app/resources/[slug]/page.tsx
@@ -9,6 +9,15 @@ import { ResourceTestimonies } from "@/components/resource-testimonies";
 import { TaxonomyBadges } from "@/components/taxonomy-badges";
 import { SITE_URL } from "@/lib/seo";
 
+const TYPE_LABELS: Record<string, string> = {
+  book: "Book",
+  podcast: "Podcast",
+  video: "Video",
+  article: "Article",
+  website: "Website",
+  app: "App",
+};
+
 export function generateStaticParams() {
   return getAllResources().map((r) => ({ slug: r.slug }));
 }
@@ -37,6 +46,8 @@ export default async function ResourcePage({ params }: { params: Promise<{ slug:
   const allTraditions = getAllTraditions();
   const allTeachers = getAllTeachers();
 
+  const allResources = getAllResources();
+
   const traditions = resource.traditions
     .map((s) => allTraditions.find((t) => t.slug === s))
     .filter(Boolean);
@@ -45,13 +56,9 @@ export default async function ResourcePage({ params }: { params: Promise<{ slug:
     .map((s) => allTeachers.find((t) => t.slug === s))
     .filter(Boolean);
 
-  const typeLabels: Record<string, string> = {
-    book: "Book",
-    podcast: "Podcast",
-    video: "Video",
-    article: "Article",
-    website: "Website",
-  };
+  const relatedResources = (resource.related_resources ?? [])
+    .map((s) => allResources.find((r) => r.slug === s))
+    .filter(Boolean);
 
   return (
     <PageLayout>
@@ -65,7 +72,7 @@ export default async function ResourcePage({ params }: { params: Promise<{ slug:
       <article className="max-w-2xl">
         <header className="mb-8">
           <div className="mb-3 flex items-center gap-2">
-            <Badge variant="outline">{typeLabels[resource.type] ?? resource.type}</Badge>
+            <Badge variant="outline">{TYPE_LABELS[resource.type] ?? resource.type}</Badge>
           </div>
           <h1 className="mb-2">{resource.title}</h1>
           {resource.author && (
@@ -124,6 +131,34 @@ export default async function ResourcePage({ params }: { params: Promise<{ slug:
                 </Badge>
               </Link>
             ))}
+          </div>
+        )}
+
+        {/* Related resources */}
+        {relatedResources.length > 0 && (
+          <div className="mb-10">
+            <h2 className="font-serif text-xl font-semibold mb-4">Related Resources</h2>
+            <div className="space-y-3">
+              {relatedResources.map((r) => (
+                <Link
+                  key={r!.slug}
+                  href={`/resources/${r!.slug}`}
+                  className="flex items-start gap-3 rounded-lg border border-border/50 bg-card p-4 hover:bg-accent/50 transition-colors group"
+                >
+                  <Badge variant="outline" className="mt-0.5 shrink-0 text-[10px]">
+                    {TYPE_LABELS[r!.type] ?? r!.type}
+                  </Badge>
+                  <div>
+                    <p className="font-serif text-sm font-medium group-hover:text-primary transition-colors">
+                      {r!.title}
+                    </p>
+                    {r!.author && (
+                      <p className="font-sans text-xs text-muted-foreground mt-0.5">{r!.author}</p>
+                    )}
+                  </div>
+                </Link>
+              ))}
+            </div>
           </div>
         )}
 

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -67,6 +67,7 @@ export interface Resource {
   experience_level?: ExperienceLevel;
   topics?: string[];
   practice_context?: string[];
+  related_resources?: string[];
 }
 
 // -- Taxonomy types --


### PR DESCRIPTION
## Summary
- Adds `related_resources?: string[]` to `Resource` interface
- Resource detail page shows "Related Resources" section with type badge, title, author
- 27 popular resources populated with curated connections (Advaita, Zen, mindfulness, Dzogchen, non-dual clusters)
- `data/resources/SCHEMA.md` documents all resource fields including the new one

## Test plan
- [ ] Visit /resources/i-am-that — see Related Resources section with be-as-you-are, adyashanti-true-meditation, etc.
- [ ] Visit /resources/zen-mind-beginners-mind — see related Zen/mindfulness resources
- [ ] Resources without related_resources show no section
- [ ] `npm run build` passes

Closes #138

🤖 Generated with [Claude Code](https://claude.com/claude-code)