### PR TITLE
fix: navigate search lookahead book results to detail page

### DIFF
--- a/src/components/home-search.tsx
+++ b/src/components/home-search.tsx
@@ -85,7 +85,7 @@ export function HomeSearch({
         type: "book",
         name: r.title,
         slug: r.slug,
-        href: `/resources#${r.slug}`,
+        href: `/resources/${r.slug}`,
         detail: r.author ?? "",
       });
     }


### PR DESCRIPTION
## Summary
- Clicking a book result in the homepage search autocomplete now navigates directly to `/resources/[slug]` (the detail page) instead of `/resources#slug` (a hash anchor on the list page)
- One-character fix: `#` → `/` in the href template

## Root Cause
Books were added to the search index with hash-anchor URLs (`/resources#slug`) — the pattern used for in-page jump links on the list page. When the individual resource detail page (`/resources/[slug]`) was added, the search index was never updated.

## Test plan
- [ ] Search for a book title on the homepage
- [ ] Click the autocomplete result
- [ ] Confirm you land on `/resources/[slug]` detail page, not the list

🤖 Generated with [Claude Code](https://claude.com/claude-code)