### PR TITLE
feat: profile enrichment nudge on reflection thank-you screen

### DIFF
--- a/src/components/__tests__/guided-reflection.test.tsx
+++ b/src/components/__tests__/guided-reflection.test.tsx
@@ -326,8 +326,10 @@ describe("GuidedReflection", () => {
     });
   });
 
-  it("shows profile completion after testimony when profile is incomplete", async () => {
-    (getProfile as ReturnType<typeof vi.fn>).mockResolvedValue({ traditions: [] });
+  // --- Profile enrichment nudge ---
+
+  it("shows enrichment nudge on success screen when bio and practice_background are empty", async () => {
+    (getProfile as ReturnType<typeof vi.fn>).mockResolvedValue({ bio: null, practice_background: null });
     await recommendAndOpenReflection();
     await waitFor(() => expect(screen.getByText("1 of 4")).toBeInTheDocument());
 
@@ -341,7 +343,134 @@ describe("GuidedReflection", () => {
     });
 
     await waitFor(() => {
-      expect(screen.getByText("A little about you")).toBeInTheDocument();
+      expect(screen.getByTestId("reflection-complete")).toBeInTheDocument();
+      expect(screen.getByTestId("profile-enrichment-nudge")).toBeInTheDocument();
+    });
+  });
+
+  it("nudge does not appear when bio and practice_background are already filled", async () => {
+    (getProfile as ReturnType<typeof vi.fn>).mockResolvedValue({
+      bio: "A practitioner of Zen.",
+      practice_background: "10 years of daily sitting.",
+    });
+    await recommendAndOpenReflection();
+    await waitFor(() => expect(screen.getByText("1 of 4")).toBeInTheDocument());
+
+    for (let i = 0; i < 3; i++) {
+      fireEvent.click(screen.getByText("Next"));
+      await waitFor(() => expect(screen.getByText(`${i + 2} of 4`)).toBeInTheDocument());
+    }
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Submit"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("reflection-complete")).toBeInTheDocument();
+      expect(screen.queryByTestId("profile-enrichment-nudge")).not.toBeInTheDocument();
+    });
+  });
+
+  it("nudge uses invitational language", async () => {
+    (getProfile as ReturnType<typeof vi.fn>).mockResolvedValue({ bio: null, practice_background: null });
+    await recommendAndOpenReflection();
+    await waitFor(() => expect(screen.getByText("1 of 4")).toBeInTheDocument());
+
+    for (let i = 0; i < 3; i++) {
+      fireEvent.click(screen.getByText("Next"));
+      await waitFor(() => expect(screen.getByText(`${i + 2} of 4`)).toBeInTheDocument());
+    }
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Submit"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("profile-enrichment-nudge")).toBeInTheDocument();
+    });
+
+    const nudge = screen.getByTestId("profile-enrichment-nudge");
+    expect(nudge.textContent).toMatch(/contemplative path|share a bit|optional/i);
+  });
+
+  it("expanding the nudge shows bio and practice_background fields", async () => {
+    (getProfile as ReturnType<typeof vi.fn>).mockResolvedValue({ bio: null, practice_background: null });
+    await recommendAndOpenReflection();
+    await waitFor(() => expect(screen.getByText("1 of 4")).toBeInTheDocument());
+
+    for (let i = 0; i < 3; i++) {
+      fireEvent.click(screen.getByText("Next"));
+      await waitFor(() => expect(screen.getByText(`${i + 2} of 4`)).toBeInTheDocument());
+    }
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Submit"));
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("profile-enrichment-nudge")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("nudge-expand-btn"));
+
+    await waitFor(() => {
+      expect(screen.getByTestId("nudge-bio-input")).toBeInTheDocument();
+      expect(screen.getByTestId("nudge-background-input")).toBeInTheDocument();
+    });
+  });
+
+  it("nudge save calls updateProfile and hides the nudge", async () => {
+    const { updateProfile } = await import("@/lib/testimonies");
+    (getProfile as ReturnType<typeof vi.fn>).mockResolvedValue({ bio: null, practice_background: null });
+    await recommendAndOpenReflection();
+    await waitFor(() => expect(screen.getByText("1 of 4")).toBeInTheDocument());
+
+    for (let i = 0; i < 3; i++) {
+      fireEvent.click(screen.getByText("Next"));
+      await waitFor(() => expect(screen.getByText(`${i + 2} of 4`)).toBeInTheDocument());
+    }
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Submit"));
+    });
+
+    await waitFor(() => expect(screen.getByTestId("profile-enrichment-nudge")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("nudge-expand-btn"));
+    await waitFor(() => expect(screen.getByTestId("nudge-bio-input")).toBeInTheDocument());
+
+    fireEvent.change(screen.getByTestId("nudge-bio-input"), { target: { value: "Zen practitioner." } });
+
+    await act(async () => {
+      fireEvent.click(screen.getByTestId("nudge-save-btn"));
+    });
+
+    await waitFor(() => {
+      expect(updateProfile).toHaveBeenCalledWith("u1", expect.objectContaining({ bio: "Zen practitioner." }));
+      expect(screen.queryByTestId("profile-enrichment-nudge")).not.toBeInTheDocument();
+    });
+  });
+
+  it("nudge skip hides the nudge without saving", async () => {
+    (getProfile as ReturnType<typeof vi.fn>).mockResolvedValue({ bio: null, practice_background: null });
+    await recommendAndOpenReflection();
+    await waitFor(() => expect(screen.getByText("1 of 4")).toBeInTheDocument());
+
+    for (let i = 0; i < 3; i++) {
+      fireEvent.click(screen.getByText("Next"));
+      await waitFor(() => expect(screen.getByText(`${i + 2} of 4`)).toBeInTheDocument());
+    }
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Submit"));
+    });
+
+    await waitFor(() => expect(screen.getByTestId("profile-enrichment-nudge")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("nudge-skip-btn"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("profile-enrichment-nudge")).not.toBeInTheDocument();
     });
   });
 

