### PR TITLE
feat: add transitions and polish to reflection flow

### DIFF
--- a/src/components/__tests__/guided-reflection.test.tsx
+++ b/src/components/__tests__/guided-reflection.test.tsx
@@ -4,14 +4,19 @@ import React from "react";
 
 // Framer Motion animations don't run in jsdom — AnimatePresence mode="wait"
 // would block navigation tests. Stub the library so components render instantly.
+type MotionDivProps = React.HTMLAttributes<HTMLDivElement> & {
+  children?: React.ReactNode;
+  initial?: unknown;
+  animate?: unknown;
+  exit?: unknown;
+  transition?: unknown;
+};
+function MotionDiv({ children, initial: _i, animate: _a, exit: _e, transition: _t, ...props }: MotionDivProps) {
+  return <div {...props}>{children}</div>;
+}
 vi.mock("framer-motion", () => ({
   AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
-  motion: {
-    div: React.forwardRef(
-      ({ children, ...props }: React.HTMLAttributes<HTMLDivElement> & { children?: React.ReactNode }, ref: React.Ref<HTMLDivElement>) =>
-        <div ref={ref} {...props}>{children}</div>
-    ),
-  },
+  motion: { div: MotionDiv },
   useReducedMotion: () => false,
 }));
 

--- a/src/components/__tests__/guided-reflection.test.tsx
+++ b/src/components/__tests__/guided-reflection.test.tsx
@@ -1,5 +1,19 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, fireEvent, waitFor, act } from "@testing-library/react";
+import React from "react";
+
+// Framer Motion animations don't run in jsdom — AnimatePresence mode="wait"
+// would block navigation tests. Stub the library so components render instantly.
+vi.mock("framer-motion", () => ({
+  AnimatePresence: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  motion: {
+    div: React.forwardRef(
+      ({ children, ...props }: React.HTMLAttributes<HTMLDivElement> & { children?: React.ReactNode }, ref: React.Ref<HTMLDivElement>) =>
+        <div ref={ref} {...props}>{children}</div>
+    ),
+  },
+  useReducedMotion: () => false,
+}));
 
 const mockUser = { id: "u1", email: "test@example.com" };
 let currentUser: typeof mockUser | null = null;
@@ -375,6 +389,92 @@ describe("GuidedReflection", () => {
       await waitFor(() => {
         expect(window.location.search).not.toContain("action=recommend");
       });
+    });
+  });
+
+  // --- Polish & transitions ---
+
+  describe("loading state and transitions", () => {
+    it("shows encouraging copy while submitting on final step", async () => {
+      let resolveTestimony!: () => void;
+      (createTestimony as ReturnType<typeof vi.fn>).mockReturnValue(
+        new Promise<{ id: string }>((resolve) => {
+          resolveTestimony = () => resolve({ id: "t1" });
+        })
+      );
+
+      await recommendAndOpenReflection();
+      await waitFor(() => expect(screen.getByText("1 of 4")).toBeInTheDocument());
+
+      fireEvent.change(screen.getByRole("textbox"), {
+        target: { value: "It transformed my practice." },
+      });
+
+      // Advance to last step
+      for (let i = 0; i < 3; i++) {
+        fireEvent.click(screen.getByText("Next"));
+        await waitFor(() => expect(screen.getByText(`${i + 2} of 4`)).toBeInTheDocument());
+      }
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Submit"));
+      });
+
+      // While submitting, encouraging text is shown
+      expect(screen.getByText("Sharing your reflection...")).toBeInTheDocument();
+
+      await act(async () => {
+        resolveTestimony();
+      });
+    });
+
+    it("submit button returns to 'Submit' label after error", async () => {
+      (createTestimony as ReturnType<typeof vi.fn>).mockRejectedValue(
+        new Error("Network error")
+      );
+
+      await recommendAndOpenReflection();
+      await waitFor(() => expect(screen.getByText("1 of 4")).toBeInTheDocument());
+
+      fireEvent.change(screen.getByRole("textbox"), {
+        target: { value: "Something meaningful." },
+      });
+
+      for (let i = 0; i < 3; i++) {
+        fireEvent.click(screen.getByText("Next"));
+        await waitFor(() => expect(screen.getByText(`${i + 2} of 4`)).toBeInTheDocument());
+      }
+
+      await act(async () => {
+        fireEvent.click(screen.getByText("Submit"));
+      });
+
+      await waitFor(() => {
+        expect(screen.getByText("Submit")).toBeInTheDocument();
+        expect(screen.getByText("Something went wrong. Please try again.")).toBeInTheDocument();
+      });
+    });
+
+    it("step wrapper is present in reflecting stage for animation targeting", async () => {
+      await recommendAndOpenReflection();
+      await waitFor(() => expect(screen.getByText("1 of 4")).toBeInTheDocument());
+
+      expect(screen.getByTestId("reflection-step-animator")).toBeInTheDocument();
+    });
+
+    it("step animator key changes when advancing steps", async () => {
+      await recommendAndOpenReflection();
+      await waitFor(() => expect(screen.getByText("1 of 4")).toBeInTheDocument());
+
+      const getKey = () =>
+        screen.getByTestId("reflection-step-animator").getAttribute("data-step");
+
+      const keyBefore = getKey();
+      fireEvent.click(screen.getByText("Next"));
+      await waitFor(() => expect(screen.getByText("2 of 4")).toBeInTheDocument());
+      const keyAfter = getKey();
+
+      expect(keyBefore).not.toBe(keyAfter);
     });
   });
 });

--- a/src/components/guided-reflection.tsx
+++ b/src/components/guided-reflection.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback, useRef } from "react";
+import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { useSupabase } from "./supabase-provider";
 import { AuthPanel } from "./auth-panel";
 import { ProfileCompletion } from "./profile-completion";
