### PR TITLE
feat: sync /discover filters with URL search params

### DIFF
--- a/src/app/discover/page.tsx
+++ b/src/app/discover/page.tsx
@@ -1,3 +1,4 @@
+import { Suspense } from "react";
 import type { Metadata } from "next";
 import { PageLayout } from "@/components/page-layout";
 import { getAllTraditions, getAllTeachers } from "@/lib/data";
@@ -28,7 +29,9 @@ export default function DiscoverPage() {
 
   return (
     <PageLayout>
-      <DiscoverClient traditionNames={traditionNames} teacherNames={teacherNames} />
+      <Suspense fallback={<div className="h-8 w-full animate-pulse bg-muted rounded" />}>
+        <DiscoverClient traditionNames={traditionNames} teacherNames={teacherNames} />
+      </Suspense>
     </PageLayout>
   );
 }

--- a/src/components/discover-client.tsx
+++ b/src/components/discover-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
-import { useState, useMemo, useEffect, useCallback } from "react";
+import { useState, useMemo, useEffect, useCallback, useRef } from "react";
+import { useRouter, useSearchParams } from "next/navigation";
 import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 
@@ -91,6 +92,41 @@ const ALL_PRACTICE_CONTEXTS = [
   "academic",
   "secular",
 ];
+
+// --- URL sync helpers ---
+
+const VALID_EXPERIENCE_LEVELS = new Set(["beginner", "intermediate", "advanced"]);
+const VALID_TYPES = new Set(["book", "video", "podcast", "article", "website", "app"]);
+const VALID_TOPICS = new Set(ALL_TOPICS);
+const VALID_CONTEXTS = new Set(ALL_PRACTICE_CONTEXTS);
+
+function paramsToFilters(params: URLSearchParams): FilterState {
+  const split = (key: string) =>
+    (params.get(key) ?? "").split(",").filter(Boolean);
+
+  const experienceLevel = params.get("experience_level") ?? "";
+  const type = params.get("type") ?? "";
+
+  return {
+    type: VALID_TYPES.has(type) ? type : "",
+    experienceLevel: VALID_EXPERIENCE_LEVELS.has(experienceLevel) ? experienceLevel : "",
+    topics: split("topics").filter((v) => VALID_TOPICS.has(v)),
+    practiceContext: split("practice_context").filter((v) => VALID_CONTEXTS.has(v)),
+    traditions: split("tradition"),
+    teachers: split("teacher"),
+  };
+}
+
+function filtersToParams(f: FilterState): URLSearchParams {
+  const p = new URLSearchParams();
+  if (f.type) p.set("type", f.type);
+  if (f.experienceLevel) p.set("experience_level", f.experienceLevel);
+  if (f.topics.length) p.set("topics", f.topics.join(","));
+  if (f.practiceContext.length) p.set("practice_context", f.practiceContext.join(","));
+  if (f.traditions.length) p.set("tradition", f.traditions.join(","));
+  if (f.teachers.length) p.set("teacher", f.teachers.join(","));
+  return p;
+}
 
 // --- Helpers ---
 
@@ -281,10 +317,25 @@ interface DiscoverClientProps {
 }
 
 export function DiscoverClient({ traditionNames, teacherNames }: DiscoverClientProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const isMounted = useRef(false);
+
   const [resources, setResources] = useState<ResourceIndexItem[] | null>(null);
   const [fetchError, setFetchError] = useState(false);
-  const [filters, setFilters] = useState<FilterState>(EMPTY_FILTERS);
+  const [filters, setFilters] = useState<FilterState>(() => paramsToFilters(searchParams));
   const [showAllTeachers, setShowAllTeachers] = useState(false);
+
+  // Sync filters → URL after every filter change (skip initial mount)
+  useEffect(() => {
+    if (!isMounted.current) {
+      isMounted.current = true;
+      return;
+    }
+    const params = filtersToParams(filters);
+    const query = params.toString();
+    router.push(query ? `/discover?${query}` : "/discover");
+  }, [filters, router]);
 
   useEffect(() => {
     fetch("/resources-index.json")


### PR DESCRIPTION
## Summary
- Filter changes push to URL via `router.push()` — enables back/forward navigation through filter history
- URL params initialize filter state on load (shareable links, homepage entry points work)
- Adds `paramsToFilters()` and `filtersToParams()` helpers with validation (invalid values ignored)
- Wraps `DiscoverClient` in `Suspense` (required for `useSearchParams` in static export)
- URL format: `/discover?experience_level=beginner&topics=a,b&practice_context=c&tradition=t1&type=book`

## Test plan
- [ ] Change a filter — URL updates without page reload
- [ ] Copy URL and paste in new tab — filters initialize correctly
- [ ] Visit `/discover?experience_level=beginner&practice_context=new-to-practice` from homepage cards
- [ ] Browser back/forward navigates filter history
- [ ] Invalid URL params (e.g. `?experience_level=invalid`) are ignored
- [ ] Clearing all filters produces clean `/discover` URL
- [ ] `npm run build` passes

Closes #243

🤖 Generated with [Claude Code](https://claude.com/claude-code)