--- a/src/components/__tests__/guided-reflection.test.tsx
+++ b/src/components/__tests__/guided-reflection.test.tsx
@@ -474,6 +474,32 @@ describe("GuidedReflection", () => {
     });
   });
 
+  it("nudge skip from expanded state hides the nudge without saving", async () => {
+    (getProfile as ReturnType<typeof vi.fn>).mockResolvedValue({ bio: null, practice_background: null });
+    await recommendAndOpenReflection();
+    await waitFor(() => expect(screen.getByText("1 of 4")).toBeInTheDocument());
+
+    for (let i = 0; i < 3; i++) {
+      fireEvent.click(screen.getByText("Next"));
+      await waitFor(() => expect(screen.getByText(`${i + 2} of 4`)).toBeInTheDocument());
+    }
+
+    await act(async () => {
+      fireEvent.click(screen.getByText("Submit"));
+    });
+
+    await waitFor(() => expect(screen.getByTestId("profile-enrichment-nudge")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("nudge-expand-btn"));
+    await waitFor(() => expect(screen.getByTestId("nudge-bio-input")).toBeInTheDocument());
+
+    fireEvent.click(screen.getByTestId("nudge-skip-expanded-btn"));
+
+    await waitFor(() => {
+      expect(screen.queryByTestId("profile-enrichment-nudge")).not.toBeInTheDocument();
+    });
+  });
+
   // --- Skip ---
 
   it("skip button dismisses reflection and shows success without submitting testimony", async () => {

--- a/src/components/guided-reflection.tsx
+++ b/src/components/guided-reflection.tsx
@@ -4,13 +4,13 @@ import { useState, useEffect, useCallback, useRef } from "react";
 import { AnimatePresence, motion, useReducedMotion } from "framer-motion";
 import { useSupabase } from "./supabase-provider";
 import { AuthPanel } from "./auth-panel";
-import { ProfileCompletion } from "./profile-completion";
 import {
   createRecommendation,
   getUserRecommendation,
   getRecommendationCount,
   createTestimony,
   getProfile,
+  updateProfile,
 } from "@/lib/testimonies";
 
 const REFLECTION_STEPS = [
@@ -34,7 +34,7 @@ const REFLECTION_STEPS = [
 
 const MAX_CHARS = 2000;
 
-type Stage = "idle" | "auth" | "reflecting" | "profile" | "success";
+type Stage = "idle" | "auth" | "reflecting" | "success";
 
 interface GuidedReflectionProps {
   resourceSlug: string;
@@ -145,23 +145,154 @@ function ReflectionStep({
   );
 }
 
-function ReflectionComplete({ firstAnswer, resourceTitle }: { firstAnswer?: string; resourceTitle: string }) {
+interface ProfileEnrichmentNudgeProps {
+  userId: string;
+}
+
+function ProfileEnrichmentNudge({ userId }: ProfileEnrichmentNudgeProps) {
+  const [expanded, setExpanded] = useState(false);
+  const [dismissed, setDismissed] = useState(false);
+  const [bio, setBio] = useState("");
+  const [practiceBackground, setPracticeBackground] = useState("");
+  const [saving, setSaving] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+
+  if (dismissed) return null;
+
+  async function handleSave() {
+    setSaving(true);
+    setErrorMsg(null);
+    try {
+      await updateProfile(userId, {
+        bio: bio || null,
+        practice_background: practiceBackground || null,
+      });
+      setDismissed(true);
+    } catch {
+      setErrorMsg("Something went wrong. Please try again.");
+    } finally {
+      setSaving(false);
+    }
+  }
+
   return (
     <div
-      data-testid="reflection-complete"
-      className="rounded-lg border border-border bg-card p-6 text-center space-y-3"
+      data-testid="profile-enrichment-nudge"
+      className="rounded-lg border border-border bg-card/60 px-6 py-5 space-y-3"
     >
-      <p className="font-serif text-lg font-medium text-foreground">
-        Thank you for sharing
-      </p>
-      {firstAnswer && (
-        <p className="text-sm text-muted-foreground italic">
-          &ldquo;{firstAnswer.slice(0, 120)}{firstAnswer.length > 120 ? "…" : ""}&rdquo;
-        </p>
+      {!expanded ? (
+        <div className="flex items-center justify-between gap-4">
+          <p className="text-sm text-muted-foreground">
+            If you'd like, you can share a bit about your contemplative path — optional, and it helps others understand your perspective.
+          </p>
+          <div className="flex shrink-0 gap-3">
+            <button
+              data-testid="nudge-expand-btn"
+              type="button"
+              onClick={() => setExpanded(true)}
+              className="text-sm font-medium text-terracotta hover:text-terracotta/80 transition-colors whitespace-nowrap"
+            >
+              Share a bit →
+            </button>
+            <button
+              data-testid="nudge-skip-btn"
+              type="button"
+              onClick={() => setDismissed(true)}
+              className="text-sm text-muted-foreground/60 hover:text-muted-foreground transition-colors underline decoration-dotted underline-offset-2 whitespace-nowrap"
+            >
+              Skip for now
+            </button>
+          </div>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          <p className="text-sm text-muted-foreground">
+            A few words about your path — entirely optional.
+          </p>
+
+          <div>
+            <label className="text-sm font-medium text-foreground">Bio</label>
+            <textarea
+              data-testid="nudge-bio-input"
+              value={bio}
+              onChange={(e) => setBio(e.target.value)}
+              placeholder="A sentence or two about yourself"
+              maxLength={500}
+              rows={2}
+              className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-terracotta/40 resize-none"
+            />
+          </div>
+
+          <div>
+            <label className="text-sm font-medium text-foreground">Practice background</label>
+            <textarea
+              data-testid="nudge-background-input"
+              value={practiceBackground}
+              onChange={(e) => setPracticeBackground(e.target.value)}
+              placeholder="How did you come to contemplative practice?"
+              maxLength={1000}
+              rows={3}
+              className="mt-1 w-full rounded-md border border-border bg-background px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-terracotta/40 resize-none"
+            />
+          </div>
+
+          {errorMsg && <p className="text-sm text-destructive">{errorMsg}</p>}
+
+          <div className="flex items-center gap-3">
+            <button
+              data-testid="nudge-save-btn"
+              type="button"
+              onClick={handleSave}
+              disabled={saving}
+              className="rounded-md bg-terracotta px-5 py-2 text-sm font-medium text-white hover:bg-terracotta/90 disabled:opacity-50 transition-colors"
+            >
+              {saving ? "Saving…" : "Save"}
+            </button>
+            <button
+              data-testid="nudge-skip-btn"
+              type="button"
+              onClick={() => setDismissed(true)}
+              className="text-sm text-muted-foreground/60 hover:text-muted-foreground transition-colors underline decoration-dotted underline-offset-2"
+            >
+              Skip for now
+            </button>
+          </div>
+        </div>
       )}
-      <p className="text-sm text-muted-foreground">
-        Your reflection on {resourceTitle} helps others find what matters.
-      </p>
+    </div>
+  );
+}
+
+function ReflectionComplete({
+  firstAnswer,
+  resourceTitle,
+  showNudge,
+  userId,
+}: {
+  firstAnswer?: string;
+  resourceTitle: string;
+  showNudge: boolean;
+  userId?: string;
+}) {
+  return (
+    <div className="space-y-4">
+      <div
+        data-testid="reflection-complete"
+        className="rounded-lg border border-border bg-card p-6 text-center space-y-3"
+      >
+        <p className="font-serif text-lg font-medium text-foreground">
+          Thank you for sharing
+        </p>
+        {firstAnswer && (
+          <p className="text-sm text-muted-foreground italic">
+            &ldquo;{firstAnswer.slice(0, 120)}{firstAnswer.length > 120 ? "…" : ""}&rdquo;
+          </p>
+        )}
+        <p className="text-sm text-muted-foreground">
+          Your reflection on {resourceTitle} helps others find what matters.
+        </p>
+      </div>
+      {showNudge && userId && <ProfileEnrichmentNudge userId={userId} />}
     </div>
   );
 }
@@ -218,7 +349,7 @@ export function GuidedReflection({ resourceSlug, resourceTitle }: GuidedReflecti
       clearActionParam();
 
       const profile = await getProfile(user.id);
-      setNeedsProfile(!profile?.traditions?.length);
+      setNeedsProfile(!(profile?.bio && profile?.practice_background));
 
       setTimeout(() => setStage("reflecting"), 300);
     } catch (err: unknown) {
@@ -293,8 +424,7 @@ export function GuidedReflection({ resourceSlug, resourceTitle }: GuidedReflecti
       .join("\n\n");
 
     if (!combined) {
-      // No answers provided — skip to success
-      setStage(needsProfile ? "profile" : "success");
+      setStage("success");
       return;
     }
 
@@ -308,7 +438,7 @@ export function GuidedReflection({ resourceSlug, resourceTitle }: GuidedReflecti
       });
       const echo = Object.values(answers).find((a) => a.trim());
       setFirstAnswer(echo);
-      setStage(needsProfile ? "profile" : "success");
+      setStage("success");
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : String(err);
       if (msg.includes("banned") || msg.includes("violates row-level security")) {
@@ -333,17 +463,15 @@ export function GuidedReflection({ resourceSlug, resourceTitle }: GuidedReflecti
 
   if (stage === "auth") return <AuthPanel />;
 
-  if (stage === "profile") {
+  if (stage === "success") {
     return (
-      <ProfileCompletion
-        userId={user!.id}
-        onComplete={() => setStage("success")}
+      <ReflectionComplete
+        firstAnswer={firstAnswer}
+        resourceTitle={resourceTitle}
+        showNudge={needsProfile}
+        userId={user?.id}
       />
     );
-  }
-
-  if (stage === "success") {
-    return <ReflectionComplete firstAnswer={firstAnswer} resourceTitle={resourceTitle} />;
   }
 
   const stepVariants = reducedMotion

--- a/src/components/guided-reflection.tsx
+++ b/src/components/guided-reflection.tsx
@@ -211,8 +211,9 @@ function ProfileEnrichmentNudge({ userId }: ProfileEnrichmentNudgeProps) {
           </p>
 
           <div>
-            <label className="text-sm font-medium text-foreground">Bio</label>
+            <label htmlFor="nudge-bio" className="text-sm font-medium text-foreground">Bio</label>
             <textarea
+              id="nudge-bio"
               data-testid="nudge-bio-input"
               value={bio}
               onChange={(e) => setBio(e.target.value)}
@@ -224,8 +225,9 @@ function ProfileEnrichmentNudge({ userId }: ProfileEnrichmentNudgeProps) {
           </div>
 
           <div>
-            <label className="text-sm font-medium text-foreground">Practice background</label>
+            <label htmlFor="nudge-background" className="text-sm font-medium text-foreground">Practice background</label>
             <textarea
+              id="nudge-background"
               data-testid="nudge-background-input"
               value={practiceBackground}
               onChange={(e) => setPracticeBackground(e.target.value)}
@@ -249,7 +251,7 @@ function ProfileEnrichmentNudge({ userId }: ProfileEnrichmentNudgeProps) {
               {saving ? "Saving…" : "Save"}
             </button>
             <button
-              data-testid="nudge-skip-btn"
+              data-testid="nudge-skip-expanded-btn"
               type="button"
               onClick={() => setDismissed(true)}
               className="text-sm text-muted-foreground/60 hover:text-muted-foreground transition-colors underline decoration-dotted underline-offset-2"

--- a/src/components/guided-reflection.tsx
+++ b/src/components/guided-reflection.tsx
@@ -183,7 +183,7 @@ function ProfileEnrichmentNudge({ userId }: ProfileEnrichmentNudgeProps) {
       {!expanded ? (
         <div className="flex items-center justify-between gap-4">
           <p className="text-sm text-muted-foreground">
-            If you'd like, you can share a bit about your contemplative path — optional, and it helps others understand your perspective.
+            If you&apos;d like, you can share a bit about your contemplative path — optional, and it helps others understand your perspective.
           </p>
           <div className="flex shrink-0 gap-3">
             <button


### PR DESCRIPTION
Closes #239

## What changed

After a practitioner submits their first reflection, an invitational nudge appears below the thank-you card to optionally share their bio and practice background. The nudge:

- Is collapsed by default with a gentle one-line prompt
- Expands to show bio and practice_background text fields only
- Has a prominent "Skip for now" in both collapsed and expanded states
- Hides itself once saved or skipped (no page reload needed)
- Does not appear when both bio and practice_background are already filled

## UX changes

Removed the old "profile" stage from the GuidedReflection state machine — previously a separate full-screen ProfileCompletion form appeared before the success screen (triggered when traditions were empty). That interstitial is replaced by the lightweight nudge on the success screen itself. The condition also changed from checking `traditions` to checking `bio && practice_background`, which is what the issue specifies.

## Test plan

- [x] New tests: nudge appears when bio/practice_background are empty
- [x] New tests: nudge hidden when both fields are filled
- [x] New tests: invitational language present
- [x] New tests: expanding the nudge shows form fields
- [x] New tests: save calls updateProfile and hides nudge
- [x] New tests: skip hides nudge without saving
- [x] All 30 guided-reflection tests pass; 582 total tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)