### PR TITLE
feat: add taxonomy-driven similar resources to resource detail pages

### DIFF
--- a/src/app/resources/[slug]/page.tsx
+++ b/src/app/resources/[slug]/page.tsx
@@ -3,7 +3,7 @@ import { notFound } from "next/navigation";
 import { PageLayout } from "@/components/page-layout";
 import { Breadcrumbs } from "@/components/breadcrumbs";
 import { Badge } from "@/components/ui/badge";
-import { getAllResources, getResource, getAllTraditions, getAllTeachers } from "@/lib/data";
+import { getAllResources, getResource, getAllTraditions, getAllTeachers, getSimilarResources } from "@/lib/data";
 import { bookshopAffiliateUrl } from "@/lib/affiliate";
 import { ResourceTestimonies } from "@/components/resource-testimonies";
 import { TaxonomyBadges } from "@/components/taxonomy-badges";
@@ -59,6 +59,8 @@ export default async function ResourcePage({ params }: { params: Promise<{ slug:
   const relatedResources = (resource.related_resources ?? [])
     .map((s) => allResources.find((r) => r.slug === s))
     .filter(Boolean);
+
+  const similarResources = getSimilarResources(resource, allResources);
 
   return (
     <PageLayout>
@@ -156,6 +158,42 @@ export default async function ResourcePage({ params }: { params: Promise<{ slug:
                       <p className="font-sans text-xs text-muted-foreground mt-0.5">{r!.author}</p>
                     )}
                   </div>
+                </Link>
+              ))}
+            </div>
+          </div>
+        )}
+
+        {/* Similar resources — taxonomy-driven, computed at build time */}
+        {similarResources.length > 0 && (
+          <div className="mb-10">
+            <h2 className="font-serif text-xl font-semibold mb-4">You might also explore</h2>
+            <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+              {similarResources.map((r) => (
+                <Link
+                  key={r.slug}
+                  href={`/resources/${r.slug}`}
+                  className="group rounded-lg border border-border/50 bg-card p-4 hover:bg-accent/50 transition-colors"
+                >
+                  <div className="flex items-center gap-2 mb-2">
+                    <Badge variant="outline" className="text-[10px]">
+                      {TYPE_LABELS[r.type] ?? r.type}
+                    </Badge>
+                    {r.experience_level && (
+                      <span className="font-sans text-[10px] text-muted-foreground capitalize">
+                        {r.experience_level}
+                      </span>
+                    )}
+                  </div>
+                  <p className="font-serif text-sm font-medium group-hover:text-primary transition-colors leading-snug mb-1">
+                    {r.title}
+                  </p>
+                  {r.author && (
+                    <p className="font-sans text-xs text-muted-foreground">{r.author}</p>
+                  )}
+                  <p className="font-sans text-xs text-foreground/60 leading-relaxed mt-1.5 line-clamp-2">
+                    {r.description}
+                  </p>
                 </Link>
               ))}
             </div>

--- a/src/lib/data.ts
+++ b/src/lib/data.ts
@@ -162,6 +162,40 @@ export function getResourcesByCenter(centerSlug: string): Resource[] {
   return getAllResources().filter((r) => r.centers.includes(centerSlug));
 }
 
+export function getSimilarResources(
+  resource: Resource,
+  allResources: Resource[],
+  { topN = 5, minScore = 0.1 }: { topN?: number; minScore?: number } = {}
+): Resource[] {
+  const tags = new Set([
+    ...(resource.topics ?? []),
+    ...(resource.practice_context ?? []),
+    ...resource.traditions,
+  ]);
+  if (tags.size === 0) return [];
+
+  return allResources
+    .filter((r) => r.slug !== resource.slug)
+    .map((r) => {
+      const otherTags = new Set([
+        ...(r.topics ?? []),
+        ...(r.practice_context ?? []),
+        ...r.traditions,
+      ]);
+      if (otherTags.size === 0) return { resource: r, score: 0 };
+      let intersection = 0;
+      for (const t of tags) if (otherTags.has(t)) intersection++;
+      const union = tags.size + otherTags.size - intersection;
+      const jaccard = intersection / union;
+      const boost = resource.experience_level && r.experience_level === resource.experience_level ? 0.1 : 0;
+      return { resource: r, score: jaccard + boost };
+    })
+    .filter(({ score }) => score >= minScore)
+    .sort((a, b) => b.score - a.score)
+    .slice(0, topN)
+    .map(({ resource: r }) => r);
+}
+
 // -- Traditions --
 
 export interface ParsedTradition {


### PR DESCRIPTION
## Summary
- Adds `getSimilarResources()` to `data.ts`: Jaccard similarity on `topics` + `practice_context` + `traditions` tag set, with 0.1 boost for matching `experience_level`
- "You might also explore" card grid on resource detail pages (build-time, not client-side)
- Shows 3–5 results above 0.1 minimum score; hidden if no similar resources found
- Cards: type badge, experience level, title, author, 2-line description

## Test plan
- [ ] Visit a resource with taxonomy tags (e.g. /resources/mindfulness-in-plain-english) — see "You might also explore" with similar resources
- [ ] Visit a resource with no taxonomy tags — no section shown
- [ ] Cards link correctly to resource detail pages
- [ ] `npm run build` passes

Closes #244

🤖 Generated with [Claude Code](https://claude.com/claude-code)