### PR TITLE
docs: correct CLAUDE.md data-layer description (Supabase is live)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,7 +8,8 @@ Interactive map of contemplative traditions + teacher/center directory.
 - TypeScript
 - Tailwind CSS + shadcn/ui
 - MDX for tradition editorial content
-- Data: JSON files in `data/` (no database for V1)
+- Editorial/reference data: JSON + MDX files in `data/` (teachers, centers, traditions)
+- User data: Supabase (Postgres) for auth, `profiles`, and `testimonies`. Accessed client-side via the anon key + PostgREST under Row Level Security. Project ref `opcbvaonwchbeawuncsy`, currently on the Free/Nano tier. Schema in `supabase/schema.sql`.
 - Deploy: Render (static site)
 
 ## Design Direction


### PR DESCRIPTION
## What

The Tech Stack section of `CLAUDE.md` still said **"Data: JSON files in `data/` (no database for V1)"**. That's stale: Supabase (auth, `profiles`, `testimonies`) has been live for months. It misled a fresh session investigating a Supabase Disk IO alert.

## Change

Split the single data line into two accurate ones:
- **Editorial/reference data**: JSON + MDX in `data/` (teachers, centers, traditions)
- **User data**: Supabase Postgres (auth, profiles, testimonies), accessed client-side via anon key + PostgREST under RLS. Notes project ref, Free/Nano tier, and `supabase/schema.sql`.

## Context

Came out of diagnosing the "running out of Disk IO Budget" email. Conclusion there: benign Free/Nano-tier artifact (DB doing ~1 IOPS over 17 rows), not a code bug. This PR just fixes the doc so the next session starts from reality.

Docs-only. No code or behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)