### PR TITLE
feat: link taxonomy badges to /discover with pre-set filters

### DIFF
--- a/src/components/taxonomy-badges.tsx
+++ b/src/components/taxonomy-badges.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { Badge } from "@/components/ui/badge";
 import type { ExperienceLevel } from "@/lib/types";
 
@@ -5,6 +6,7 @@ interface TaxonomyBadgesProps {
   experienceLevel?: ExperienceLevel;
   topics?: string[];
   practiceContext?: string[];
+  linked?: boolean;
 }
 
 const LEVEL_STYLES: Record<ExperienceLevel, string> = {
@@ -33,6 +35,7 @@ export function TaxonomyBadges({
   experienceLevel,
   topics,
   practiceContext,
+  linked = true,
 }: TaxonomyBadgesProps) {
   const hasTopics = topics && topics.length > 0;
   const hasContext = practiceContext && practiceContext.length > 0;
@@ -43,33 +46,65 @@ export function TaxonomyBadges({
     <div className="space-y-3">
       {experienceLevel && (
         <div>
-          <span
-            className={`inline-flex items-center rounded-full border px-2.5 py-0.5 font-serif text-xs font-medium ${LEVEL_STYLES[experienceLevel]}`}
-          >
-            {LEVEL_LABELS[experienceLevel]}
-          </span>
+          {linked ? (
+            <Link href={`/discover?experience_level=${experienceLevel}`}>
+              <span
+                className={`inline-flex items-center rounded-full border px-2.5 py-0.5 font-serif text-xs font-medium cursor-pointer hover:opacity-80 transition-opacity ${LEVEL_STYLES[experienceLevel]}`}
+              >
+                {LEVEL_LABELS[experienceLevel]}
+              </span>
+            </Link>
+          ) : (
+            <span
+              className={`inline-flex items-center rounded-full border px-2.5 py-0.5 font-serif text-xs font-medium ${LEVEL_STYLES[experienceLevel]}`}
+            >
+              {LEVEL_LABELS[experienceLevel]}
+            </span>
+          )}
         </div>
       )}
       {(hasTopics || hasContext) && (
         <div className="flex flex-wrap gap-1.5">
-          {topics?.map((topic) => (
-            <Badge
-              key={topic}
-              variant="outline"
-              className="font-serif text-[11px]"
-            >
-              {formatLabel(topic)}
-            </Badge>
-          ))}
-          {practiceContext?.map((ctx) => (
-            <Badge
-              key={ctx}
-              variant="outline"
-              className="font-serif text-[11px] border-dashed"
-            >
-              {formatLabel(ctx)}
-            </Badge>
-          ))}
+          {topics?.map((topic) =>
+            linked ? (
+              <Link key={topic} href={`/discover?topics=${topic}`}>
+                <Badge
+                  variant="outline"
+                  className="font-serif text-[11px] cursor-pointer hover:bg-accent transition-colors"
+                >
+                  {formatLabel(topic)}
+                </Badge>
+              </Link>
+            ) : (
+              <Badge
+                key={topic}
+                variant="outline"
+                className="font-serif text-[11px]"
+              >
+                {formatLabel(topic)}
+              </Badge>
+            )
+          )}
+          {practiceContext?.map((ctx) =>
+            linked ? (
+              <Link key={ctx} href={`/discover?practice_context=${ctx}`}>
+                <Badge
+                  variant="outline"
+                  className="font-serif text-[11px] border-dashed cursor-pointer hover:bg-accent transition-colors"
+                >
+                  {formatLabel(ctx)}
+                </Badge>
+              </Link>
+            ) : (
+              <Badge
+                key={ctx}
+                variant="outline"
+                className="font-serif text-[11px] border-dashed"
+              >
+                {formatLabel(ctx)}
+              </Badge>
+            )
+          )}
         </div>
       )}
     </div>


### PR DESCRIPTION
## Summary
- `TaxonomyBadges` now wraps each badge in a `Link` to `/discover` with the corresponding filter param
- Experience level → `/discover?experience_level=<level>`
- Topics → `/discover?topics=<topic>`
- Practice context → `/discover?practice_context=<context>`
- Adds `linked?: boolean` prop (default `true`) to opt out in non-navigable contexts
- Hover: opacity fade on level badge, `bg-accent` on topic/context badges — subtle but clearly interactive

## Test plan
- [ ] Visit a resource with taxonomy badges (e.g. /resources/mindfulness-in-plain-english)
- [ ] Click "Beginner" level badge → /discover?experience_level=beginner
- [ ] Click a topic badge → /discover?topics=<slug>
- [ ] Click a practice context badge → /discover?practice_context=<slug>
- [ ] Hover state is visible (cursor pointer, subtle color change)
- [ ] `npm run build` passes

Closes #245

🤖 Generated with [Claude Code](https://claude.com/claude-code)