@@ -130,7 +131,7 @@ function ReflectionStep({
           disabled={submitting}
           className="rounded-md bg-terracotta px-5 py-2 text-sm font-medium text-white hover:bg-terracotta/90 disabled:opacity-50 transition-colors"
         >
-          {submitting ? "Submitting..." : isLast ? "Submit" : "Next"}
+          {submitting ? "Sharing your reflection..." : isLast ? "Submit" : "Next"}
         </button>
         <button
           type="button"
@@ -168,6 +169,7 @@ function ReflectionComplete({ firstAnswer }: { firstAnswer?: string }) {
 // --- Main orchestrator ---
 
 export function GuidedReflection({ resourceSlug, resourceTitle }: GuidedReflectionProps) {
+  const reducedMotion = useReducedMotion();
   const { user, loading: authLoading } = useSupabase();
   const [stage, setStage] = useState<Stage>("idle");
   const [hasRecommended, setHasRecommended] = useState(false);
@@ -344,21 +346,39 @@ export function GuidedReflection({ resourceSlug, resourceTitle }: GuidedReflecti
     return <ReflectionComplete firstAnswer={firstAnswer} />;
   }
 
+  const stepVariants = reducedMotion
+    ? {}
+    : {
+        initial: { opacity: 0, y: 8 },
+        animate: { opacity: 1, y: 0 },
+        exit: { opacity: 0, y: -8 },
+        transition: { duration: 0.25, ease: "easeOut" },
+      };
+
   if (stage === "reflecting") {
     return (
-      <ReflectionStep
-        step={REFLECTION_STEPS[currentStep]}
-        stepIndex={currentStep}
-        totalSteps={REFLECTION_STEPS.length}
-        answer={answers[currentStep] ?? ""}
-        onChange={handleAnswerChange}
-        onNext={handleNext}
-        onBack={handleBack}
-        onSkip={handleSkip}
-        isLast={currentStep === REFLECTION_STEPS.length - 1}
-        submitting={submitting}
-        errorMsg={errorMsg}
-      />
+      <AnimatePresence mode="wait">
+        <motion.div
+          key={currentStep}
+          data-testid="reflection-step-animator"
+          data-step={currentStep}
+          {...stepVariants}
+        >
+          <ReflectionStep
+            step={REFLECTION_STEPS[currentStep]}
+            stepIndex={currentStep}
+            totalSteps={REFLECTION_STEPS.length}
+            answer={answers[currentStep] ?? ""}
+            onChange={handleAnswerChange}
+            onNext={handleNext}
+            onBack={handleBack}
+            onSkip={handleSkip}
+            isLast={currentStep === REFLECTION_STEPS.length - 1}
+            submitting={submitting}
+            errorMsg={errorMsg}
+          />
+        </motion.div>
+      </AnimatePresence>
     );
   }
 

--- a/src/components/guided-reflection.tsx
+++ b/src/components/guided-reflection.tsx
@@ -145,7 +145,7 @@ function ReflectionStep({
   );
 }
 
-function ReflectionComplete({ firstAnswer }: { firstAnswer?: string }) {
+function ReflectionComplete({ firstAnswer, resourceTitle }: { firstAnswer?: string; resourceTitle: string }) {
   return (
     <div
       data-testid="reflection-complete"
@@ -160,7 +160,7 @@ function ReflectionComplete({ firstAnswer }: { firstAnswer?: string }) {
         </p>
       )}
       <p className="text-sm text-muted-foreground">
-        Your reflection helps others find what matters.
+        Your reflection on {resourceTitle} helps others find what matters.
       </p>
     </div>
   );
@@ -343,7 +343,7 @@ export function GuidedReflection({ resourceSlug, resourceTitle }: GuidedReflecti
   }
 
   if (stage === "success") {
-    return <ReflectionComplete firstAnswer={firstAnswer} />;
+    return <ReflectionComplete firstAnswer={firstAnswer} resourceTitle={resourceTitle} />;
   }
 
   const stepVariants = reducedMotion

--- a/src/components/guided-reflection.tsx
+++ b/src/components/guided-reflection.tsx
@@ -352,7 +352,7 @@ export function GuidedReflection({ resourceSlug, resourceTitle }: GuidedReflecti
         initial: { opacity: 0, y: 8 },
         animate: { opacity: 1, y: 0 },
         exit: { opacity: 0, y: -8 },
-        transition: { duration: 0.25, ease: "easeOut" },
+        transition: { duration: 0.25, ease: "easeOut" as const },
       };
 
   if (stage === "reflecting") {


### PR DESCRIPTION
Closes #237

## Summary

- Wraps each step in `AnimatePresence` + `motion.div` with `key={currentStep}` so Framer Motion detects swaps and animates exit before entry
- Entry: `opacity 0→1`, `y: 8→0`; Exit: `opacity 1→0`, `y: 0→-8`; 250ms ease-out — within the 200-300ms target
- `useReducedMotion()` hook: when true, all motion variants are empty objects (no animation applied)
- Loading copy during submission: **"Sharing your reflection..."** instead of "Submitting..."
- Thank-you echo already implemented in #236; now fully visible on the polished screen
- No layout shift: `AnimatePresence mode="wait"` serialises exit→entry so no two steps overlap

## Test plan

- [ ] 25 guided-reflection tests pass (4 new covering loading copy, animator presence, and step key changes)
- [ ] 577 total tests pass
- [ ] Framer Motion stubbed in tests via `vi.mock("framer-motion")` — `AnimatePresence` is a pass-through, `motion.div` renders as `div`, preventing `mode="wait"` from blocking navigation assertions in jsdom

🤖 Generated with [Claude Code](https://claude.com/claude-code)